### PR TITLE
Add options to specify monitoring and logging services

### DIFF
--- a/cluster_regional.tf
+++ b/cluster_regional.tf
@@ -30,6 +30,9 @@ resource "google_container_cluster" "primary" {
   subnetwork         = "projects/${local.network_project_id}/regions/${var.region}/subnetworks/${var.subnetwork}"
   min_master_version = "${local.kubernetes_version}"
 
+  logging_service    = "${var.logging_service}"
+  monitoring_service = "${var.monitoring_service}"
+
   addons_config {
     http_load_balancing {
       disabled = "${var.http_load_balancing ? 0 : 1}"

--- a/cluster_zonal.tf
+++ b/cluster_zonal.tf
@@ -30,6 +30,9 @@ resource "google_container_cluster" "zonal_primary" {
   subnetwork         = "projects/${local.network_project_id}/regions/${var.region}/subnetworks/${var.subnetwork}"
   min_master_version = "${local.kubernetes_version}"
 
+  logging_service    = "${var.logging_service}"
+  monitoring_service = "${var.monitoring_service}"
+
   addons_config {
     http_load_balancing {
       disabled = "${var.http_load_balancing ? 0 : 1}"

--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,16 @@ locals {
     zonal    = "${element(concat(google_container_cluster.zonal_primary.*.min_master_version, list("")), 0)}"
   }
 
+  cluster_type_output_logging_service = {
+    regional = "${element(concat(google_container_cluster.primary.*.logging_service, list("")), 0)}"
+    zonal    = "${element(concat(google_container_cluster.zonal_primary.*.logging_service, list("")), 0)}"
+  }
+
+  cluster_type_output_monitoring_service = {
+    regional = "${element(concat(google_container_cluster.primary.*.monitoring_service, list("")), 0)}"
+    zonal    = "${element(concat(google_container_cluster.zonal_primary.*.monitoring_service, list("")), 0)}"
+  }
+
   cluster_type_output_network_policy_enabled = {
     regional = "${element(concat(google_container_cluster.primary.*.addons_config.0.network_policy_config.0.disabled, list("")), 0)}"
     zonal    = "${element(concat(google_container_cluster.zonal_primary.*.addons_config.0.network_policy_config.0.disabled, list("")), 0)}"
@@ -116,6 +126,8 @@ locals {
   cluster_ca_certificate      = "${lookup(local.cluster_master_auth_map, "cluster_ca_certificate")}"
   cluster_master_version      = "${local.cluster_type_output_master_version[local.cluster_type]}"
   cluster_min_master_version  = "${local.cluster_type_output_min_master_version[local.cluster_type]}"
+  cluster_logging_service     = "${local.cluster_type_output_logging_service[local.cluster_type]}"
+  cluster_monitoring_service  = "${local.cluster_type_output_monitoring_service[local.cluster_type]}"
   cluster_node_pools_names    = "${local.cluster_type_output_node_pools_names[local.cluster_type]}"
   cluster_node_pools_versions = "${local.cluster_type_output_node_pools_versions[local.cluster_type]}"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -50,6 +50,16 @@ output "min_master_version" {
   value       = "${local.cluster_min_master_version}"
 }
 
+output "logging_service" {
+  description = "Logging service used"
+  value       = "${local.cluster_logging_service}"
+}
+
+output "monitoring_service" {
+  description = "Monitoring service used"
+  value       = "${local.cluster_monitoring_service}"
+}
+
 output "master_version" {
   description = "Current master kubernetes version"
   value       = "${local.cluster_master_version}"

--- a/variables.tf
+++ b/variables.tf
@@ -160,3 +160,13 @@ variable "ip_masq_link_local" {
   description = "Whether to masquerade traffic to the link-local prefix (169.254.0.0/16)."
   default     = "false"
 }
+
+variable "logging_service" {
+  description = "The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none"
+  default     = "logging.googleapis.com"
+}
+
+variable "monitoring_service" {
+  description = "The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none"
+  default     = "monitoring.googleapis.com"
+}


### PR DESCRIPTION
Many GKE users opt to use different logging and monitoring
apis (e.g. DataDog) and would like to have the option to
disable StackDriver monitoring and logging.