### PR TITLE
Add TravisCI lint check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - TFVERSION=0.11.8 bash -c 'curl -L "https://releases.hashicorp.com/terraform/${TFVERSION}/terraform_${TFVERSION}_linux_amd64.zip" -o /tmp/terraform.zip'
   - sudo unzip -d /usr/local/bin/ /tmp/terraform.zip
   - sudo chmod +x /usr/local/bin/terraform
-  - sudo apt-get update && apt-get install -y python-pip
+  - sudo apt-get update && sudo apt-get install -y python-pip
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - TFDOCSVERSION=0.4.0 bash -c 'curl -L "https://github.com/segmentio/terraform-docs/releases/download/v${TFDOCSVERSION}/terraform-docs-v${TFDOCSVERSION}-linux-amd64" -o /tmp/terraform-docs'
   - sudo mv /tmp/terraform-docs /usr/local/bin/terraform-docs
   - sudo chmod +x /usr/local/bin/terraform-docs
-  - sudo apt-get update && sudo apt-get install -y python-pip
+  - sudo apt-get update && sudo apt-get install -y python-flake8
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
   - TFVERSION=0.11.8 bash -c 'curl -L "https://releases.hashicorp.com/terraform/${TFVERSION}/terraform_${TFVERSION}_linux_amd64.zip" -o /tmp/terraform.zip'
   - sudo unzip -d /usr/local/bin/ /tmp/terraform.zip
   - sudo chmod +x /usr/local/bin/terraform
+  - sudo apt-get update && apt-get install -y python-pip
 
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ before_install:
   - TFVERSION=0.11.8 bash -c 'curl -L "https://releases.hashicorp.com/terraform/${TFVERSION}/terraform_${TFVERSION}_linux_amd64.zip" -o /tmp/terraform.zip'
   - sudo unzip -d /usr/local/bin/ /tmp/terraform.zip
   - sudo chmod +x /usr/local/bin/terraform
-  - TFDOCSVERSION=0.4.0 bash -c 'curl -L "https://github.com/segmentio/terraform-docs/releases/download/v${TFDOCSVERSION}/terraform-docs-v${TFDOCSVERSION}-linux-amd64" -o /usr/local/bin/terraform-docs'
+  - TFDOCSVERSION=0.4.0 bash -c 'curl -L "https://github.com/segmentio/terraform-docs/releases/download/v${TFDOCSVERSION}/terraform-docs-v${TFDOCSVERSION}-linux-amd64" -o /tmp/terraform-docs'
+  - sudo mv /tmp/terraform-docs /usr/local/bin/terraform-docs
   - sudo chmod +x /usr/local/bin/terraform-docs
   - sudo apt-get update && sudo apt-get install -y python-pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: ruby
+rvm:
+  - 2.4.2
+
+before_install:
+  - TFVERSION=0.11.8 bash -c 'curl -L "https://releases.hashicorp.com/terraform/${TFVERSION}/terraform_${TFVERSION}_linux_amd64.zip" -o /tmp/terraform.zip'
+  - sudo unzip -d /usr/local/bin/ /tmp/terraform.zip
+  - sudo chmod +x /usr/local/bin/terraform
+
+sudo: required
+
+env:
+  - MAKE_TASK=lint
+
+script:
+  - make $MAKE_TASK

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ before_install:
   - TFVERSION=0.11.8 bash -c 'curl -L "https://releases.hashicorp.com/terraform/${TFVERSION}/terraform_${TFVERSION}_linux_amd64.zip" -o /tmp/terraform.zip'
   - sudo unzip -d /usr/local/bin/ /tmp/terraform.zip
   - sudo chmod +x /usr/local/bin/terraform
+  - TFDOCSVERSION=0.4.0 bash -c 'curl -L "https://github.com/segmentio/terraform-docs/releases/download/v${TFDOCSVERSION}/terraform-docs-v${TFDOCSVERSION}-linux-amd64" -o /usr/local/bin/terraform-docs'
+  - sudo chmod +x /usr/local/bin/terraform-docs
   - sudo apt-get update && sudo apt-get install -y python-pip
 
 sudo: required

--- a/Makefile
+++ b/Makefile
@@ -80,3 +80,6 @@ zonal_test_integration:
 .PHONY: test_integration
 test_integration: regional_test_integration zonal_test_integration
 	@echo "Running tests for regional and zonal clusters"
+
+.PHONY: lint
+lint: check_shell check_python check_golang check_terraform check_docker check_base_files test_check_headers check_headers check_trailing_whitespace generate_docs

--- a/networks.tf
+++ b/networks.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
 data "google_compute_network" "gke_network" {
   name    = "${var.network}"
   project = "${local.network_project_id}"

--- a/networks.tf
+++ b/networks.tf
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 data "google_compute_network" "gke_network" {
   name    = "${var.network}"
   project = "${local.network_project_id}"

--- a/test/make.sh
+++ b/test/make.sh
@@ -41,10 +41,6 @@ function basefiles() {
 function docker() {
   echo "Running hadolint on Dockerfiles"
   find . -name "Dockerfile" -exec hadolint {} \;
-  rc=$?
-  if [ $rc != 0 ]; then
-    exit 1
-  fi
 }
 
 # This function runs 'terraform validate' against all
@@ -53,10 +49,6 @@ function check_terraform() {
   echo "Running terraform validate"
   #shellcheck disable=SC2156
   find . -name "*.tf" -exec bash -c 'terraform validate --check-variables=false $(dirname "{}")' \;
-  rc=$?
-  if [ $rc != 0 ]; then
-    exit 1
-  fi
 }
 
 # This function runs 'go fmt' and 'go vet' on every file
@@ -64,15 +56,7 @@ function check_terraform() {
 function golang() {
   echo "Running go fmt and go vet"
   find . -name "*.go" -exec go fmt {} \;
-  rc=$?
-  if [ $rc != 0 ]; then
-    exit 1
-  fi
   find . -name "*.go" -exec go vet {} \;
-  rc=$?
-  if [ $rc != 0 ]; then
-    exit 1
-  fi
 }
 
 # This function runs the flake8 linter on every file
@@ -80,10 +64,6 @@ function golang() {
 function check_python() {
   echo "Running flake8"
   find . -name "*.py" -exec flake8 {} \;
-  rc=$?
-  if [ $rc != 0 ]; then
-    exit 1
-  fi
 }
 
 # This function runs the shellcheck linter on every
@@ -91,10 +71,6 @@ function check_python() {
 function check_shell() {
   echo "Running shellcheck"
   find . -name "*.sh" -exec shellcheck -x {} \;
-  rc=$?
-  if [ $rc != 0 ]; then
-    exit 1
-  fi
 }
 
 # This function makes sure that there is no trailing whitespace
@@ -104,7 +80,7 @@ function check_trailing_whitespace() {
   echo "The following lines have trailing whitespace"
   grep -r '[[:blank:]]$' --exclude-dir=".terraform" --exclude="*.png" --exclude="*.pyc" --exclude-dir=".git" .
   rc=$?
-  if [ $rc != 0 ]; then
+  if [ $rc = 0 ]; then
     exit 1
   fi
 }
@@ -112,7 +88,7 @@ function check_trailing_whitespace() {
 function generate_docs() {
   echo "Generating markdown docs with terraform-docs"
   TMPFILE=$(mktemp)
-  for j in $(for i in $(find . -type f | grep \.tf$) ; do dirname $i ; done | sort -u) ; do
+  for j in $(for i in $(find . -type f | grep \.tf$) ; do dirname "$i" ; done | sort -u) ; do
     terraform-docs markdown "$j" > "$TMPFILE"
     python helpers/combine_docfiles.py "$j"/README.md "$TMPFILE"
   done

--- a/test/make.sh
+++ b/test/make.sh
@@ -88,7 +88,7 @@ function check_trailing_whitespace() {
 function generate_docs() {
   echo "Generating markdown docs with terraform-docs"
   TMPFILE=$(mktemp)
-  for j in `for i in $(find . -type f | grep \.tf$) ; do dirname $i ; done | sort -u` ; do
+  for j in $(for i in $(find . -type f | grep \.tf$) ; do dirname $i ; done | sort -u) ; do
     terraform-docs markdown "$j" > "$TMPFILE"
     python helpers/combine_docfiles.py "$j"/README.md "$TMPFILE"
   done

--- a/test/make.sh
+++ b/test/make.sh
@@ -40,7 +40,7 @@ function basefiles() {
 # every file named 'Dockerfile'
 function docker() {
   echo "Running hadolint on Dockerfiles"
-  find . -name "Dockerfile" -exec hadolint {} \;
+  find . -name "Dockerfile" -exec hadolint {} \; || exit 1
 }
 
 # This function runs 'terraform validate' against all
@@ -48,29 +48,29 @@ function docker() {
 function check_terraform() {
   echo "Running terraform validate"
   #shellcheck disable=SC2156
-  find . -name "*.tf" -exec bash -c 'terraform validate --check-variables=false $(dirname "{}")' \;
+  find . -name "*.tf" -exec bash -c 'terraform validate --check-variables=false $(dirname "{}")' \; || exit 1
 }
 
 # This function runs 'go fmt' and 'go vet' on every file
 # that ends in '.go'
 function golang() {
   echo "Running go fmt and go vet"
-  find . -name "*.go" -exec go fmt {} \;
-  find . -name "*.go" -exec go vet {} \;
+  find . -name "*.go" -exec go fmt {} \; || exit 1
+  find . -name "*.go" -exec go vet {} \; || exit 1
 }
 
 # This function runs the flake8 linter on every file
 # ending in '.py'
 function check_python() {
   echo "Running flake8"
-  find . -name "*.py" -exec flake8 {} \;
+  find . -name "*.py" -exec flake8 {} \; || exit 1
 }
 
 # This function runs the shellcheck linter on every
 # file ending in '.sh'
 function check_shell() {
   echo "Running shellcheck"
-  find . -name "*.sh" -exec shellcheck -x {} \;
+  find . -name "*.sh" -exec shellcheck -x {} \; || exit 1
 }
 
 # This function makes sure that there is no trailing whitespace
@@ -78,11 +78,7 @@ function check_shell() {
 # There are some exclusions
 function check_trailing_whitespace() {
   echo "The following lines have trailing whitespace"
-  grep -r '[[:blank:]]$' --exclude-dir=".terraform" --exclude="*.png" --exclude="*.pyc" --exclude-dir=".git" .
-  rc=$?
-  if [ $rc = 0 ]; then
-    exit 1
-  fi
+  grep -r '[[:blank:]]$' --exclude-dir=".terraform" --exclude="*.png" --exclude="*.pyc" --exclude-dir=".git" . || exit 1
 }
 
 function generate_docs() {

--- a/test/make.sh
+++ b/test/make.sh
@@ -40,7 +40,11 @@ function basefiles() {
 # every file named 'Dockerfile'
 function docker() {
   echo "Running hadolint on Dockerfiles"
-  find . -name "Dockerfile" -exec hadolint {} \; || exit 1
+  find . -name "Dockerfile" -exec hadolint {} \;
+  rc=$?
+  if [ $rc != 0 ]; then
+    exit 1
+  fi
 }
 
 # This function runs 'terraform validate' against all
@@ -48,29 +52,49 @@ function docker() {
 function check_terraform() {
   echo "Running terraform validate"
   #shellcheck disable=SC2156
-  find . -name "*.tf" -exec bash -c 'terraform validate --check-variables=false $(dirname "{}")' \; || exit 1
+  find . -name "*.tf" -exec bash -c 'terraform validate --check-variables=false $(dirname "{}")' \;
+  rc=$?
+  if [ $rc != 0 ]; then
+    exit 1
+  fi
 }
 
 # This function runs 'go fmt' and 'go vet' on every file
 # that ends in '.go'
 function golang() {
   echo "Running go fmt and go vet"
-  find . -name "*.go" -exec go fmt {} \; || exit 1
-  find . -name "*.go" -exec go vet {} \; || exit 1
+  find . -name "*.go" -exec go fmt {} \;
+  rc=$?
+  if [ $rc != 0 ]; then
+    exit 1
+  fi
+  find . -name "*.go" -exec go vet {} \;
+  rc=$?
+  if [ $rc != 0 ]; then
+    exit 1
+  fi
 }
 
 # This function runs the flake8 linter on every file
 # ending in '.py'
 function check_python() {
   echo "Running flake8"
-  find . -name "*.py" -exec flake8 {} \; || exit 1
+  find . -name "*.py" -exec flake8 {} \;
+  rc=$?
+  if [ $rc != 0 ]; then
+    exit 1
+  fi
 }
 
 # This function runs the shellcheck linter on every
 # file ending in '.sh'
 function check_shell() {
   echo "Running shellcheck"
-  find . -name "*.sh" -exec shellcheck -x {} \; || exit 1
+  find . -name "*.sh" -exec shellcheck -x {} \;
+  rc=$?
+  if [ $rc != 0 ]; then
+    exit 1
+  fi
 }
 
 # This function makes sure that there is no trailing whitespace
@@ -78,7 +102,11 @@ function check_shell() {
 # There are some exclusions
 function check_trailing_whitespace() {
   echo "The following lines have trailing whitespace"
-  grep -r '[[:blank:]]$' --exclude-dir=".terraform" --exclude="*.png" --exclude="*.pyc" --exclude-dir=".git" . || exit 1
+  grep -r '[[:blank:]]$' --exclude-dir=".terraform" --exclude="*.png" --exclude="*.pyc" --exclude-dir=".git" .
+  rc=$?
+  if [ $rc != 0 ]; then
+    exit 1
+  fi
 }
 
 function generate_docs() {


### PR DESCRIPTION
Instructions for enabling:
- [ ] Turn on TravisCI through the travis UI for this repo
- [ ] Add any additional checks by adding more `env` entries e.g. `- MAKE_TASK=test_integration`

I didn't get around to fixing all the lint errors in this try. Also, the scripts need to be modified to fail fast i.e. they pass currently event though the flake8 tests fail