### PR TITLE
Get tests running

### DIFF
--- a/test/integration/gcloud/run.sh
+++ b/test/integration/gcloud/run.sh
@@ -311,11 +311,11 @@ function bundle_install() {
 
 # Execute kitchen tests
 function run_kitchen() {
-  kitchen create
-  kitchen converge
-  kitchen converge # second time to enable network policy
-  kitchen verify
-  kitchen destroy
+  bundle exec kitchen create
+  bundle exec kitchen converge
+  bundle exec kitchen converge # second time to enable network policy
+  bundle exec kitchen verify
+  bundle exec kitchen destroy
 }
 
 # Preparing environment

--- a/test/integration/gcloud/run.sh
+++ b/test/integration/gcloud/run.sh
@@ -74,6 +74,7 @@ locals {
 
 provider "google" {
   credentials              = "\${file(local.credentials_file_path)}"
+  region                   = "${REGION}"
 }
 
 provider "kubernetes" {


### PR DESCRIPTION
On my machine, with a clean checkout, I encountered two problems trying to run the test suite:

* `run.sh` tries to run `kitchen` commands without entering the `bundle` context, potentially causing errors loading the `kitchen-terraform` gem
* While the provider is available when Terraform code is generated for integration tests, it is not explicitly set in the `google` provider, causing errors when it is not otherwise configured.