### PR TITLE
`region` is required for `google_compute_subnetwork`

### DIFF
--- a/networks.tf
+++ b/networks.tf
@@ -5,5 +5,6 @@ data "google_compute_network" "gke_network" {
 
 data "google_compute_subnetwork" "gke_subnetwork" {
   name    = "${var.subnetwork}"
+  region  = "${var.region}"
   project = "${local.network_project_id}"
 }


### PR DESCRIPTION
My environment is on GKE with shared VPC network.
And, I've got an error below when I tried 'terraform plan'. I believe this PR fix my issue.

```
data.google_compute_subnetwork.gke_subnetwork: Cannot determine region: set in this resource, or set provider-level 'region' or 'zone'.
```

Terraform Code:
```
module "gke-cluster-my-cluster" {
  source              = "github.com/terraform-google-modules/terraform-google-kubernetes-engine"
  project_id          = "my_project"
  name                = "my_cluster"
  kubernetes_version  = "1.10.6-gke.2"
  regional            = false
  region              = "us-east4"
  zones               = ["us-east4-a"]
  network_project_id  = "my_network_project"
  network             = "my_network"
  subnetwork          = "my_subnet"
  ip_range_pods       = "my_cidr_container"
  ip_range_services   = "my_cidr_service"
  network_policy      = true
  http_load_balancing = true

  node_pools = [
    {
      name                     = "my_node_pool"
      image_type               = "COS"
      instance_service_account = "my_service_account@my_project.iam.gserviceaccount.com"
      machine_type             = "n1-standard-32" # 32 CPU / 120 GB Memory
      min_count                = "1"
    },
  ]

  node_pools_tags = {
    all = []
    my_node_pool = [
      "allow-k8s-services-internal",
      "allow-k8s-services-external",
    ]
  }

  node_pools_labels = {
    all = {}
    my_node_pool = {}
  }

  node_pools_taints = {
    all = []
    my_node_pool = []
  }

  non_masquerade_cidrs = [
    "${data.google_compute_subnetwork.my_subnet.secondary_ip_range.0.ip_cidr_range}",
    "${data.google_compute_subnetwork.my_subnet.secondary_ip_range.1.ip_cidr_range}",
  ]

  stub_domains         {
    "some_domain_1" = ["some_ip","some_ip"]
    "some_domain_2" = ["some_ip","some_ip"]
    "some_domain_3" = ["some_ip","some_ip"]
  }
}
```