### PR TITLE
Default K8s Version Uses Latest Patch Suffix for 1.10.6

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -57,7 +57,7 @@ variable "subnetwork" {
 
 variable "kubernetes_version" {
   description = "The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region."
-  default     = "1.10.6-gke.2"
+  default     = "1.10.6"
 }
 
 variable "node_version" {


### PR DESCRIPTION
Removes explicit patch suffix to allow usage of latest when launching new clusters. Only the latest tends to be supported.

Closes https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/24.