### PR TITLE
Master and Node Versions Default to Latest

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -57,7 +57,7 @@ variable "subnetwork" {
 
 variable "kubernetes_version" {
   description = "The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region."
-  default     = "1.10.6"
+  default     = "latest"
 }
 
 variable "node_version" {


### PR DESCRIPTION
This is as opposed to letting GKE figure out the latest patch suffix. This strategy does not work for specifying node version - only masters. An explicit patch suffix is required for node version.

Latest, "...specifies the highest supported Kubernetes version currently available on GKE in the cluster's zone or region" [1]. I've tested this in `us-west1`, `us-west2`, and `us-central1` and it's worked as suspected - all masters and nodes were launched with version 1.11.2-gke.18.

An alternate approach would be to use the [`google_container_engine_versions` data source](https://www.terraform.io/docs/providers/google/d/google_container_engine_versions.html). This would be useful if we had a need to target a specific minor or patch version as the default. I would argue that it's more appropriate for the projects that use this module to utilize `google_container_engine_versions` to satisfy project-specific needs.

[1]: https://cloud.google.com/kubernetes-engine/versioning-and-upgrades#specifying_cluster_version