### PR TITLE
Set horizontal_pod_autoscaling to true by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
+* Set `horizontal_pod_autoscaling` to `true` by default. #42
 
 ## [v0.4.0] - 2018-12-19
 ### Added

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Then perform the following commands on the root folder:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | description | The description of the cluster | string | `` | no |
-| horizontal_pod_autoscaling | Enable horizontal pod autoscaling addon | string | `false` | no |
+| horizontal_pod_autoscaling | Enable horizontal pod autoscaling addon | string | `true` | no |
 | http_load_balancing | Enable httpload balancer addon | string | `true` | no |
 | ip_masq_link_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | string | `false` | no |
 | ip_masq_resync_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | string | `60s` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -86,7 +86,7 @@ variable "master_authorized_networks_config" {
 
 variable "horizontal_pod_autoscaling" {
   description = "Enable horizontal pod autoscaling addon"
-  default     = false
+  default     = true
 }
 
 variable "http_load_balancing" {


### PR DESCRIPTION
I just wanted to do a step further with #42 issue reported recently. It might be considered a cosmetic change, but I deeply believe following the standards from the `google_container_cluster` resource is more than appropriate. 
The choose of `false` comes from 21ec8db89dcf0c27fe80ccf2b28703500e234768 which is the very first commit from this module, hence this might be worth updating.

Fixes #42.