### PR TITLE
Add remove_default_node_pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Then perform the following commands on the root folder:
 | network | The VPC network to host the cluster in (required) | string | - | yes |
 | network_policy | Enable network policy addon | string | `false` | no |
 | network_project_id | The project ID of the shared VPC's host (for shared vpc support) | string | `` | no |
+| remove_default_node_pool | Boolean value determining removal of default node pool | bool | false | no |
 | node_pools | List of maps containing node pools | list | `<list>` | no |
 | node_pools_labels | Map of maps containing node labels by node-pool name | map | `<map>` | no |
 | node_pools_tags | Map of lists containing node network tags by node-pool name | map | `<map>` | no |

--- a/cluster_regional.tf
+++ b/cluster_regional.tf
@@ -26,8 +26,8 @@ resource "google_container_cluster" "primary" {
   region           = "${var.region}"
   additional_zones = ["${coalescelist(compact(var.zones), sort(random_shuffle.available_zones.result))}"]
 
-  network            = "projects/${data.google_compute_network.gke_network.project}/global/networks/${data.google_compute_network.gke_network.name}"
-  subnetwork         = "projects/${data.google_compute_network.gke_network.project}/regions/${var.region}/subnetworks/${data.google_compute_subnetwork.gke_subnetwork.name}"
+  network            = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
+  subnetwork         = "${replace(data.google_compute_subnetwork.gke_subnetwork.self_link, "https://www.googleapis.com/compute/v1/", "")}"
   min_master_version = "${local.kubernetes_version}"
 
   logging_service    = "${var.logging_service}"

--- a/cluster_regional.tf
+++ b/cluster_regional.tf
@@ -26,8 +26,8 @@ resource "google_container_cluster" "primary" {
   region           = "${var.region}"
   additional_zones = ["${coalescelist(compact(var.zones), sort(random_shuffle.available_zones.result))}"]
 
-  network            = "${data.google_compute_network.gke_network.self_link}"
-  subnetwork         = "${data.google_compute_subnetwork.gke_subnetwork.self_link}"
+  network            = "projects/${var.project_id}/global/networks/${data.google_compute_network.gke_network.name}"
+  subnetwork         = "projects/${var.project_id}/regions/${var.region}/subnetworks/${data.google_compute_subnetwork.gke_subnetwork.name}"
   min_master_version = "${local.kubernetes_version}"
 
   logging_service    = "${var.logging_service}"

--- a/cluster_regional.tf
+++ b/cluster_regional.tf
@@ -26,8 +26,8 @@ resource "google_container_cluster" "primary" {
   region           = "${var.region}"
   additional_zones = ["${coalescelist(compact(var.zones), sort(random_shuffle.available_zones.result))}"]
 
-  network            = "projects/${var.project_id}/global/networks/${data.google_compute_network.gke_network.name}"
-  subnetwork         = "projects/${var.project_id}/regions/${var.region}/subnetworks/${data.google_compute_subnetwork.gke_subnetwork.name}"
+  network            = "projects/${data.google_compute_network.gke_network.project}/global/networks/${data.google_compute_network.gke_network.name}"
+  subnetwork         = "projects/${data.google_compute_network.gke_network.project}/regions/${var.region}/subnetworks/${data.google_compute_subnetwork.gke_subnetwork.name}"
   min_master_version = "${local.kubernetes_version}"
 
   logging_service    = "${var.logging_service}"

--- a/cluster_regional.tf
+++ b/cluster_regional.tf
@@ -81,6 +81,8 @@ resource "google_container_cluster" "primary" {
       service_account = "${lookup(var.node_pools[0], "service_account", var.service_account)}"
     }
   }
+
+  remove_default_node_pool = "${var.remove_default_node_pool}"
 }
 
 /******************************************

--- a/cluster_zonal.tf
+++ b/cluster_zonal.tf
@@ -26,8 +26,8 @@ resource "google_container_cluster" "zonal_primary" {
   zone             = "${var.zones[0]}"
   additional_zones = ["${slice(var.zones,1,length(var.zones))}"]
 
-  network            = "projects/${var.project_id}/global/networks/${data.google_compute_network.gke_network.name}"
-  subnetwork         = "projects/${var.project_id}/regions/${var.region}/subnetworks/${data.google_compute_subnetwork.gke_subnetwork.name}"
+  network            = "projects/${data.google_compute_network.gke_network.project}/global/networks/${data.google_compute_network.gke_network.name}"
+  subnetwork         = "projects/${data.google_compute_network.gke_network.project}/regions/${var.region}/subnetworks/${data.google_compute_subnetwork.gke_subnetwork.name}"
   min_master_version = "${local.kubernetes_version}"
 
   logging_service    = "${var.logging_service}"

--- a/cluster_zonal.tf
+++ b/cluster_zonal.tf
@@ -81,6 +81,8 @@ resource "google_container_cluster" "zonal_primary" {
       service_account = "${lookup(var.node_pools[0], "service_account", var.service_account)}"
     }
   }
+
+  remove_default_node_pool = "${var.remove_default_node_pool}"
 }
 
 /******************************************

--- a/cluster_zonal.tf
+++ b/cluster_zonal.tf
@@ -26,8 +26,8 @@ resource "google_container_cluster" "zonal_primary" {
   zone             = "${var.zones[0]}"
   additional_zones = ["${slice(var.zones,1,length(var.zones))}"]
 
-  network            = "${data.google_compute_network.gke_network.self_link}"
-  subnetwork         = "${data.google_compute_subnetwork.gke_subnetwork.self_link}"
+  network            = "projects/${var.project_id}/global/networks/${data.google_compute_network.gke_network.name}"
+  subnetwork         = "projects/${var.project_id}/regions/${var.region}/subnetworks/${data.google_compute_subnetwork.gke_subnetwork.name}"
   min_master_version = "${local.kubernetes_version}"
 
   logging_service    = "${var.logging_service}"

--- a/cluster_zonal.tf
+++ b/cluster_zonal.tf
@@ -26,8 +26,8 @@ resource "google_container_cluster" "zonal_primary" {
   zone             = "${var.zones[0]}"
   additional_zones = ["${slice(var.zones,1,length(var.zones))}"]
 
-  network            = "projects/${data.google_compute_network.gke_network.project}/global/networks/${data.google_compute_network.gke_network.name}"
-  subnetwork         = "projects/${data.google_compute_network.gke_network.project}/regions/${var.region}/subnetworks/${data.google_compute_subnetwork.gke_subnetwork.name}"
+  network            = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
+  subnetwork         = "${replace(data.google_compute_subnetwork.gke_subnetwork.self_link, "https://www.googleapis.com/compute/v1/", "")}"
   min_master_version = "${local.kubernetes_version}"
 
   logging_service    = "${var.logging_service}"

--- a/variables.tf
+++ b/variables.tf
@@ -117,6 +117,11 @@ variable "ip_range_services" {
   description = "The secondary ip range to use for pods"
 }
 
+variable "remove_default_node_pool" {
+  description = "Remove default node pool while setting up the cluster"
+  default     = false
+}
+
 variable "node_pools" {
   type        = "list"
   description = "List of maps containing node pools"


### PR DESCRIPTION
In the #15 issue there was a request for remove_default_node_pool. I'm interested in introducing this to the module. There's no point in keeping the default node pool the `google_container_cluster` forces us to have on the beginning. Usually, the one wants to manage the pools explicitly, and so do I, hence this PR.

Adding the `remove_default_node_pool` was not enough to make it work perfectly. A change in the manner of providing the `google_container_cluster` with the network and subnetwork parameters had to be changed as well. Without it, terraform produced permadiff with every `plan` and `apply`.  That's the issue with google provider, more on that is described [in this google provider issue](https://github.com/terraform-providers/terraform-provider-google/issues/1566). 

The approach I propose is a workaround which won't cause any backward incompatibilities. The issue I faced might be the problem described from the #15.

If anyone is having the better solution, feel free to propose it!