### PR TITLE
Add random suffix to end of cluster names during testing

### DIFF
--- a/cluster_regional.tf
+++ b/cluster_regional.tf
@@ -110,7 +110,7 @@ resource "google_container_node_pool" "pools" {
     machine_type = "${lookup(var.node_pools[count.index], "machine_type", "n1-standard-2")}"
     labels       = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_labels["all"], var.node_pools_labels[lookup(var.node_pools[count.index], "name")])}"
     taint        = "${concat(var.node_pools_taints["all"], var.node_pools_taints[lookup(var.node_pools[count.index], "name")])}"
-    tags         = "${concat(list("gke-${var.name}"), list("gke-${var.name}-${lookup(var.node_pools[count.index], "name")}"), var.node_pools_tags["all"], var.node_pools_tags[lookup(var.node_pools[count.index], "name")])}"
+    tags         = ["${concat(list("gke-${var.name}"), list("gke-${var.name}-${lookup(var.node_pools[count.index], "name")}"), var.node_pools_tags["all"], var.node_pools_tags[lookup(var.node_pools[count.index], "name")])}"]
 
     disk_size_gb    = "${lookup(var.node_pools[count.index], "disk_size_gb", 100)}"
     disk_type       = "${lookup(var.node_pools[count.index], "disk_type", "pd-standard")}"

--- a/cluster_zonal.tf
+++ b/cluster_zonal.tf
@@ -110,7 +110,7 @@ resource "google_container_node_pool" "zonal_pools" {
     machine_type = "${lookup(var.node_pools[count.index], "machine_type", "n1-standard-2")}"
     labels       = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_labels["all"], var.node_pools_labels[lookup(var.node_pools[count.index], "name")])}"
     taint        = "${concat(var.node_pools_taints["all"], var.node_pools_taints[lookup(var.node_pools[count.index], "name")])}"
-    tags         = "${concat(list("gke-${var.name}"), list("gke-${var.name}-${lookup(var.node_pools[count.index], "name")}"), var.node_pools_tags["all"], var.node_pools_tags[lookup(var.node_pools[count.index], "name")])}"
+    tags         = ["${concat(list("gke-${var.name}"), list("gke-${var.name}-${lookup(var.node_pools[count.index], "name")}"), var.node_pools_tags["all"], var.node_pools_tags[lookup(var.node_pools[count.index], "name")])}"]
 
     disk_size_gb    = "${lookup(var.node_pools[count.index], "disk_size_gb", 100)}"
     disk_type       = "${lookup(var.node_pools[count.index], "disk_type", "pd-standard")}"

--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -35,11 +35,10 @@ data "google_client_config" "default" {}
 module "gke" {
   source             = "../../"
   project_id         = "${var.project_id}"
-  name               = "${local.cluster_type}-cluster"
+  name               = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
   region             = "${var.region}"
   network            = "${var.network}"
-  subnetwork         = "${var.subnetwork}"
-  ip_range_pods      = "${var.ip_range_pods}"
+  subnetwork         = "${var.subnetwork}" ip_range_pods      = "${var.ip_range_pods}"
   ip_range_services  = "${var.ip_range_services}"
   kubernetes_version = "1.11.5-gke.4"
   service_account    = "${var.compute_engine_service_account}"

--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -33,12 +33,14 @@ provider "kubernetes" {
 data "google_client_config" "default" {}
 
 module "gke" {
-  source             = "../../"
-  project_id         = "${var.project_id}"
-  name               = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
-  region             = "${var.region}"
-  network            = "${var.network}"
-  subnetwork         = "${var.subnetwork}" ip_range_pods      = "${var.ip_range_pods}"
+  source     = "../../"
+  project_id = "${var.project_id}"
+  name       = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
+  region     = "${var.region}"
+  network    = "${var.network}"
+  subnetwork = "${var.subnetwork}"
+
+  ip_range_pods      = "${var.ip_range_pods}"
   ip_range_services  = "${var.ip_range_services}"
   kubernetes_version = "1.11.5-gke.4"
   service_account    = "${var.compute_engine_service_account}"

--- a/examples/deploy_service/variables.tf
+++ b/examples/deploy_service/variables.tf
@@ -22,6 +22,11 @@ variable "credentials_path" {
   description = "The path to the GCP credentials JSON file"
 }
 
+variable "cluster_name_suffix" {
+  description = "A suffix to append to the default cluster name"
+  default     = ""
+}
+
 variable "region" {
   description = "The region to host the cluster in"
 }

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -26,7 +26,7 @@ provider "google" {
 module "gke" {
   source             = "../../"
   project_id         = "${var.project_id}"
-  name               = "${local.cluster_type}-cluster"
+  name               = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
   region             = "${var.region}"
   network            = "${var.network}"
   subnetwork         = "${var.subnetwork}"

--- a/examples/node_pool/variables.tf
+++ b/examples/node_pool/variables.tf
@@ -22,6 +22,11 @@ variable "credentials_path" {
   description = "The path to the GCP credentials JSON file"
 }
 
+variable "cluster_name_suffix" {
+  description = "A suffix to append to the default cluster name"
+  default     = ""
+}
+
 variable "region" {
   description = "The region to host the cluster in"
 }

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -26,7 +26,7 @@ provider "google" {
 module "gke" {
   source             = "../../"
   project_id         = "${var.project_id}"
-  name               = "${local.cluster_type}-cluster"
+  name               = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
   region             = "${var.region}"
   network            = "${var.network}"
   network_project_id = "${var.network_project_id}"

--- a/examples/shared_vpc/variables.tf
+++ b/examples/shared_vpc/variables.tf
@@ -22,6 +22,11 @@ variable "credentials_path" {
   description = "The path to the GCP credentials JSON file"
 }
 
+variable "cluster_name_suffix" {
+  description = "A suffix to append to the default cluster name"
+  default     = ""
+}
+
 variable "region" {
   description = "The region to host the cluster in"
 }

--- a/examples/simple_regional/main.tf
+++ b/examples/simple_regional/main.tf
@@ -26,7 +26,7 @@ provider "google" {
 module "gke" {
   source             = "../../"
   project_id         = "${var.project_id}"
-  name               = "${local.cluster_type}-cluster"
+  name               = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
   regional           = true
   region             = "${var.region}"
   network            = "${var.network}"

--- a/examples/simple_regional/variables.tf
+++ b/examples/simple_regional/variables.tf
@@ -22,6 +22,11 @@ variable "credentials_path" {
   description = "The path to the GCP credentials JSON file"
 }
 
+variable "cluster_name_suffix" {
+  description = "A suffix to append to the default cluster name"
+  default     = ""
+}
+
 variable "region" {
   description = "The region to host the cluster in"
 }

--- a/examples/simple_zonal/main.tf
+++ b/examples/simple_zonal/main.tf
@@ -26,7 +26,7 @@ provider "google" {
 module "gke" {
   source             = "../../"
   project_id         = "${var.project_id}"
-  name               = "${local.cluster_type}-cluster"
+  name               = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
   regional           = false
   region             = "${var.region}"
   zones              = "${var.zones}"

--- a/examples/simple_zonal/variables.tf
+++ b/examples/simple_zonal/variables.tf
@@ -22,6 +22,11 @@ variable "credentials_path" {
   description = "The path to the GCP credentials JSON file"
 }
 
+variable "cluster_name_suffix" {
+  description = "A suffix to append to the default cluster name"
+  default     = ""
+}
+
 variable "region" {
   description = "The region to host the cluster in"
 }

--- a/examples/stub_domains/main.tf
+++ b/examples/stub_domains/main.tf
@@ -26,7 +26,7 @@ provider "google" {
 module "gke" {
   source             = "../../"
   project_id         = "${var.project_id}"
-  name               = "${local.cluster_type}-cluster"
+  name               = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
   region             = "${var.region}"
   network            = "${var.network}"
   subnetwork         = "${var.subnetwork}"

--- a/examples/stub_domains/variables.tf
+++ b/examples/stub_domains/variables.tf
@@ -22,6 +22,11 @@ variable "credentials_path" {
   description = "The path to the GCP credentials JSON file"
 }
 
+variable "cluster_name_suffix" {
+  description = "A suffix to append to the default cluster name"
+  default     = ""
+}
+
 variable "region" {
   description = "The region to host the cluster in"
 }

--- a/test/fixtures/deploy_service/example.tf
+++ b/test/fixtures/deploy_service/example.tf
@@ -19,6 +19,7 @@ module "example" {
 
   project_id                     = "${var.project_id}"
   credentials_path               = "${local.credentials_path}"
+  cluster_name_suffix            = "-${random_string.suffix.result}"
   region                         = "${var.region}"
   network                        = "${google_compute_network.main.name}"
   subnetwork                     = "${google_compute_subnetwork.main.name}"

--- a/test/fixtures/node_pool/example.tf
+++ b/test/fixtures/node_pool/example.tf
@@ -19,6 +19,7 @@ module "example" {
 
   project_id                     = "${var.project_id}"
   credentials_path               = "${local.credentials_path}"
+  cluster_name_suffix            = "-${random_string.suffix.result}"
   region                         = "${var.region}"
   network                        = "${google_compute_network.main.name}"
   subnetwork                     = "${google_compute_subnetwork.main.name}"

--- a/test/fixtures/shared_vpc/example.tf
+++ b/test/fixtures/shared_vpc/example.tf
@@ -19,6 +19,7 @@ module "example" {
 
   project_id                     = "${var.project_id}"
   credentials_path               = "${local.credentials_path}"
+  cluster_name_suffix            = "-${random_string.suffix.result}"
   region                         = "${var.region}"
   network                        = "${google_compute_network.main.name}"
   network_project_id             = "${var.project_id}"

--- a/test/fixtures/simple_regional/example.tf
+++ b/test/fixtures/simple_regional/example.tf
@@ -19,6 +19,7 @@ module "example" {
 
   project_id                     = "${var.project_id}"
   credentials_path               = "${local.credentials_path}"
+  cluster_name_suffix            = "-${random_string.suffix.result}"
   region                         = "${var.region}"
   network                        = "${google_compute_network.main.name}"
   subnetwork                     = "${google_compute_subnetwork.main.name}"

--- a/test/fixtures/simple_zonal/example.tf
+++ b/test/fixtures/simple_zonal/example.tf
@@ -19,6 +19,7 @@ module "example" {
 
   project_id                     = "${var.project_id}"
   credentials_path               = "${local.credentials_path}"
+  cluster_name_suffix            = "-${random_string.suffix.result}"
   region                         = "${var.region}"
   zones                          = ["${var.zones}"]
   network                        = "${google_compute_network.main.name}"

--- a/test/fixtures/stub_domains/example.tf
+++ b/test/fixtures/stub_domains/example.tf
@@ -19,6 +19,7 @@ module "example" {
 
   project_id                     = "${var.project_id}"
   credentials_path               = "${local.credentials_path}"
+  cluster_name_suffix            = "-${random_string.suffix.result}"
   region                         = "${var.region}"
   network                        = "${google_compute_network.main.name}"
   subnetwork                     = "${google_compute_subnetwork.main.name}"

--- a/test/integration/node_pool/controls/gcloud.rb
+++ b/test/integration/node_pool/controls/gcloud.rb
@@ -128,8 +128,8 @@ control "gcloud" do
                 "tags" => match_array([
                   "all-node-example",
                   "pool-01-example",
-                  "gke-node-pool-cluster",
-                  "gke-node-pool-cluster-pool-01",
+                  "gke-#{cluster_name}",
+                  "gke-#{cluster_name}-pool-01",
                 ]),
               ),
             )
@@ -245,8 +245,8 @@ control "gcloud" do
               "config" => including(
                 "tags" => match_array([
                   "all-node-example",
-                  "gke-node-pool-cluster",
-                  "gke-node-pool-cluster-pool-02",
+                  "gke-#{cluster_name}",
+                  "gke-#{cluster_name}-pool-02",
                 ])
               ),
             )


### PR DESCRIPTION
Reduces likelihood of naming collisions when running tests in parallel.