### PR TITLE
Fix failing horizontal-pod-autoscaling tests

### DIFF
--- a/test/integration/simple_regional/controls/gcloud.rb
+++ b/test/integration/simple_regional/controls/gcloud.rb
@@ -48,9 +48,7 @@ control "gcloud" do
 
       it "has the expected addon settings" do
         expect(data['addonsConfig']).to eq({
-          "horizontalPodAutoscaling" => {
-            "disabled" => true,
-          },
+          "horizontalPodAutoscaling" => {},
           "httpLoadBalancing" => {},
           "kubernetesDashboard" => {
             "disabled" => true,

--- a/test/integration/simple_zonal/controls/gcloud.rb
+++ b/test/integration/simple_zonal/controls/gcloud.rb
@@ -48,9 +48,7 @@ control "gcloud" do
 
       it "has the expected addon settings" do
         expect(data['addonsConfig']).to eq({
-          "horizontalPodAutoscaling" => {
-            "disabled" => true,
-          },
+          "horizontalPodAutoscaling" => {},
           "httpLoadBalancing" => {},
           "kubernetesDashboard" => {
             "disabled" => true,

--- a/test/integration/stub_domains/controls/gcloud.rb
+++ b/test/integration/stub_domains/controls/gcloud.rb
@@ -40,9 +40,7 @@ control "gcloud" do
 
       it "has the expected addon settings" do
         expect(data['addonsConfig']).to eq({
-          "horizontalPodAutoscaling" => {
-            "disabled" => true,
-          },
+          "horizontalPodAutoscaling" => {},
           "httpLoadBalancing" => {},
           "kubernetesDashboard" => {
             "disabled" => true,


### PR DESCRIPTION
This was compounded by an erroneous Concourse pipeline config, where an error in running the integration tests would cause the created resources to be cleaned up, but would not actually trigger a failure. This has since been corrected.