### PR TITLE
Add initial_node_count var for node_pool block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Set `horizontal_pod_autoscaling` to `true` by default. #42
 * Add `remove_default_node_pool` set to `false` by default #15
 * Allow arbitrary key-value pairs to be set on node pool metadata. #52
-* Add `initial_node_count` parameter to node_pool block.
+* Add `initial_node_count` parameter to node_pool block. #60 
 
 ## [v0.4.0] - 2018-12-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 * Set `horizontal_pod_autoscaling` to `true` by default. #42
 * Add `remove_default_node_pool` set to `false` by default #15
 * Allow arbitrary key-value pairs to be set on node pool metadata. #52
+* Add `initial_node_count` parameter to node_pool block.
 
 ## [v0.4.0] - 2018-12-19
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,17 +30,18 @@ module "gke" {
 
   node_pools = [
     {
-      name            = "default-node-pool"
-      machine_type    = "n1-standard-2"
-      min_count       = 1
-      max_count       = 100
-      disk_size_gb    = 100
-      disk_type       = "pd-standard"
-      image_type      = "COS"
-      auto_repair     = true
-      auto_upgrade    = true
-      service_account = "project-service-account@<PROJECT ID>.iam.gserviceaccount.com"
-      preemptible     = false
+      name               = "default-node-pool"
+      machine_type       = "n1-standard-2"
+      min_count          = 1
+      max_count          = 100
+      disk_size_gb       = 100
+      disk_type          = "pd-standard"
+      image_type         = "COS"
+      auto_repair        = true
+      auto_upgrade       = true
+      service_account    = "project-service-account@<PROJECT ID>.iam.gserviceaccount.com"
+      preemptible        = false
+      initial_node_count = 80
     },
   ]
 

--- a/cluster_regional.tf
+++ b/cluster_regional.tf
@@ -95,7 +95,7 @@ resource "google_container_node_pool" "pools" {
   region             = "${var.region}"
   cluster            = "${var.name}"
   version            = "${lookup(var.node_pools[count.index], "auto_upgrade", false) ? "" : lookup(var.node_pools[count.index], "version", local.node_version)}"
-  initial_node_count = "${lookup(var.node_pools[count.index], "min_count", 1)}"
+  initial_node_count = "${lookup(var.node_pools[count.index], "initial_node_count", lookup(var.node_pools[count.index], "min_count", 1))}"
 
   autoscaling {
     min_node_count = "${lookup(var.node_pools[count.index], "min_count", 1)}"

--- a/cluster_zonal.tf
+++ b/cluster_zonal.tf
@@ -95,7 +95,7 @@ resource "google_container_node_pool" "zonal_pools" {
   zone               = "${var.zones[0]}"
   cluster            = "${var.name}"
   version            = "${lookup(var.node_pools[count.index], "auto_upgrade", false) ? "" : lookup(var.node_pools[count.index], "version", local.node_version)}"
-  initial_node_count = "${lookup(var.node_pools[count.index], "min_count", 1)}"
+  initial_node_count = "${lookup(var.node_pools[count.index], "initial_node_count", lookup(var.node_pools[count.index], "min_count", 1))}"
 
   autoscaling {
     min_node_count = "${lookup(var.node_pools[count.index], "min_count", 1)}"


### PR DESCRIPTION
Hi,

I wanted to extend the node_pool block parameters a bit and add optional, explicitly set initial_node_count for node pool. It assumes the min_count or 1 when not defined, so it doesn't affect anyone when not set. 
We need this to start new node pool with predefined node count even when autoscaling minimal value is set lower, useful especially when adding new node pool as a reaction to increased traffic etc.

I added no tests. If there's anyone willing to write them since I haven't had a chance yet, please don't hesitate.