### PR TITLE
Remove explicit versions from test cases and examples

### DIFF
--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -40,10 +40,9 @@ module "gke" {
   network    = "${var.network}"
   subnetwork = "${var.subnetwork}"
 
-  ip_range_pods      = "${var.ip_range_pods}"
-  ip_range_services  = "${var.ip_range_services}"
-  kubernetes_version = "1.11.5-gke.4"
-  service_account    = "${var.compute_engine_service_account}"
+  ip_range_pods     = "${var.ip_range_pods}"
+  ip_range_services = "${var.ip_range_services}"
+  service_account   = "${var.compute_engine_service_account}"
 }
 
 resource "kubernetes_pod" "nginx-example" {

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -24,16 +24,14 @@ provider "google" {
 }
 
 module "gke" {
-  source             = "../../"
-  project_id         = "${var.project_id}"
-  name               = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
-  region             = "${var.region}"
-  network            = "${var.network}"
-  subnetwork         = "${var.subnetwork}"
-  ip_range_pods      = "${var.ip_range_pods}"
-  ip_range_services  = "${var.ip_range_services}"
-  kubernetes_version = "1.11.5-gke.4"
-  node_version       = "1.11.5-gke.4"
+  source            = "../../"
+  project_id        = "${var.project_id}"
+  name              = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
+  region            = "${var.region}"
+  network           = "${var.network}"
+  subnetwork        = "${var.subnetwork}"
+  ip_range_pods     = "${var.ip_range_pods}"
+  ip_range_services = "${var.ip_range_services}"
 
   node_pools = [
     {

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -33,8 +33,6 @@ module "gke" {
   subnetwork         = "${var.subnetwork}"
   ip_range_pods      = "${var.ip_range_pods}"
   ip_range_services  = "${var.ip_range_services}"
-  kubernetes_version = "1.11.5-gke.4"
-  node_version       = "1.11.5-gke.4"
   service_account    = "${var.compute_engine_service_account}"
 }
 

--- a/examples/simple_regional/main.tf
+++ b/examples/simple_regional/main.tf
@@ -24,18 +24,16 @@ provider "google" {
 }
 
 module "gke" {
-  source             = "../../"
-  project_id         = "${var.project_id}"
-  name               = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
-  regional           = true
-  region             = "${var.region}"
-  network            = "${var.network}"
-  subnetwork         = "${var.subnetwork}"
-  ip_range_pods      = "${var.ip_range_pods}"
-  ip_range_services  = "${var.ip_range_services}"
-  kubernetes_version = "1.11.5-gke.4"
-  node_version       = "1.11.5-gke.4"
-  service_account    = "${var.compute_engine_service_account}"
+  source            = "../../"
+  project_id        = "${var.project_id}"
+  name              = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
+  regional          = true
+  region            = "${var.region}"
+  network           = "${var.network}"
+  subnetwork        = "${var.subnetwork}"
+  ip_range_pods     = "${var.ip_range_pods}"
+  ip_range_services = "${var.ip_range_services}"
+  service_account   = "${var.compute_engine_service_account}"
 }
 
 data "google_client_config" "default" {}

--- a/examples/stub_domains/main.tf
+++ b/examples/stub_domains/main.tf
@@ -24,18 +24,16 @@ provider "google" {
 }
 
 module "gke" {
-  source             = "../../"
-  project_id         = "${var.project_id}"
-  name               = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
-  region             = "${var.region}"
-  network            = "${var.network}"
-  subnetwork         = "${var.subnetwork}"
-  ip_range_pods      = "${var.ip_range_pods}"
-  ip_range_services  = "${var.ip_range_services}"
-  network_policy     = true
-  kubernetes_version = "1.11.5-gke.4"
-  node_version       = "1.11.5-gke.4"
-  service_account    = "${var.compute_engine_service_account}"
+  source            = "../../"
+  project_id        = "${var.project_id}"
+  name              = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
+  region            = "${var.region}"
+  network           = "${var.network}"
+  subnetwork        = "${var.subnetwork}"
+  ip_range_pods     = "${var.ip_range_pods}"
+  ip_range_services = "${var.ip_range_services}"
+  network_policy    = true
+  service_account   = "${var.compute_engine_service_account}"
 
   stub_domains {
     "example.com" = [

--- a/test/integration/deploy_service/controls/gcloud.rb
+++ b/test/integration/deploy_service/controls/gcloud.rb
@@ -37,10 +37,6 @@ control "gcloud" do
       it "is running" do
         expect(data['status']).to eq 'RUNNING'
       end
-
-      it "has the expected initial cluster version" do
-        expect(data['initialClusterVersion']).to eq "1.11.5-gke.4"
-      end
     end
   end
 end

--- a/test/integration/simple_regional/controls/gcloud.rb
+++ b/test/integration/simple_regional/controls/gcloud.rb
@@ -42,10 +42,6 @@ control "gcloud" do
         expect(data['location']).to match(/^.*[1-9]$/)
       end
 
-      it "has the expected initial cluster version" do
-        expect(data['initialClusterVersion']).to eq "1.11.5-gke.4"
-      end
-
       it "has the expected addon settings" do
         expect(data['addonsConfig']).to eq({
           "horizontalPodAutoscaling" => {},
@@ -74,14 +70,6 @@ control "gcloud" do
 
     describe "node pool" do
       let(:node_pools) { data['nodePools'].reject { |p| p['name'] == "default-pool" } }
-
-      it "is running the expected version of Kubernetes" do
-        expect(node_pools).to include(
-          including(
-            "version" => "1.11.5-gke.4",
-          )
-        )
-      end
 
       it "has autoscaling enabled" do
         expect(node_pools).to include(


### PR DESCRIPTION
At one point, these were necessary to ensure that tests passed, particularly when working with zonal clusters. This does not seem to be the case any longer, and merely add overhead, as they have to be updated to keep tests green.