### PR TITLE
Drop explicit version from simple_zonal example

### DIFF
--- a/examples/simple_zonal/main.tf
+++ b/examples/simple_zonal/main.tf
@@ -34,8 +34,6 @@ module "gke" {
   subnetwork         = "${var.subnetwork}"
   ip_range_pods      = "${var.ip_range_pods}"
   ip_range_services  = "${var.ip_range_services}"
-  kubernetes_version = "1.11.4-gke.13"
-  node_version       = "1.11.4-gke.13"
   service_account    = "${var.compute_engine_service_account}"
 }
 

--- a/test/integration/simple_zonal/controls/gcloud.rb
+++ b/test/integration/simple_zonal/controls/gcloud.rb
@@ -46,10 +46,6 @@ control "gcloud" do
         expect(data['locations'].size).to eq 1
       end
 
-      it "has the expected initial cluster version" do
-        expect(data['initialClusterVersion']).to eq "1.11.4-gke.13"
-      end
-
       it "has the expected addon settings" do
         expect(data['addonsConfig']).to eq({
           "horizontalPodAutoscaling" => {},
@@ -78,14 +74,6 @@ control "gcloud" do
 
     describe "node pool" do
       let(:node_pools) { data['nodePools'].reject { |p| p['name'] == "default-pool" } }
-
-      it "is running the expected version of Kubernetes" do
-        expect(node_pools).to include(
-          including(
-            "version" => "1.11.4-gke.13",
-          )
-        )
-      end
 
       it "has autoscaling enabled" do
         expect(node_pools).to include(


### PR DESCRIPTION
The explicit version in the simple_zonal example is causing failures as
1.11.4-gke.13 has been dropped as a valid master version. This commit
drops the explicit versions in the simple_zonal example; we can just use
the latest version avilable.