### PR TITLE
Allow oauth_scopes to be overridden

### DIFF
--- a/autogen/cluster_regional.tf
+++ b/autogen/cluster_regional.tf
@@ -122,9 +122,7 @@ resource "google_container_node_pool" "pools" {
     service_account = "${lookup(var.node_pools[count.index], "service_account", var.service_account)}"
     preemptible     = "${lookup(var.node_pools[count.index], "preemptible", false)}"
 
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform",
-    ]
+    oauth_scopes = "${var.oauth_scopes}"
   }
 
   lifecycle {

--- a/autogen/cluster_zonal.tf
+++ b/autogen/cluster_zonal.tf
@@ -122,9 +122,7 @@ resource "google_container_node_pool" "zonal_pools" {
     service_account = "${lookup(var.node_pools[count.index], "service_account", var.service_account)}"
     preemptible     = "${lookup(var.node_pools[count.index], "preemptible", false)}"
 
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform",
-    ]
+    oauth_scopes = "${var.oauth_scopes}"
   }
 
   lifecycle {

--- a/cluster_regional.tf
+++ b/cluster_regional.tf
@@ -122,9 +122,7 @@ resource "google_container_node_pool" "pools" {
     service_account = "${lookup(var.node_pools[count.index], "service_account", var.service_account)}"
     preemptible     = "${lookup(var.node_pools[count.index], "preemptible", false)}"
 
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform",
-    ]
+    oauth_scopes = "${var.oauth_scopes}"
   }
 
   lifecycle {

--- a/cluster_zonal.tf
+++ b/cluster_zonal.tf
@@ -122,9 +122,7 @@ resource "google_container_node_pool" "zonal_pools" {
     service_account = "${lookup(var.node_pools[count.index], "service_account", var.service_account)}"
     preemptible     = "${lookup(var.node_pools[count.index], "preemptible", false)}"
 
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/cloud-platform",
-    ]
+    oauth_scopes = "${var.oauth_scopes}"
   }
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -211,3 +211,11 @@ variable "service_account" {
   description = "The service account to default running nodes as if not overridden in `node_pools`. Defaults to the compute engine default service account"
   default     = ""
 }
+
+variable "oauth_scopes" {
+  type = "list"
+  description = "The oauth scope the GKE compute nodes are allowed to have"
+  default = [
+      "https://www.googleapis.com/auth/cloud-platform",
+    ]
+}


### PR DESCRIPTION
oauth_scope in the current master version is always tied to only `cloud-platform`. But a module using this might want to override this. I have a typical case where I want to give pods access to decrypt ciphers from kms.