### PR TITLE
[skip ci] Update CHANGELOG links, add entries for v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,17 +15,20 @@ Extending the adopted spec, each change should have a link to its corresponding 
 * Add `remove_default_node_pool` set to `false` by default. Fixes [#15]. [#55]
 * Allow arbitrary key-value pairs to be set on node pool metadata. [#52]
 * Add `initial_node_count` parameter to node_pool block. [#60]
+* Add test tasks to allow for parallelized local testing runs using Concourse [#109]
 
 ### Changed
 * Set `horizontal_pod_autoscaling` to `true` by default. Fixes [#42]. [#54]
 * Update simple-zonal example GKE version to supported version. [#49]
 * Remove explicit versions from test cases and examples. [#62]
 * Set up submodule structure for public and private clusters. [#61]
+* Update the google and google-beta providers to v2.2 [#106]
 
 ### Fixed
 * Zonal clusters can now accept a single zone. Fixes [#43]. [#50]
 * Drop explicit version from simple_zonal example. [#74]
 * Fix link to "configure a service account" [#73]
+* Fix issue with regional cluster roll outs causing version skews [#108]
 
 ## [v0.4.0] - 2018-12-19
 ### Added
@@ -67,6 +70,9 @@ Extending the adopted spec, each change should have a link to its corresponding 
 [#42]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/42
 [#15]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/15
 
+[#109]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/109
+[#108]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/108
+[#106]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/106
 [#80]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/80
 [#74]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/74
 [#73]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/73

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,44 +1,90 @@
 # Change Log
-
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
-project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Extending the adopted spec, each change should have a link to its corresponding pull request appended.
 
 ## [Unreleased]
+
+## [v0.5.0] - 2019-02-28
+### Added
+* Allow creation of service accounts. [#80]
+* Add support for private clusters via submodule. [#69]
+* Add `remove_default_node_pool` set to `false` by default. Fixes [#15]. [#55]
+* Allow arbitrary key-value pairs to be set on node pool metadata. [#52]
+* Add `initial_node_count` parameter to node_pool block. [#60]
+
 ### Changed
-* Add support for private clusters via submodule. #69
-* Set `horizontal_pod_autoscaling` to `true` by default. #42
-* Add `remove_default_node_pool` set to `false` by default #15
-* Allow arbitrary key-value pairs to be set on node pool metadata. #52
-* Add `initial_node_count` parameter to node_pool block. #60
+* Set `horizontal_pod_autoscaling` to `true` by default. Fixes [#42]. [#54]
+* Update simple-zonal example GKE version to supported version. [#49]
+* Remove explicit versions from test cases and examples. [#62]
+* Set up submodule structure for public and private clusters. [#61]
+
+### Fixed
+* Zonal clusters can now accept a single zone. Fixes [#43]. [#50]
+* Drop explicit version from simple_zonal example. [#74]
+* Fix link to "configure a service account" [#73]
 
 ## [v0.4.0] - 2018-12-19
 ### Added
-* Added support for testing with kitchen-terraform. #33
-* Added support for preemptible nodes. #38
+* Added support for testing with kitchen-terraform. [#33]
+* Added support for preemptible nodes. [#38]
 
 ### Changed
-* Updated default version to `1.10.6`. #31
+* Updated default version to `1.10.6`. [#31]
 
 ### Fixed
-* `region` argument on google_compute_subnetwork caused errors. #22
-* Added check to wait for GKE cluster to be `READY` before completing. #46
+* `region` argument on google_compute_subnetwork caused errors. [#22]
+* Added check to wait for GKE cluster to be `READY` before completing. [#46]
 
 ## [v0.3.0] - 2018-10-10
 ### Changed
-* Updated network/subnetwork lookup to use data source. #16
-* Make zone configuration optional when creating a regional cluster. #19
+* Updated network/subnetwork lookup to use data source. [#16]
+* Make zone configuration optional when creating a regional cluster. [#19]
 
 ## [v0.2.0] - 2018-09-26
 
 ### Added
 
-* Support for configuring master authorized networks. (#10)
-* Support specifying monitoring and logging services. (#9)
+* Support for configuring master authorized networks. [#10]
+* Support specifying monitoring and logging services. [#9]
 
-## [v0.1.0] - 2018-09-12
+## v0.1.0 - 2018-09-12
 
 ### Added
 
 * Initial release of module.
+
+[Unreleased]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/compare/v0.5.0...HEAD
+[v0.4.0]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/compare/v0.4.0...v0.5.0
+[v0.4.0]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/compare/v0.3.0...v0.4.0
+[v0.3.0]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/compare/v0.2.0...v0.3.0
+[v0.2.0]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/compare/v0.1.0...v0.2.0
+
+[#43]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/43
+[#42]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/42
+[#15]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/15
+
+[#80]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/80
+[#74]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/74
+[#73]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/73
+[#61]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/61
+[#69]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/69
+[#62]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/62
+[#60]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/60
+[#54]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/54
+[#52]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/52
+[#50]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/50
+[#49]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/49
+[#46]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/46
+[#38]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/38
+[#33]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/33
+[#31]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/31
+[#22]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/22
+[#19]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/19
+[#16]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/16
+[#15]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/15
+[#10]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/10
+[#9]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 * Add `remove_default_node_pool` set to `false` by default. Fixes [#15]. [#55]
 * Allow arbitrary key-value pairs to be set on node pool metadata. [#52]
 * Add `initial_node_count` parameter to node_pool block. [#60]
+* Fix permanent metadata skew due to disable-legacy-endpoints keys [#114]
 
 ### Changed
 * Set `horizontal_pod_autoscaling` to `true` by default. Fixes [#42]. [#54]
@@ -69,7 +70,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 [#42]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/42
 [#15]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/15
 
-[#109]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/109
+[#114]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/114
 [#108]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/108
 [#106]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/106
 [#80]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/80

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ Extending the adopted spec, each change should have a link to its corresponding 
 * Add `remove_default_node_pool` set to `false` by default. Fixes [#15]. [#55]
 * Allow arbitrary key-value pairs to be set on node pool metadata. [#52]
 * Add `initial_node_count` parameter to node_pool block. [#60]
-* Add test tasks to allow for parallelized local testing runs using Concourse [#109]
 
 ### Changed
 * Set `horizontal_pod_autoscaling` to `true` by default. Fixes [#42]. [#54]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ Extending the adopted spec, each change should have a link to its corresponding 
 ### Added
 * Allow creation of service accounts. [#80]
 * Add support for private clusters via submodule. [#69]
-* Add `remove_default_node_pool` set to `false` by default. Fixes [#15]. [#55]
+* Add `remove_default_node_pool` set to `false` by default. Implements [#15]. [#55]
 * Allow arbitrary key-value pairs to be set on node pool metadata. [#52]
 * Add `initial_node_count` parameter to node_pool block. [#60]
-* Fix permanent metadata skew due to disable-legacy-endpoints keys [#114]
+* Add `disable_legacy_metadata_endpoints` variable. [#]
 
 ### Changed
 * Set `horizontal_pod_autoscaling` to `true` by default. Fixes [#42]. [#54]
@@ -23,12 +23,13 @@ Extending the adopted spec, each change should have a link to its corresponding 
 * Remove explicit versions from test cases and examples. [#62]
 * Set up submodule structure for public and private clusters. [#61]
 * Update the google and google-beta providers to v2.2 [#106]
+* Drop explicit version from simple_zonal example. [#74]
 
 ### Fixed
 * Zonal clusters can now accept a single zone. Fixes [#43]. [#50]
-* Drop explicit version from simple_zonal example. [#74]
 * Fix link to "configure a service account" [#73]
 * Fix issue with regional cluster roll outs causing version skews [#108]
+* Fix permanent metadata skew due to disable-legacy-endpoints keys [#114]
 
 ## [v0.4.0] - 2018-12-19
 ### Added
@@ -80,6 +81,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 [#69]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/69
 [#62]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/62
 [#60]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/60
+[#55]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/55
 [#54]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/54
 [#52]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/52
 [#50]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/50
@@ -91,6 +93,5 @@ Extending the adopted spec, each change should have a link to its corresponding 
 [#22]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/22
 [#19]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/19
 [#16]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/16
-[#15]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/15
 [#10]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/10
 [#9]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 ## [Unreleased]
 
-## [v0.5.0] - 2019-02-28
+## [v1.0.0] - Unreleased
 ### Added
 * Allow creation of service accounts. [#80]
 * Add support for private clusters via submodule. [#69]
@@ -60,8 +60,8 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 * Initial release of module.
 
-[Unreleased]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/compare/v0.5.0...HEAD
-[v0.4.0]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/compare/v0.4.0...v0.5.0
+[Unreleased]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/compare/v1.0.0...HEAD
+[v0.4.0]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/compare/v0.4.0...v1.0.0
 [v0.4.0]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/compare/v0.3.0...v0.4.0
 [v0.3.0]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/compare/v0.2.0...v0.3.0
 [v0.2.0]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/compare/v0.1.0...v0.2.0


### PR DESCRIPTION
This commit updates the CHANGELOG.md to include links for versions,
links for pull request entries, separates additions and changes for
the unreleased version, catches up pull request
of 2019-02-28.