### PR TITLE
Lock google, google-beta provider version to ~> 1.20      

### DIFF
--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -21,6 +21,7 @@ locals {
 provider "google" {
   credentials = "${file(var.credentials_path)}"
   region      = "${var.region}"
+  version     = "~> 1.20"
 }
 
 provider "kubernetes" {

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -19,6 +19,7 @@ locals {
 }
 
 provider "google" {
+  version     = "~> 1.20"
   credentials = "${file(var.credentials_path)}"
   region      = "${var.region}"
 }

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -19,6 +19,7 @@ locals {
 }
 
 provider "google" {
+  version     = "~> 1.20"
   credentials = "${file(var.credentials_path)}"
   region      = "${var.region}"
 }

--- a/examples/simple_regional_private/main.tf
+++ b/examples/simple_regional_private/main.tf
@@ -19,6 +19,7 @@ locals {
 }
 
 provider "google-beta" {
+  version     = "~> 1.20"
   credentials = "${file(var.credentials_path)}"
   region      = "${var.region}"
 }

--- a/examples/simple_zonal/main.tf
+++ b/examples/simple_zonal/main.tf
@@ -19,6 +19,7 @@ locals {
 }
 
 provider "google" {
+  version     = "~> 1.20"
   credentials = "${file(var.credentials_path)}"
   region      = "${var.region}"
 }

--- a/examples/simple_zonal_private/main.tf
+++ b/examples/simple_zonal_private/main.tf
@@ -19,6 +19,7 @@ locals {
 }
 
 provider "google-beta" {
+  version     = "~> 1.20"
   credentials = "${file(var.credentials_path)}"
   region      = "${var.region}"
 }

--- a/examples/stub_domains/main.tf
+++ b/examples/stub_domains/main.tf
@@ -19,6 +19,7 @@ locals {
 }
 
 provider "google" {
+  version     = "~> 1.20"
   credentials = "${file(var.credentials_path)}"
   region      = "${var.region}"
 }


### PR DESCRIPTION
The google and google-beta providers are causing some issues with the simple-regional-private example; these issues in turn are causing CI to fail for all recent pull requests. This commit repairs CI by pinning the version of the google and google-beta providers; we can address v2.0 support in the future.