### PR TITLE
Fix issues with `substr` for Service Accounts

### DIFF
--- a/autogen/sa.tf
+++ b/autogen/sa.tf
@@ -24,7 +24,7 @@ locals {
 resource "google_service_account" "cluster_service_account" {
   count        = "${var.service_account == "create" ? 1 : 0}"
   project      = "${var.project_id}"
-  account_id   = "tf-gke-${substr(var.name, 0, 20)}"
+  account_id   = "tf-gke-${substr(var.name, 0, min(20, length(var.name)))}"
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 

--- a/modules/private-cluster/sa.tf
+++ b/modules/private-cluster/sa.tf
@@ -24,7 +24,7 @@ locals {
 resource "google_service_account" "cluster_service_account" {
   count        = "${var.service_account == "create" ? 1 : 0}"
   project      = "${var.project_id}"
-  account_id   = "tf-gke-${substr(var.name, 0, 20)}"
+  account_id   = "tf-gke-${substr(var.name, 0, min(20, length(var.name)))}"
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 

--- a/sa.tf
+++ b/sa.tf
@@ -24,7 +24,7 @@ locals {
 resource "google_service_account" "cluster_service_account" {
   count        = "${var.service_account == "create" ? 1 : 0}"
   project      = "${var.project_id}"
-  account_id   = "tf-gke-${substr(var.name, 0, 20)}"
+  account_id   = "tf-gke-${substr(var.name, 0, min(20, length(var.name)))}"
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 


### PR DESCRIPTION
Fixes the following error:

```
* module.gke.google_service_account.cluster_service_account: substr: 'offset + length' cannot be larger than the length of the string in:

tf-gke-${substr(var.name, 0, 20)}
```