### PR TITLE
WIP: pin deploy-service and node-pool kubernetes version

### DIFF
--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -41,6 +41,8 @@ module "gke" {
   network    = "${var.network}"
   subnetwork = "${var.subnetwork}"
 
+  kubernetes_version = "1.11.6-gke.11"
+
   ip_range_pods     = "${var.ip_range_pods}"
   ip_range_services = "${var.ip_range_services}"
   service_account   = "${var.compute_engine_service_account}"

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -34,6 +34,8 @@ module "gke" {
   ip_range_pods     = "${var.ip_range_pods}"
   ip_range_services = "${var.ip_range_services}"
 
+  kubernetes_version = "1.11.6-gke.11"
+
   node_pools = [
     {
       name            = "pool-01"


### PR DESCRIPTION
Changes in GKE 1.12 appear to have make our node-pool and
deploy-service examples unstable. This pins these examples/tests to get
CI green; once CI is green we can investigate support for GKE v1.12.