### PR TITLE
examples/deploy-service: pin GKE version to 1.11

### DIFF
--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -41,6 +41,8 @@ module "gke" {
   network    = "${var.network}"
   subnetwork = "${var.subnetwork}"
 
+  kubernetes_version = "1.11.7-gke.12"
+
   ip_range_pods     = "${var.ip_range_pods}"
   ip_range_services = "${var.ip_range_services}"
   service_account   = "${var.compute_engine_service_account}"


### PR DESCRIPTION
Changes in GKE 1.12 have caused node pool resources to become unstable;
in turn this has caused the deploy-service example and tests to become
unreliable.

This commit bypasses the problem by pinning the GKE version to 1.11 to
get CI passing again. Once CI is green we can resolve the root cause
while other pull requests are reviewed.