### PR TITLE
Synchronize zonal and regional node pool auto_upgrade default

### DIFF
--- a/cluster_zonal.tf
+++ b/cluster_zonal.tf
@@ -108,7 +108,7 @@ resource "google_container_node_pool" "zonal_pools" {
 
   management {
     auto_repair  = "${lookup(var.node_pools[count.index], "auto_repair", true)}"
-    auto_upgrade = "${lookup(var.node_pools[count.index], "auto_upgrade", false)}"
+    auto_upgrade = "${lookup(var.node_pools[count.index], "auto_upgrade", true)}"
   }
 
   node_config {


### PR DESCRIPTION
The regional and zonal node pool configurations had different defaults for `auto_upgrade`. We prefer auto-upgrading node pools in general, and moreover having different defaults for regional and zonal node pools is very surprising.

This commit reconciles the difference by changing the zonal node pool auto_upgrade default to true.