### PR TITLE
Ensure node-pool example node count < 6

### DIFF
--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -25,19 +25,23 @@ provider "google" {
 }
 
 module "gke" {
-  source            = "../../"
-  project_id        = "${var.project_id}"
-  name              = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
-  region            = "${var.region}"
-  network           = "${var.network}"
-  subnetwork        = "${var.subnetwork}"
-  ip_range_pods     = "${var.ip_range_pods}"
-  ip_range_services = "${var.ip_range_services}"
+  source                   = "../../"
+  project_id               = "${var.project_id}"
+  name                     = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
+  regional                 = "false"
+  region                   = "${var.region}"
+  zones                    = "${var.zones}"
+  network                  = "${var.network}"
+  subnetwork               = "${var.subnetwork}"
+  ip_range_pods            = "${var.ip_range_pods}"
+  ip_range_services        = "${var.ip_range_services}"
+  remove_default_node_pool = "true"
 
   node_pools = [
     {
       name            = "pool-01"
       min_count       = 1
+      max_count       = 2
       service_account = "${var.compute_engine_service_account}"
     },
     {

--- a/examples/node_pool/variables.tf
+++ b/examples/node_pool/variables.tf
@@ -31,6 +31,11 @@ variable "region" {
   description = "The region to host the cluster in"
 }
 
+variable "zones" {
+  type        = "list"
+  description = "The zone to host the cluster in (required if is a zonal cluster)"
+}
+
 variable "network" {
   description = "The VPC network to host the cluster in"
 }

--- a/test/fixtures/node_pool/example.tf
+++ b/test/fixtures/node_pool/example.tf
@@ -21,6 +21,7 @@ module "example" {
   credentials_path               = "${local.credentials_path}"
   cluster_name_suffix            = "-${random_string.suffix.result}"
   region                         = "${var.region}"
+  zones                          = ["${slice(var.zones,0,1)}"]
   network                        = "${google_compute_network.main.name}"
   subnetwork                     = "${google_compute_subnetwork.main.name}"
   ip_range_pods                  = "${google_compute_subnetwork.main.secondary_ip_range.0.range_name}"


### PR DESCRIPTION
When GKE stands up a cluster with more than 6 nodes in the node pool, it will automatically resize the master node. This causes the cluster to enter reconciling, which fouls up our CI configuration.

This commit sidesteps this problem by converting the node-pool example to a zonal pool, removing the default node pool and shrinking the max size of the added node pools. We can add graceful handling of cluster reconciliation in a followup PR.

This pull request depends on #98.
