### PR TITLE
Add a `check_generate_docs` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,11 @@ DOCKER_TAG_KITCHEN_TERRAFORM ?= ${DOCKER_TAG_BASE_KITCHEN_TERRAFORM}
 DOCKER_IMAGE_KITCHEN_TERRAFORM := cft/kitchen-terraform_terraform-google-kubernetes-engine
 
 # All is the first target in the file so it will get picked up when you just run 'make' on its own
-all: check_shell check_python check_golang check_terraform check_docker check_base_files test_check_headers check_headers check_trailing_whitespace generate_docs
+.PHONY: all
+all: check generate_docs
+
+.PHONY: check
+check: check_shell check_python check_golang check_terraform check_docker check_base_files test_check_headers check_headers check_trailing_whitespace check_generate_docs
 
 # The .PHONY directive tells make that this isn't a real target and so
 # the presence of a file named 'check_shell' won't cause this target to stop
@@ -70,6 +74,14 @@ test_check_headers:
 check_headers:
 	@echo "Checking file headers"
 	@python test/verify_boilerplate.py
+
+.PHONY: check_generate
+check_generate: ## Check that `make generate` does not generate a diff
+	:
+
+.PHONY: check_generate_docs
+check_generate_docs: ## Check that `make generate_docs` does not generate a diff
+	@source test/make.sh && check_generate_docs
 
 # Integration tests
 .PHONY: test_integration

--- a/test/make.sh
+++ b/test/make.sh
@@ -98,3 +98,27 @@ function generate_docs() {
   done
   rm -f "$TMPFILE"
 }
+
+function check_generate() {
+  make generate
+  git diff --exit-codes
+}
+
+function check_generate_docs() {
+  TMPDIR=$(mktemp -d)
+  git worktree add --detach "$TMPDIR"
+  cd "$TMPDIR" || exit 1
+
+  make generate_docs
+  git diff --stat --exit-code
+  rc=$?
+  cd - || exit 1
+
+  if [[ $rc -ne 0 ]]; then
+    echo '`make generate_docs` creates a diff, run "make generate_docs" and commit the results'
+  fi
+  rm -rf "$TMPDIR"
+  git worktree prune
+
+  exit $rc
+}


### PR DESCRIPTION
Currently we have no automatic way of determining if a given commit or
pull request has stale documentation; this leads to buildups in changes
that tend to tag along with other fixes.

This commit resolves the issue by adding a check that verifies that a
fresh copy of the repository does not have a diff present after docs
generation.