### PR TITLE
Add tasks to run test suites on Concourse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ credentials.json
 
 # File to populate env vars used by Docker test runs
 .envrc
+
+.concourse

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,10 @@ check_headers:
 test_integration:
 	test/ci_integration.sh
 
+.PHONY: test_integration_concourse
+test_integration_concourse:
+	test/ci_integration_concourse.sh
+
 .PHONY: generate_docs
 generate_docs:
 	@source test/make.sh && generate_docs
@@ -130,7 +134,7 @@ docker_create: docker_build_kitchen_terraform
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
 		-v $(CURDIR):/cft/workdir \
 		${DOCKER_IMAGE_KITCHEN_TERRAFORM}:${DOCKER_TAG_KITCHEN_TERRAFORM} \
-		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen create"
+		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen create -c 8"
 
 .PHONY: docker_converge
 docker_converge:
@@ -144,7 +148,7 @@ docker_converge:
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
 		-v $(CURDIR):/cft/workdir \
 		${DOCKER_IMAGE_KITCHEN_TERRAFORM}:${DOCKER_TAG_KITCHEN_TERRAFORM} \
-		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen converge && kitchen converge"
+		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen converge -c 8 && kitchen converge -c 8"
 
 .PHONY: docker_verify
 docker_verify:
@@ -172,7 +176,7 @@ docker_destroy:
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
 		-v $(CURDIR):/cft/workdir \
 		${DOCKER_IMAGE_KITCHEN_TERRAFORM}:${DOCKER_TAG_KITCHEN_TERRAFORM} \
-		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen destroy"
+		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen destroy -c 8"
 
 .PHONY: test_integration_docker
 test_integration_docker:

--- a/README.md
+++ b/README.md
@@ -92,62 +92,63 @@ Then perform the following commands on the root folder:
 
 [^]: (autogen_docs_start)
 
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| description | The description of the cluster | string | `""` | no |
-| horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | string | `"true"` | no |
-| http\_load\_balancing | Enable httpload balancer addon | string | `"true"` | no |
-| ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | string | `"false"` | no |
-| ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | string | `"60s"` | no |
-| ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | string | - | yes |
-| ip\_range\_services | The _name_ of the secondary subnet ip range to use for services | string | - | yes |
-| kubernetes\_dashboard | Enable kubernetes dashboard addon | string | `"false"` | no |
-| kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | string | `"latest"` | no |
-| logging\_service | The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none | string | `"logging.googleapis.com"` | no |
-| maintenance\_start\_time | Time window specified for daily maintenance operations in RFC3339 format | string | `"05:00"` | no |
-| master\_authorized\_networks\_config | The desired configuration options for master authorized networks. Omit the nested cidr_blocks attribute to disallow external access (except the cluster node IPs, which GKE automatically whitelists)<br><br>  ### example format ###   master_authorized_networks_config = [{     cidr_blocks = [{       cidr_block   = "10.0.0.0/8"       display_name = "example_network"     }],   }] | list | `<list>` | no |
-| monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | string | `"monitoring.googleapis.com"` | no |
-| name | The name of the cluster (required) | string | n/a | yes |
-| network | The VPC network to host the cluster in (required) | string | n/a | yes |
-| network\_policy | Enable network policy addon | string | `"false"` | no |
-| network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | string | `""` | no |
-| node\_pools | List of maps containing node pools | list | `<list>` | no |
-| node\_pools\_labels | Map of maps containing node labels by node-pool name | map | `<map>` | no |
-| node\_pools\_metadata | Map of maps containing node metadata by node-pool name | map | `<map>` | no |
-| node\_pools\_tags | Map of lists containing node network tags by node-pool name | map | `<map>` | no |
-| node\_pools\_taints | Map of lists containing node taints by node-pool name | map | `<map>` | no |
-| node\_version | The Kubernetes version of the node pools. Defaults kubernetes_version (master) variable and can be overridden for individual node pools by setting the `version` key on them. Must be empyty or set the same as master at cluster creation. | string | `""` | no |
-| non\_masquerade\_cidrs | List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading. | list | `<list>` | no |
-| project\_id | The project ID to host the cluster in (required) | string | n/a | yes |
-| region | The region to host the cluster in (required) | string | n/a | yes |
-| regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | string | `"true"` | no |
-| remove\_default\_node\_pool | Remove default node pool while setting up the cluster | string | `"false"` | no |
-| service\_account | The service account to default running nodes as if not overridden in `node_pools`. Defaults to the compute engine default service account. May also specify `create` to automatically create a cluster-specific service account | string | `""` | no |
-| stub\_domains | Map of stub domains and their resolvers to forward DNS queries for a certain domain to an external DNS server | map | `<map>` | no |
-| subnetwork | The subnetwork to host the cluster in (required) | string | n/a | yes |
+| description | The description of the cluster | string | `` | no |
+| horizontal_pod_autoscaling | Enable horizontal pod autoscaling addon | string | `true` | no |
+| http_load_balancing | Enable httpload balancer addon | string | `true` | no |
+| ip_masq_link_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | string | `false` | no |
+| ip_masq_resync_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | string | `60s` | no |
+| ip_range_pods | The secondary ip range to use for pods | string | - | yes |
+| ip_range_services | The secondary ip range to use for pods | string | - | yes |
+| kubernetes_dashboard | Enable kubernetes dashboard addon | string | `false` | no |
+| kubernetes_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | string | `latest` | no |
+| logging_service | The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none | string | `logging.googleapis.com` | no |
+| maintenance_start_time | Time window specified for daily maintenance operations in RFC3339 format | string | `05:00` | no |
+| master_authorized_networks_config | The desired configuration options for master authorized networks. Omit the nested cidr_blocks attribute to disallow external access (except the cluster node IPs, which GKE automatically whitelists)<br><br>  ### example format ###   master_authorized_networks_config = [{     cidr_blocks = [{       cidr_block   = "10.0.0.0/8"       display_name = "example_network"     }],   }] | list | `<list>` | no |
+| monitoring_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | string | `monitoring.googleapis.com` | no |
+| name | The name of the cluster (required) | string | - | yes |
+| network | The VPC network to host the cluster in (required) | string | - | yes |
+| network_policy | Enable network policy addon | string | `false` | no |
+| network_project_id | The project ID of the shared VPC's host (for shared vpc support) | string | `` | no |
+| remove_default_node_pool | Boolean value determining removal of default node pool | bool | false | no |
+| node_pools | List of maps containing node pools | list | `<list>` | no |
+| node_pools_labels | Map of maps containing node labels by node-pool name | map | `<map>` | no |
+| node_pools_metadata | Map of maps containing node metadata by node-pool name | map | `<map>` | no |
+| node_pools_tags | Map of lists containing node network tags by node-pool name | map | `<map>` | no |
+| node_pools_taints | Map of lists containing node taints by node-pool name | map | `<map>` | no |
+| node_version | The Kubernetes version of the node pools. Defaults kubernetes_version (master) variable and can be overridden for individual node pools by setting the `version` key on them. Must be empyty or set the same as master at cluster creation. | string | `` | no |
+| non_masquerade_cidrs | List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading. | list | `<list>` | no |
+| project_id | The project ID to host the cluster in (required) | string | - | yes |
+| region | The region to host the cluster in (required) | string | - | yes |
+| regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | string | `true` | no |
+| service_account | The service account to default running nodes as if not overridden in `node_pools`. Defaults to the compute engine default service account | string | `` | no |
+| stub_domains | Map of stub domains and their resolvers to forward DNS queries for a certain domain to an external DNS server | map | `<map>` | no |
+| subnetwork | The subnetwork to host the cluster in (required) | string | - | yes |
 | zones | The zones to host the cluster in (optional if regional cluster / required if zonal) | list | `<list>` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| ca\_certificate | Cluster ca certificate (base64 encoded) |
+| ca_certificate | Cluster ca certificate (base64 encoded) |
 | endpoint | Cluster endpoint |
-| horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |
-| http\_load\_balancing\_enabled | Whether http load balancing enabled |
-| kubernetes\_dashboard\_enabled | Whether kubernetes dashboard enabled |
+| horizontal_pod_autoscaling_enabled | Whether horizontal pod autoscaling enabled |
+| http_load_balancing_enabled | Whether http load balancing enabled |
+| kubernetes_dashboard_enabled | Whether kubernetes dashboard enabled |
 | location | Cluster location (region if regional cluster, zone if zonal cluster) |
-| logging\_service | Logging service used |
-| master\_authorized\_networks\_config | Networks from which access to master is permitted |
-| master\_version | Current master kubernetes version |
-| min\_master\_version | Minimum master kubernetes version |
-| monitoring\_service | Monitoring service used |
+| logging_service | Logging service used |
+| master_authorized_networks_config | Networks from which access to master is permitted |
+| master_version | Current master kubernetes version |
+| min_master_version | Minimum master kubernetes version |
+| monitoring_service | Monitoring service used |
 | name | Cluster name |
-| network\_policy\_enabled | Whether network policy enabled |
-| node\_pools\_names | List of node pools names |
-| node\_pools\_versions | List of node pools versions |
+| network_policy_enabled | Whether network policy enabled |
+| node_pools_names | List of node pools names |
+| node_pools_versions | List of node pools versions |
 | region | Cluster region |
 | type | Cluster type (regional / zonal) |
 | zones | List of zones in which the cluster resides |
@@ -263,6 +264,8 @@ The test-kitchen instances in `test/fixtures/` wrap identically-named examples i
   5. `kitchen destroy` tears down the underlying resources created by `kitchen converge`. Run `kitchen destroy <INSTANCE_NAME>` to tear down resources for a specific test case.
 
 Alternatively, you can simply run `make test_integration_docker` to run all the test steps non-interactively.
+
+If you wish to parallelize running the test suites, it is also possible to offload the work onto Concourse to run each test suite for you using the command `make test_integration_concourse`. The `.concourse` directory will be created and contain all of the logs from the running test suites.
 
 #### Test configuration
 

--- a/autogen/README.md
+++ b/autogen/README.md
@@ -275,6 +275,8 @@ The test-kitchen instances in `test/fixtures/` wrap identically-named examples i
 
 Alternatively, you can simply run `make test_integration_docker` to run all the test steps non-interactively.
 
+If you wish to parallelize running the test suites, it is also possible to offload the work onto Concourse to run each test suite for you using the command `make test_integration_concourse`. The `.concourse` directory will be created and contain all of the logs from the running test suites.
+
 #### Test configuration
 
 Each test-kitchen instance is configured with a `variables.tfvars` file in the test fixture directory, e.g. `test/fixtures/node_pool/terraform.tfvars`.

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -95,65 +95,63 @@ Then perform the following commands on the root folder:
 
 [^]: (autogen_docs_start)
 
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| description | The description of the cluster | string | `""` | no |
-| enable\_private\_endpoint | (Beta) Whether the master's internal IP address is used as the cluster endpoint | string | `"false"` | no |
-| enable\_private\_nodes | (Beta) Whether nodes have internal IP addresses only | string | `"false"` | no |
-| horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | string | `"true"` | no |
-| http\_load\_balancing | Enable httpload balancer addon | string | `"true"` | no |
-| ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | string | `"false"` | no |
-| ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | string | `"60s"` | no |
-| ip\_range\_pods | The secondary ip range to use for pods | string | n/a | yes |
-| ip\_range\_services | The secondary ip range to use for pods | string | n/a | yes |
-| kubernetes\_dashboard | Enable kubernetes dashboard addon | string | `"false"` | no |
-| kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | string | `"latest"` | no |
-| logging\_service | The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none | string | `"logging.googleapis.com"` | no |
-| maintenance\_start\_time | Time window specified for daily maintenance operations in RFC3339 format | string | `"05:00"` | no |
-| master\_authorized\_networks\_config | The desired configuration options for master authorized networks. Omit the nested cidr_blocks attribute to disallow external access (except the cluster node IPs, which GKE automatically whitelists)<br><br>  ### example format ###   master_authorized_networks_config = [{     cidr_blocks = [{       cidr_block   = "10.0.0.0/8"       display_name = "example_network"     }],   }] | list | `<list>` | no |
-| master\_ipv4\_cidr\_block | (Beta) The IP range in CIDR notation to use for the hosted master network | string | `"10.0.0.0/28"` | no |
-| monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | string | `"monitoring.googleapis.com"` | no |
-| name | The name of the cluster (required) | string | n/a | yes |
-| network | The VPC network to host the cluster in (required) | string | n/a | yes |
-| network\_policy | Enable network policy addon | string | `"false"` | no |
-| network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | string | `""` | no |
-| node\_pools | List of maps containing node pools | list | `<list>` | no |
-| node\_pools\_labels | Map of maps containing node labels by node-pool name | map | `<map>` | no |
-| node\_pools\_metadata | Map of maps containing node metadata by node-pool name | map | `<map>` | no |
-| node\_pools\_tags | Map of lists containing node network tags by node-pool name | map | `<map>` | no |
-| node\_pools\_taints | Map of lists containing node taints by node-pool name | map | `<map>` | no |
-| node\_version | The Kubernetes version of the node pools. Defaults kubernetes_version (master) variable and can be overridden for individual node pools by setting the `version` key on them. Must be empyty or set the same as master at cluster creation. | string | `""` | no |
-| non\_masquerade\_cidrs | List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading. | list | `<list>` | no |
-| project\_id | The project ID to host the cluster in (required) | string | n/a | yes |
-| region | The region to host the cluster in (required) | string | n/a | yes |
-| regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | string | `"true"` | no |
-| remove\_default\_node\_pool | Remove default node pool while setting up the cluster | string | `"false"` | no |
-| service\_account | The service account to default running nodes as if not overridden in `node_pools`. Defaults to the compute engine default service account. May also specify `create` to automatically create a cluster-specific service account | string | `""` | no |
-| stub\_domains | Map of stub domains and their resolvers to forward DNS queries for a certain domain to an external DNS server | map | `<map>` | no |
-| subnetwork | The subnetwork to host the cluster in (required) | string | n/a | yes |
+| description | The description of the cluster | string | `` | no |
+| horizontal_pod_autoscaling | Enable horizontal pod autoscaling addon | string | `true` | no |
+| http_load_balancing | Enable httpload balancer addon | string | `true` | no |
+| ip_masq_link_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | string | `false` | no |
+| ip_masq_resync_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | string | `60s` | no |
+| ip_range_pods | The secondary ip range to use for pods | string | - | yes |
+| ip_range_services | The secondary ip range to use for pods | string | - | yes |
+| kubernetes_dashboard | Enable kubernetes dashboard addon | string | `false` | no |
+| kubernetes_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | string | `latest` | no |
+| logging_service | The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none | string | `logging.googleapis.com` | no |
+| maintenance_start_time | Time window specified for daily maintenance operations in RFC3339 format | string | `05:00` | no |
+| master_authorized_networks_config | The desired configuration options for master authorized networks. Omit the nested cidr_blocks attribute to disallow external access (except the cluster node IPs, which GKE automatically whitelists)<br><br>  ### example format ###   master_authorized_networks_config = [{     cidr_blocks = [{       cidr_block   = "10.0.0.0/8"       display_name = "example_network"     }],   }] | list | `<list>` | no |
+| monitoring_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | string | `monitoring.googleapis.com` | no |
+| name | The name of the cluster (required) | string | - | yes |
+| network | The VPC network to host the cluster in (required) | string | - | yes |
+| network_policy | Enable network policy addon | string | `false` | no |
+| network_project_id | The project ID of the shared VPC's host (for shared vpc support) | string | `` | no |
+| remove_default_node_pool | Boolean value determining removal of default node pool | bool | false | no |
+| node_pools | List of maps containing node pools | list | `<list>` | no |
+| node_pools_labels | Map of maps containing node labels by node-pool name | map | `<map>` | no |
+| node_pools_metadata | Map of maps containing node metadata by node-pool name | map | `<map>` | no |
+| node_pools_tags | Map of lists containing node network tags by node-pool name | map | `<map>` | no |
+| node_pools_taints | Map of lists containing node taints by node-pool name | map | `<map>` | no |
+| node_version | The Kubernetes version of the node pools. Defaults kubernetes_version (master) variable and can be overridden for individual node pools by setting the `version` key on them. Must be empyty or set the same as master at cluster creation. | string | `` | no |
+| non_masquerade_cidrs | List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading. | list | `<list>` | no |
+| project_id | The project ID to host the cluster in (required) | string | - | yes |
+| region | The region to host the cluster in (required) | string | - | yes |
+| regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | string | `true` | no |
+| service_account | The service account to default running nodes as if not overridden in `node_pools`. Defaults to the compute engine default service account | string | `` | no |
+| stub_domains | Map of stub domains and their resolvers to forward DNS queries for a certain domain to an external DNS server | map | `<map>` | no |
+| subnetwork | The subnetwork to host the cluster in (required) | string | - | yes |
 | zones | The zones to host the cluster in (optional if regional cluster / required if zonal) | list | `<list>` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| ca\_certificate | Cluster ca certificate (base64 encoded) |
+| ca_certificate | Cluster ca certificate (base64 encoded) |
 | endpoint | Cluster endpoint |
-| horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |
-| http\_load\_balancing\_enabled | Whether http load balancing enabled |
-| kubernetes\_dashboard\_enabled | Whether kubernetes dashboard enabled |
+| horizontal_pod_autoscaling_enabled | Whether horizontal pod autoscaling enabled |
+| http_load_balancing_enabled | Whether http load balancing enabled |
+| kubernetes_dashboard_enabled | Whether kubernetes dashboard enabled |
 | location | Cluster location (region if regional cluster, zone if zonal cluster) |
-| logging\_service | Logging service used |
-| master\_authorized\_networks\_config | Networks from which access to master is permitted |
-| master\_version | Current master kubernetes version |
-| min\_master\_version | Minimum master kubernetes version |
-| monitoring\_service | Monitoring service used |
+| logging_service | Logging service used |
+| master_authorized_networks_config | Networks from which access to master is permitted |
+| master_version | Current master kubernetes version |
+| min_master_version | Minimum master kubernetes version |
+| monitoring_service | Monitoring service used |
 | name | Cluster name |
-| network\_policy\_enabled | Whether network policy enabled |
-| node\_pools\_names | List of node pools names |
-| node\_pools\_versions | List of node pools versions |
+| network_policy_enabled | Whether network policy enabled |
+| node_pools_names | List of node pools names |
+| node_pools_versions | List of node pools versions |
 | region | Cluster region |
 | type | Cluster type (regional / zonal) |
 | zones | List of zones in which the cluster resides |
@@ -269,6 +267,8 @@ The test-kitchen instances in `test/fixtures/` wrap identically-named examples i
   5. `kitchen destroy` tears down the underlying resources created by `kitchen converge`. Run `kitchen destroy <INSTANCE_NAME>` to tear down resources for a specific test case.
 
 Alternatively, you can simply run `make test_integration_docker` to run all the test steps non-interactively.
+
+If you wish to parallelize running the test suites, it is also possible to offload the work onto Concourse to run each test suite for you using the command `make test_integration_concourse`. The `.concourse` directory will be created and contain all of the logs from the running test suites.
 
 #### Test configuration
 

--- a/test/ci/tasks/deploy-service-local.yml
+++ b/test/ci/tasks/deploy-service-local.yml
@@ -1,0 +1,31 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: gcr.io/cloud-foundation-cicd/cft/kitchen-terraform_terraform-google-kubernetes-engine
+    tag: f6b7f4ec0a865371531657731b6d52673a0bcd64
+    username: _json_key
+    password: |-
+      <INSERT_KEY_JSON>
+
+inputs:
+  - name: terraform-google-kubernetes-engine
+
+caches:
+  - path: terraform-google-kubernetes-engine
+
+run:
+  path: bash
+  args: ["-c", "./test/ci_integration.sh"]
+  dir: terraform-google-kubernetes-engine
+
+params:
+  COMPUTE_ENGINE_SERVICE_ACCOUNT: COMPUTE_ENGINE_SERVICE_ACCOUNT
+  PROJECT_ID: PROJECT_ID
+  REGION: REGION
+  ZONES: ZONES
+  SERVICE_ACCOUNT_JSON: SERVICE_ACCOUNT_JSON
+  CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+  GOOGLE_APPLICATION_CREDENTIALS: GOOGLE_APPLICATION_CREDENTIALS
+  SUITE: deploy-service-local

--- a/test/ci/tasks/node-pool-local.yml
+++ b/test/ci/tasks/node-pool-local.yml
@@ -1,0 +1,31 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: gcr.io/cloud-foundation-cicd/cft/kitchen-terraform_terraform-google-kubernetes-engine
+    tag: f6b7f4ec0a865371531657731b6d52673a0bcd64
+    username: _json_key
+    password: |-
+      <INSERT_KEY_JSON>
+
+inputs:
+  - name: terraform-google-kubernetes-engine
+
+caches:
+  - path: terraform-google-kubernetes-engine
+
+run:
+  path: bash
+  args: ["-c", "./test/ci_integration.sh"]
+  dir: terraform-google-kubernetes-engine
+
+params:
+  COMPUTE_ENGINE_SERVICE_ACCOUNT: COMPUTE_ENGINE_SERVICE_ACCOUNT
+  PROJECT_ID: PROJECT_ID
+  REGION: REGION
+  ZONES: ZONES
+  SERVICE_ACCOUNT_JSON: SERVICE_ACCOUNT_JSON
+  CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+  GOOGLE_APPLICATION_CREDENTIALS: GOOGLE_APPLICATION_CREDENTIALS
+  SUITE: node-pool-local

--- a/test/ci/tasks/shared-vpc-local.yml
+++ b/test/ci/tasks/shared-vpc-local.yml
@@ -1,0 +1,31 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: gcr.io/cloud-foundation-cicd/cft/kitchen-terraform_terraform-google-kubernetes-engine
+    tag: f6b7f4ec0a865371531657731b6d52673a0bcd64
+    username: _json_key
+    password: |-
+      <INSERT_KEY_JSON>
+
+inputs:
+  - name: terraform-google-kubernetes-engine
+
+caches:
+  - path: terraform-google-kubernetes-engine
+
+run:
+  path: bash
+  args: ["-c", "./test/ci_integration.sh"]
+  dir: terraform-google-kubernetes-engine
+
+params:
+  COMPUTE_ENGINE_SERVICE_ACCOUNT: COMPUTE_ENGINE_SERVICE_ACCOUNT
+  PROJECT_ID: PROJECT_ID
+  REGION: REGION
+  ZONES: ZONES
+  SERVICE_ACCOUNT_JSON: SERVICE_ACCOUNT_JSON
+  CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+  GOOGLE_APPLICATION_CREDENTIALS: GOOGLE_APPLICATION_CREDENTIALS
+  SUITE: shared-vpc-local

--- a/test/ci/tasks/simple-regional-local.yml
+++ b/test/ci/tasks/simple-regional-local.yml
@@ -1,0 +1,31 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: gcr.io/cloud-foundation-cicd/cft/kitchen-terraform_terraform-google-kubernetes-engine
+    tag: f6b7f4ec0a865371531657731b6d52673a0bcd64
+    username: _json_key
+    password: |-
+      <INSERT_KEY_JSON>
+
+inputs:
+  - name: terraform-google-kubernetes-engine
+
+caches:
+  - path: terraform-google-kubernetes-engine
+
+run:
+  path: bash
+  args: ["-c", "./test/ci_integration.sh"]
+  dir: terraform-google-kubernetes-engine
+
+params:
+  COMPUTE_ENGINE_SERVICE_ACCOUNT: COMPUTE_ENGINE_SERVICE_ACCOUNT
+  PROJECT_ID: PROJECT_ID
+  REGION: REGION
+  ZONES: ZONES
+  SERVICE_ACCOUNT_JSON: SERVICE_ACCOUNT_JSON
+  CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+  GOOGLE_APPLICATION_CREDENTIALS: GOOGLE_APPLICATION_CREDENTIALS
+  SUITE: simple-regional-local

--- a/test/ci/tasks/simple-regional-private-local.yml
+++ b/test/ci/tasks/simple-regional-private-local.yml
@@ -1,0 +1,31 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: gcr.io/cloud-foundation-cicd/cft/kitchen-terraform_terraform-google-kubernetes-engine
+    tag: f6b7f4ec0a865371531657731b6d52673a0bcd64
+    username: _json_key
+    password: |-
+      <INSERT_KEY_JSON>
+
+inputs:
+  - name: terraform-google-kubernetes-engine
+
+caches:
+  - path: terraform-google-kubernetes-engine
+
+run:
+  path: bash
+  args: ["-c", "./test/ci_integration.sh"]
+  dir: terraform-google-kubernetes-engine
+
+params:
+  COMPUTE_ENGINE_SERVICE_ACCOUNT: COMPUTE_ENGINE_SERVICE_ACCOUNT
+  PROJECT_ID: PROJECT_ID
+  REGION: REGION
+  ZONES: ZONES
+  SERVICE_ACCOUNT_JSON: SERVICE_ACCOUNT_JSON
+  CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+  GOOGLE_APPLICATION_CREDENTIALS: GOOGLE_APPLICATION_CREDENTIALS
+  SUITE: simple-regional-private-local

--- a/test/ci/tasks/simple-zonal-local.yml
+++ b/test/ci/tasks/simple-zonal-local.yml
@@ -1,0 +1,31 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: gcr.io/cloud-foundation-cicd/cft/kitchen-terraform_terraform-google-kubernetes-engine
+    tag: f6b7f4ec0a865371531657731b6d52673a0bcd64
+    username: _json_key
+    password: |-
+      <INSERT_KEY_JSON>
+
+inputs:
+  - name: terraform-google-kubernetes-engine
+
+caches:
+  - path: terraform-google-kubernetes-engine
+
+run:
+  path: bash
+  args: ["-c", "./test/ci_integration.sh"]
+  dir: terraform-google-kubernetes-engine
+
+params:
+  COMPUTE_ENGINE_SERVICE_ACCOUNT: COMPUTE_ENGINE_SERVICE_ACCOUNT
+  PROJECT_ID: PROJECT_ID
+  REGION: REGION
+  ZONES: ZONES
+  SERVICE_ACCOUNT_JSON: SERVICE_ACCOUNT_JSON
+  CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+  GOOGLE_APPLICATION_CREDENTIALS: GOOGLE_APPLICATION_CREDENTIALS
+  SUITE: simple-zonal-local

--- a/test/ci/tasks/simple-zonal-private-local.yml
+++ b/test/ci/tasks/simple-zonal-private-local.yml
@@ -1,0 +1,31 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: gcr.io/cloud-foundation-cicd/cft/kitchen-terraform_terraform-google-kubernetes-engine
+    tag: f6b7f4ec0a865371531657731b6d52673a0bcd64
+    username: _json_key
+    password: |-
+      <INSERT_KEY_JSON>
+
+inputs:
+  - name: terraform-google-kubernetes-engine
+
+caches:
+  - path: terraform-google-kubernetes-engine
+
+run:
+  path: bash
+  args: ["-c", "./test/ci_integration.sh"]
+  dir: terraform-google-kubernetes-engine
+
+params:
+  COMPUTE_ENGINE_SERVICE_ACCOUNT: COMPUTE_ENGINE_SERVICE_ACCOUNT
+  PROJECT_ID: PROJECT_ID
+  REGION: REGION
+  ZONES: ZONES
+  SERVICE_ACCOUNT_JSON: SERVICE_ACCOUNT_JSON
+  CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+  GOOGLE_APPLICATION_CREDENTIALS: GOOGLE_APPLICATION_CREDENTIALS
+  SUITE: simple-zonal-private-local

--- a/test/ci/tasks/stub-domains-local.yml
+++ b/test/ci/tasks/stub-domains-local.yml
@@ -1,0 +1,31 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: gcr.io/cloud-foundation-cicd/cft/kitchen-terraform_terraform-google-kubernetes-engine
+    tag: f6b7f4ec0a865371531657731b6d52673a0bcd64
+    username: _json_key
+    password: |-
+      <INSERT_KEY_JSON>
+
+inputs:
+  - name: terraform-google-kubernetes-engine
+
+caches:
+  - path: terraform-google-kubernetes-engine
+
+run:
+  path: bash
+  args: ["-c", "./test/ci_integration.sh"]
+  dir: terraform-google-kubernetes-engine
+
+params:
+  COMPUTE_ENGINE_SERVICE_ACCOUNT: COMPUTE_ENGINE_SERVICE_ACCOUNT
+  PROJECT_ID: PROJECT_ID
+  REGION: REGION
+  ZONES: ZONES
+  SERVICE_ACCOUNT_JSON: SERVICE_ACCOUNT_JSON
+  CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE: CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
+  GOOGLE_APPLICATION_CREDENTIALS: GOOGLE_APPLICATION_CREDENTIALS
+  SUITE: stub-domains-local

--- a/test/ci_integration_concourse.sh
+++ b/test/ci_integration_concourse.sh
@@ -1,0 +1,35 @@
+#! /usr/bin/env bash
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eou
+
+run_pipelines() {
+  if [[ ! -d .concourse/logs ]]; then
+    mkdir -p .concourse/logs
+  fi
+
+  for file in test/ci/tasks/*; do
+    tmp="$(mktemp -d)"
+    awk -v input="${SERVICE_ACCOUNT_JSON}" 'NR == 1, /<INSERT_KEY_JSON>/ { sub(/<INSERT_KEY_JSON>/, input) } 1' "${file}" | sed '11,49s/^/      /' | tee "${tmp}/$(basename "${file}")"
+    fly -t cft execute -c "${tmp}/$(basename "${file}")" >.concourse/logs/"$(basename "${file%.yml}").log" 2>&1 &
+  done
+}
+
+main() {
+  run_pipelines
+}
+
+main "$@"


### PR DESCRIPTION
Currently, the test suites take an exorbitant amount of time to run.
Since there are eight different test suites, parallelizing the ability
to run them should save developers considerable time when testing
changes.

This commit adds a make target to be able to run all eight test suites
simultaneously on Concourse.