### PR TITLE
Add suffix to cluster service account

### DIFF
--- a/autogen/outputs.tf
+++ b/autogen/outputs.tf
@@ -107,3 +107,8 @@ output "node_pools_versions" {
   description = "List of node pools versions"
   value       = "${local.cluster_node_pools_versions}"
 }
+
+output "service_account" {
+  description = "The service account to default running nodes as if not overridden in `node_pools`."
+  value = "${local.service_account}"
+}

--- a/autogen/sa.tf
+++ b/autogen/sa.tf
@@ -21,10 +21,17 @@ locals {
   service_account      = "${var.service_account == "create" ? element(local.service_account_list, 0) : var.service_account}"
 }
 
+resource "random_string" "cluster_service_account_suffix" {
+  upper   = "false"
+  lower   = "true"
+  special = "false"
+  length  = 4
+}
+
 resource "google_service_account" "cluster_service_account" {
   count        = "${var.service_account == "create" ? 1 : 0}"
   project      = "${var.project_id}"
-  account_id   = "tf-gke-${substr(var.name, 0, min(20, length(var.name)))}"
+  account_id   = "tf-gke-${substr(var.name, 0, min(15, length(var.name)))}-${random_string.cluster_service_account_suffix.result}"
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 

--- a/examples/deploy_service/outputs.tf
+++ b/examples/deploy_service/outputs.tf
@@ -27,3 +27,8 @@ output "client_token" {
 output "ca_certificate" {
   value = "${module.gke.ca_certificate}"
 }
+
+output "service_account" {
+  description = "The service account to default running nodes as if not overridden in `node_pools`."
+  value       = "${module.gke.service_account}"
+}

--- a/examples/node_pool/outputs.tf
+++ b/examples/node_pool/outputs.tf
@@ -27,3 +27,8 @@ output "client_token" {
 output "ca_certificate" {
   value = "${module.gke.ca_certificate}"
 }
+
+output "service_account" {
+  description = "The service account to default running nodes as if not overridden in `node_pools`."
+  value       = "${module.gke.service_account}"
+}

--- a/examples/shared_vpc/outputs.tf
+++ b/examples/shared_vpc/outputs.tf
@@ -27,3 +27,8 @@ output "client_token" {
 output "ca_certificate" {
   value = "${module.gke.ca_certificate}"
 }
+
+output "service_account" {
+  description = "The service account to default running nodes as if not overridden in `node_pools`."
+  value       = "${module.gke.service_account}"
+}

--- a/examples/simple_regional/outputs.tf
+++ b/examples/simple_regional/outputs.tf
@@ -27,3 +27,8 @@ output "client_token" {
 output "ca_certificate" {
   value = "${module.gke.ca_certificate}"
 }
+
+output "service_account" {
+  description = "The service account to default running nodes as if not overridden in `node_pools`."
+  value       = "${module.gke.service_account}"
+}

--- a/examples/simple_regional_private/outputs.tf
+++ b/examples/simple_regional_private/outputs.tf
@@ -27,3 +27,8 @@ output "client_token" {
 output "ca_certificate" {
   value = "${module.gke.ca_certificate}"
 }
+
+output "service_account" {
+  description = "The service account to default running nodes as if not overridden in `node_pools`."
+  value       = "${module.gke.service_account}"
+}

--- a/examples/simple_zonal/outputs.tf
+++ b/examples/simple_zonal/outputs.tf
@@ -27,3 +27,8 @@ output "client_token" {
 output "ca_certificate" {
   value = "${module.gke.ca_certificate}"
 }
+
+output "service_account" {
+  description = "The service account to default running nodes as if not overridden in `node_pools`."
+  value       = "${module.gke.service_account}"
+}

--- a/examples/simple_zonal_private/outputs.tf
+++ b/examples/simple_zonal_private/outputs.tf
@@ -27,3 +27,8 @@ output "client_token" {
 output "ca_certificate" {
   value = "${module.gke.ca_certificate}"
 }
+
+output "service_account" {
+  description = "The service account to default running nodes as if not overridden in `node_pools`."
+  value       = "${module.gke.service_account}"
+}

--- a/examples/stub_domains/outputs.tf
+++ b/examples/stub_domains/outputs.tf
@@ -27,3 +27,8 @@ output "client_token" {
 output "ca_certificate" {
   value = "${module.gke.ca_certificate}"
 }
+
+output "service_account" {
+  description = "The service account to default running nodes as if not overridden in `node_pools`."
+  value       = "${module.gke.service_account}"
+}

--- a/modules/private-cluster/outputs.tf
+++ b/modules/private-cluster/outputs.tf
@@ -107,3 +107,8 @@ output "node_pools_versions" {
   description = "List of node pools versions"
   value       = "${local.cluster_node_pools_versions}"
 }
+
+output "service_account" {
+  description = "The service account to default running nodes as if not overridden in `node_pools`."
+  value = "${local.service_account}"
+}

--- a/modules/private-cluster/sa.tf
+++ b/modules/private-cluster/sa.tf
@@ -21,10 +21,17 @@ locals {
   service_account      = "${var.service_account == "create" ? element(local.service_account_list, 0) : var.service_account}"
 }
 
+resource "random_string" "cluster_service_account_suffix" {
+  upper   = "false"
+  lower   = "true"
+  special = "false"
+  length  = 4
+}
+
 resource "google_service_account" "cluster_service_account" {
   count        = "${var.service_account == "create" ? 1 : 0}"
   project      = "${var.project_id}"
-  account_id   = "tf-gke-${substr(var.name, 0, min(20, length(var.name)))}"
+  account_id   = "tf-gke-${substr(var.name, 0, min(15, length(var.name)))}-${random_string.cluster_service_account_suffix.result}"
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -107,3 +107,8 @@ output "node_pools_versions" {
   description = "List of node pools versions"
   value       = "${local.cluster_node_pools_versions}"
 }
+
+output "service_account" {
+  description = "The service account to default running nodes as if not overridden in `node_pools`."
+  value = "${local.service_account}"
+}

--- a/sa.tf
+++ b/sa.tf
@@ -21,10 +21,17 @@ locals {
   service_account      = "${var.service_account == "create" ? element(local.service_account_list, 0) : var.service_account}"
 }
 
+resource "random_string" "cluster_service_account_suffix" {
+  upper   = "false"
+  lower   = "true"
+  special = "false"
+  length  = 4
+}
+
 resource "google_service_account" "cluster_service_account" {
   count        = "${var.service_account == "create" ? 1 : 0}"
   project      = "${var.project_id}"
-  account_id   = "tf-gke-${substr(var.name, 0, min(20, length(var.name)))}"
+  account_id   = "tf-gke-${substr(var.name, 0, min(15, length(var.name)))}-${random_string.cluster_service_account_suffix.result}"
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 

--- a/test/fixtures/shared/outputs.tf
+++ b/test/fixtures/shared/outputs.tf
@@ -77,3 +77,8 @@ output "ca_certificate" {
   description = "The cluster CA certificate"
   value       = "${module.example.ca_certificate}"
 }
+
+output "service_account" {
+  description = "The service account to default running nodes as if not overridden in `node_pools`."
+  value       = "${module.example.service_account}"
+}

--- a/test/integration/simple_zonal/controls/gcloud.rb
+++ b/test/integration/simple_zonal/controls/gcloud.rb
@@ -15,6 +15,7 @@
 project_id = attribute('project_id')
 location = attribute('location')
 cluster_name = attribute('cluster_name')
+service_account = attribute('service_account')
 
 credentials_path = attribute('credentials_path')
 ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = credentials_path
@@ -83,7 +84,7 @@ control "gcloud" do
         expect(node_pools).to include(
           including(
             "config" => including(
-              "serviceAccount" => starting_with("tf-gke-simple-zonal-cluster@"),
+              "serviceAccount" => service_account,
             ),
           ),
         )

--- a/test/integration/simple_zonal/inspec.yml
+++ b/test/integration/simple_zonal/inspec.yml
@@ -21,3 +21,6 @@ attributes:
   - name: client_token
     required: true
     type: string
+  - name: service_account
+    required: true
+    type: string


### PR DESCRIPTION
The service account ID truncation may drop appended to the cluster name; this means that multiple clusters with a common prefix but different name may try to create service accounts with identical IDs and then fail.

This commit resolves the issue by adding a suffix to the service account name to ensure uniqueness.