### PR TITLE
Fix permanent metadata skew due to disable-legacy-endpoints keys

### DIFF
--- a/autogen/cluster_regional.tf
+++ b/autogen/cluster_regional.tf
@@ -121,7 +121,7 @@ resource "google_container_node_pool" "pools" {
     image_type   = "${lookup(var.node_pools[count.index], "image_type", "COS")}"
     machine_type = "${lookup(var.node_pools[count.index], "machine_type", "n1-standard-2")}"
     labels       = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_labels["all"], var.node_pools_labels[lookup(var.node_pools[count.index], "name")])}"
-    metadata     = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_metadata["all"], var.node_pools_metadata[lookup(var.node_pools[count.index], "name")])}"
+    metadata     = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_metadata["all"], var.node_pools_metadata[lookup(var.node_pools[count.index], "name")], map("disable-legacy-endpoints", var.disable_legacy_metadata_endpoints))}"
     taint        = "${concat(var.node_pools_taints["all"], var.node_pools_taints[lookup(var.node_pools[count.index], "name")])}"
     tags         = ["${concat(list("gke-${var.name}"), list("gke-${var.name}-${lookup(var.node_pools[count.index], "name")}"), var.node_pools_tags["all"], var.node_pools_tags[lookup(var.node_pools[count.index], "name")])}"]
 

--- a/autogen/cluster_zonal.tf
+++ b/autogen/cluster_zonal.tf
@@ -121,7 +121,7 @@ resource "google_container_node_pool" "zonal_pools" {
     image_type   = "${lookup(var.node_pools[count.index], "image_type", "COS")}"
     machine_type = "${lookup(var.node_pools[count.index], "machine_type", "n1-standard-2")}"
     labels       = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_labels["all"], var.node_pools_labels[lookup(var.node_pools[count.index], "name")])}"
-    metadata     = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_metadata["all"], var.node_pools_metadata[lookup(var.node_pools[count.index], "name")])}"
+    metadata     = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_metadata["all"], var.node_pools_metadata[lookup(var.node_pools[count.index], "name")], map("disable-legacy-endpoints", var.disable_legacy_metadata_endpoints))}"
     taint        = "${concat(var.node_pools_taints["all"], var.node_pools_taints[lookup(var.node_pools[count.index], "name")])}"
     tags         = ["${concat(list("gke-${var.name}"), list("gke-${var.name}-${lookup(var.node_pools[count.index], "name")}"), var.node_pools_tags["all"], var.node_pools_tags[lookup(var.node_pools[count.index], "name")])}"]
 

--- a/autogen/variables.tf
+++ b/autogen/variables.tf
@@ -124,6 +124,12 @@ variable "remove_default_node_pool" {
   default     = false
 }
 
+variable "disable_legacy_metadata_endpoints" {
+  description = "Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated."
+  default     = "true"
+}
+
+
 variable "node_pools" {
   type        = "list"
   description = "List of maps containing node pools"

--- a/cluster_regional.tf
+++ b/cluster_regional.tf
@@ -114,7 +114,7 @@ resource "google_container_node_pool" "pools" {
     image_type   = "${lookup(var.node_pools[count.index], "image_type", "COS")}"
     machine_type = "${lookup(var.node_pools[count.index], "machine_type", "n1-standard-2")}"
     labels       = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_labels["all"], var.node_pools_labels[lookup(var.node_pools[count.index], "name")])}"
-    metadata     = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_metadata["all"], var.node_pools_metadata[lookup(var.node_pools[count.index], "name")])}"
+    metadata     = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_metadata["all"], var.node_pools_metadata[lookup(var.node_pools[count.index], "name")], map("disable-legacy-endpoints", var.disable_legacy_metadata_endpoints))}"
     taint        = "${concat(var.node_pools_taints["all"], var.node_pools_taints[lookup(var.node_pools[count.index], "name")])}"
     tags         = ["${concat(list("gke-${var.name}"), list("gke-${var.name}-${lookup(var.node_pools[count.index], "name")}"), var.node_pools_tags["all"], var.node_pools_tags[lookup(var.node_pools[count.index], "name")])}"]
 

--- a/cluster_zonal.tf
+++ b/cluster_zonal.tf
@@ -114,7 +114,7 @@ resource "google_container_node_pool" "zonal_pools" {
     image_type   = "${lookup(var.node_pools[count.index], "image_type", "COS")}"
     machine_type = "${lookup(var.node_pools[count.index], "machine_type", "n1-standard-2")}"
     labels       = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_labels["all"], var.node_pools_labels[lookup(var.node_pools[count.index], "name")])}"
-    metadata     = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_metadata["all"], var.node_pools_metadata[lookup(var.node_pools[count.index], "name")])}"
+    metadata     = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_metadata["all"], var.node_pools_metadata[lookup(var.node_pools[count.index], "name")], map("disable-legacy-endpoints", var.disable_legacy_metadata_endpoints))}"
     taint        = "${concat(var.node_pools_taints["all"], var.node_pools_taints[lookup(var.node_pools[count.index], "name")])}"
     tags         = ["${concat(list("gke-${var.name}"), list("gke-${var.name}-${lookup(var.node_pools[count.index], "name")}"), var.node_pools_tags["all"], var.node_pools_tags[lookup(var.node_pools[count.index], "name")])}"]
 

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -30,17 +30,18 @@ provider "google-beta" {
 }
 
 module "gke" {
-  source                   = "../../"
-  project_id               = "${var.project_id}"
-  name                     = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
-  regional                 = "false"
-  region                   = "${var.region}"
-  zones                    = "${var.zones}"
-  network                  = "${var.network}"
-  subnetwork               = "${var.subnetwork}"
-  ip_range_pods            = "${var.ip_range_pods}"
-  ip_range_services        = "${var.ip_range_services}"
-  remove_default_node_pool = "true"
+  source                            = "../../"
+  project_id                        = "${var.project_id}"
+  name                              = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
+  regional                          = "false"
+  region                            = "${var.region}"
+  zones                             = "${var.zones}"
+  network                           = "${var.network}"
+  subnetwork                        = "${var.subnetwork}"
+  ip_range_pods                     = "${var.ip_range_pods}"
+  ip_range_services                 = "${var.ip_range_services}"
+  remove_default_node_pool          = "true"
+  disable_legacy_metadata_endpoints = "false"
 
   node_pools = [
     {

--- a/modules/private-cluster/cluster_regional.tf
+++ b/modules/private-cluster/cluster_regional.tf
@@ -119,7 +119,7 @@ resource "google_container_node_pool" "pools" {
     image_type   = "${lookup(var.node_pools[count.index], "image_type", "COS")}"
     machine_type = "${lookup(var.node_pools[count.index], "machine_type", "n1-standard-2")}"
     labels       = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_labels["all"], var.node_pools_labels[lookup(var.node_pools[count.index], "name")])}"
-    metadata     = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_metadata["all"], var.node_pools_metadata[lookup(var.node_pools[count.index], "name")])}"
+    metadata     = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_metadata["all"], var.node_pools_metadata[lookup(var.node_pools[count.index], "name")], map("disable-legacy-endpoints", var.disable_legacy_metadata_endpoints))}"
     taint        = "${concat(var.node_pools_taints["all"], var.node_pools_taints[lookup(var.node_pools[count.index], "name")])}"
     tags         = ["${concat(list("gke-${var.name}"), list("gke-${var.name}-${lookup(var.node_pools[count.index], "name")}"), var.node_pools_tags["all"], var.node_pools_tags[lookup(var.node_pools[count.index], "name")])}"]
 

--- a/modules/private-cluster/cluster_zonal.tf
+++ b/modules/private-cluster/cluster_zonal.tf
@@ -119,7 +119,7 @@ resource "google_container_node_pool" "zonal_pools" {
     image_type   = "${lookup(var.node_pools[count.index], "image_type", "COS")}"
     machine_type = "${lookup(var.node_pools[count.index], "machine_type", "n1-standard-2")}"
     labels       = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_labels["all"], var.node_pools_labels[lookup(var.node_pools[count.index], "name")])}"
-    metadata     = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_metadata["all"], var.node_pools_metadata[lookup(var.node_pools[count.index], "name")])}"
+    metadata     = "${merge(map("cluster_name", var.name), map("node_pool", lookup(var.node_pools[count.index], "name")), var.node_pools_metadata["all"], var.node_pools_metadata[lookup(var.node_pools[count.index], "name")], map("disable-legacy-endpoints", var.disable_legacy_metadata_endpoints))}"
     taint        = "${concat(var.node_pools_taints["all"], var.node_pools_taints[lookup(var.node_pools[count.index], "name")])}"
     tags         = ["${concat(list("gke-${var.name}"), list("gke-${var.name}-${lookup(var.node_pools[count.index], "name")}"), var.node_pools_tags["all"], var.node_pools_tags[lookup(var.node_pools[count.index], "name")])}"]
 

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -124,6 +124,12 @@ variable "remove_default_node_pool" {
   default     = false
 }
 
+variable "disable_legacy_metadata_endpoints" {
+  description = "Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated."
+  default     = true
+}
+
+
 variable "node_pools" {
   type        = "list"
   description = "List of maps containing node pools"

--- a/test/integration/node_pool/controls/gcloud.rb
+++ b/test/integration/node_pool/controls/gcloud.rb
@@ -111,6 +111,7 @@ control "gcloud" do
               "config" => including(
                 "metadata" => including(
                   "shutdown-script" => File.open("examples/node_pool/data/shutdown-script.sh").read,
+                  "disable-legacy-endpoints" => "false",
                 ),
               ),
             )

--- a/variables.tf
+++ b/variables.tf
@@ -124,6 +124,12 @@ variable "remove_default_node_pool" {
   default     = false
 }
 
+variable "disable_legacy_metadata_endpoints" {
+  description = "Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated."
+  default     = true
+}
+
+
 variable "node_pools" {
   type        = "list"
   description = "List of maps containing node pools"


### PR DESCRIPTION
GKE 1.12 and later defaults to disabling legacy endpoints; this default
behavior injects additional metadata into the node pool metadata. The
addition of this metadata causes node pools to be destroyed and rebuilt
every time Terraform runs.