### PR TITLE
Add check for generating docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,11 @@ DOCKER_TAG_KITCHEN_TERRAFORM ?= ${DOCKER_TAG_BASE_KITCHEN_TERRAFORM}
 DOCKER_IMAGE_KITCHEN_TERRAFORM := cft/kitchen-terraform_terraform-google-kubernetes-engine
 
 # All is the first target in the file so it will get picked up when you just run 'make' on its own
-all: check_shell check_python check_golang check_terraform check_docker check_base_files test_check_headers check_headers check_trailing_whitespace generate_docs
+.PHONY: all
+all: check generate_docs
+
+.PHONY: check
+check: check_shell check_python check_golang check_terraform check_docker check_base_files test_check_headers check_headers check_trailing_whitespace check_generate_docs
 
 # The .PHONY directive tells make that this isn't a real target and so
 # the presence of a file named 'check_shell' won't cause this target to stop
@@ -70,6 +74,10 @@ test_check_headers:
 check_headers:
 	@echo "Checking file headers"
 	@python test/verify_boilerplate.py
+
+.PHONY: check_generate_docs
+check_generate_docs: ## Check that `make generate_docs` does not generate a diff
+	@source test/make.sh && check_generate_docs
 
 # Integration tests
 .PHONY: test_integration

--- a/test/make.sh
+++ b/test/make.sh
@@ -96,3 +96,22 @@ function generate_docs() {
   done
   rm -f "$TMPFILE"
 }
+
+function check_generate_docs() {
+  TMPDIR=$(mktemp -d)
+  git worktree add --detach "$TMPDIR"
+  cd "$TMPDIR" || exit 1
+
+  make generate_docs
+  git diff --stat --exit-code
+  rc=$?
+  cd - || exit 1
+
+  if [[ $rc -ne 0 ]]; then
+    echo '"make generate_docs" creates a diff, run "make generate_docs" and commit the results'
+  fi
+  rm -rf "$TMPDIR"
+  git worktree prune
+
+  exit $rc
+}

--- a/test/make.sh
+++ b/test/make.sh
@@ -99,19 +99,19 @@ function generate_docs() {
 
 function check_generate_docs() {
   TMPDIR=$(mktemp -d)
-  git worktree add --detach "$TMPDIR"
+  git worktree add --detach "$TMPDIR" >/dev/null
   cd "$TMPDIR" || exit 1
 
-  make generate_docs
-  git diff --stat --exit-code
+  make generate_docs >/dev/null
+  git diff --stat --exit-code >/dev/null
   rc=$?
-  cd - || exit 1
+  cd - >/dev/null || exit 1
 
   if [[ $rc -ne 0 ]]; then
     echo '"make generate_docs" creates a diff, run "make generate_docs" and commit the results'
   fi
   rm -rf "$TMPDIR"
-  git worktree prune
+  git worktree prune >/dev/null
 
   exit $rc
 }


### PR DESCRIPTION
As it stands, it has become very easy for documentation to become out of date due to forgetting to run generate or generate_docs before submitting a PR. This PR adds a make target to verify that documentation has been properly generated for use in CI.