### PR TITLE
Fix format of autogenerated files

### DIFF
--- a/autogen/main.tf
+++ b/autogen/main.tf
@@ -162,5 +162,6 @@ data "google_container_engine_versions" "zone" {
   //     data.google_container_engine_versions.zone: Cannot determine zone: set in this resource, or set provider-level zone.
   //
   zone     = "${var.zones[0] == "" ? data.google_compute_zones.available.names[0] : var.zones[0]}"
+
   project  = "${var.project_id}"
 }

--- a/autogen/variables.tf
+++ b/autogen/variables.tf
@@ -129,7 +129,6 @@ variable "disable_legacy_metadata_endpoints" {
   default     = "true"
 }
 
-
 variable "node_pools" {
   type        = "list"
   description = "List of maps containing node pools"
@@ -219,17 +218,17 @@ variable "service_account" {
 }
 {% if private_cluster %}
 variable "enable_private_endpoint" {
-  description  = "(Beta) Whether the master's internal IP address is used as the cluster endpoint"
-  default      = false
+  description = "(Beta) Whether the master's internal IP address is used as the cluster endpoint"
+  default     = false
 }
 
 variable "enable_private_nodes" {
-  description  = "(Beta) Whether nodes have internal IP addresses only"
-  default      = false
+  description = "(Beta) Whether nodes have internal IP addresses only"
+  default     = false
 }
 
 variable "master_ipv4_cidr_block" {
-  description  = "(Beta) The IP range in CIDR notation to use for the hosted master network"
-  default      = "10.0.0.0/28"
+  description = "(Beta) The IP range in CIDR notation to use for the hosted master network"
+  default     = "10.0.0.0/28"
 }
 {% endif %}

--- a/helpers/generate_modules/generate_modules.py
+++ b/helpers/generate_modules/generate_modules.py
@@ -66,7 +66,7 @@ def main(argv):
                 module.template_options(BASE_TEMPLATE_OPTIONS)
             )
             with open(os.path.join(module.path, template_file), "w") as f:
-                f.write(rendered.rstrip())
+                f.write(rendered)
                 if template_file.endswith(".tf"):
                     subprocess.call(
                         [

--- a/main.tf
+++ b/main.tf
@@ -161,6 +161,7 @@ data "google_container_engine_versions" "zone" {
   //
   //     data.google_container_engine_versions.zone: Cannot determine zone: set in this resource, or set provider-level zone.
   //
-  zone     = "${var.zones[0] == "" ? data.google_compute_zones.available.names[0] : var.zones[0]}"
-  project  = "${var.project_id}"
+  zone = "${var.zones[0] == "" ? data.google_compute_zones.available.names[0] : var.zones[0]}"
+
+  project = "${var.project_id}"
 }

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -161,6 +161,7 @@ data "google_container_engine_versions" "zone" {
   //
   //     data.google_container_engine_versions.zone: Cannot determine zone: set in this resource, or set provider-level zone.
   //
-  zone     = "${var.zones[0] == "" ? data.google_compute_zones.available.names[0] : var.zones[0]}"
-  project  = "${var.project_id}"
+  zone = "${var.zones[0] == "" ? data.google_compute_zones.available.names[0] : var.zones[0]}"
+
+  project = "${var.project_id}"
 }

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -129,7 +129,6 @@ variable "disable_legacy_metadata_endpoints" {
   default     = "true"
 }
 
-
 variable "node_pools" {
   type        = "list"
   description = "List of maps containing node pools"
@@ -218,16 +217,16 @@ variable "service_account" {
   default     = ""
 }
 variable "enable_private_endpoint" {
-  description  = "(Beta) Whether the master's internal IP address is used as the cluster endpoint"
-  default      = false
+  description = "(Beta) Whether the master's internal IP address is used as the cluster endpoint"
+  default     = false
 }
 
 variable "enable_private_nodes" {
-  description  = "(Beta) Whether nodes have internal IP addresses only"
-  default      = false
+  description = "(Beta) Whether nodes have internal IP addresses only"
+  default     = false
 }
 
 variable "master_ipv4_cidr_block" {
-  description  = "(Beta) The IP range in CIDR notation to use for the hosted master network"
-  default      = "10.0.0.0/28"
+  description = "(Beta) The IP range in CIDR notation to use for the hosted master network"
+  default     = "10.0.0.0/28"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -129,7 +129,6 @@ variable "disable_legacy_metadata_endpoints" {
   default     = "true"
 }
 
-
 variable "node_pools" {
   type        = "list"
   description = "List of maps containing node pools"


### PR DESCRIPTION
This branch tweaks the autogeneration logic to fix diffs created by running `terraform fmt` on the autogenerated files.