### PR TITLE
Add deploy_using_private_endpoint variable

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,6 +20,10 @@ driver:
 provisioner:
   name: "terraform"
 
+verifier:
+  name: terraform
+  color: false
+
 platforms:
   - name: local
 
@@ -147,3 +151,9 @@ suites:
           backend: local
     provisioner:
       name: terraform
+  - name: stub_domains_private
+    driver:
+      root_module_directory: test/fixtures/stub_domains_private
+      systems:
+        - name: stub_domains_private
+          backend: local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Extending the adopted spec, each change should have a link to its corresponding 
 ### Added
 
 * Support for v2.6 and v2.7 of the Google providers. [#152]
+* `deploy_using_private_endpoint` variable on `private-cluster`
+  submodule. [#136]
 
 ### Fixed
 
@@ -122,6 +124,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 [#152]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/152
 [#151]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/151
 [#148]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/148
+[#136]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/136
 [#132]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/132
 [#121]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/121
 [#109]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/109

--- a/autogen/main.tf
+++ b/autogen/main.tf
@@ -65,14 +65,17 @@ locals {
 
 {% if private_cluster %}
   cluster_type_output_endpoint = {
-    regional = "${element(concat((
-      var.deploy_using_private_endpoint ? google_container_cluster.primary.*.private_endpoint :
-      google_container_cluster.primary.*.endpoint
-    ), list("")), 0)}"
-    zonal    = "${element(concat((
-      var.deploy_using_private_endpoint ? google_container_cluster.zonal_primary.*.private_endpoint :
-      google_container_cluster.zonal_primary.*.endpoint
-    ), list("")), 0)}"
+    regional = "${
+      var.deploy_using_private_endpoint ?
+      element(concat(google_container_cluster.primary.*.private_cluster_config.0.private_endpoint, list("")), 0) :
+      element(concat(google_container_cluster.primary.*.endpoint, list("")), 0)
+    }"
+
+    zonal = "${
+      var.deploy_using_private_endpoint ?
+      element(concat(google_container_cluster.zonal_primary.*.private_cluster_config.0.private_endpoint, list("")), 0) :
+      element(concat(google_container_cluster.zonal_primary.*.endpoint, list("")), 0)
+    }"
   }
 {% else %}
   cluster_type_output_endpoint = {

--- a/autogen/main.tf
+++ b/autogen/main.tf
@@ -63,10 +63,23 @@ locals {
     zonal    = "${concat(google_container_cluster.zonal_primary.*.zone, local.cluster_type_output_zonal_zones)}"
   }
 
+{% if private_cluster %}
+  cluster_type_output_endpoint = {
+    regional = "${element(concat((
+      var.deploy_using_private_endpoint ? google_container_cluster.primary.*.private_endpoint :
+      google_container_cluster.primary.*.endpoint
+    ), list("")), 0)}"
+    zonal    = "${element(concat((
+      var.deploy_using_private_endpoint ? google_container_cluster.zonal_primary.*.private_endpoint :
+      google_container_cluster.zonal_primary.*.endpoint
+    ), list("")), 0)}"
+  }
+{% else %}
   cluster_type_output_endpoint = {
     regional = "${element(concat(google_container_cluster.primary.*.endpoint, list("")), 0)}"
     zonal    = "${element(concat(google_container_cluster.zonal_primary.*.endpoint, list("")), 0)}"
   }
+{% endif %}
 
   cluster_type_output_master_auth = {
     regional = "${concat(google_container_cluster.primary.*.master_auth, list())}"

--- a/autogen/variables.tf
+++ b/autogen/variables.tf
@@ -228,6 +228,11 @@ variable "service_account" {
 }
 {% if private_cluster %}
 
+variable "deploy_using_private_endpoint" {
+  description = "(Beta) A toggle for Terraform and kubectl to connect to the master's internal IP address during deployment."
+  default     = "false"
+}
+
 variable "enable_private_endpoint" {
   description = "(Beta) Whether the master's internal IP address is used as the cluster endpoint"
   default     = false

--- a/examples/stub_domains_private/README.md
+++ b/examples/stub_domains_private/README.md
@@ -1,0 +1,53 @@
+# Stub Domains Private Cluster
+
+This example illustrates how to create a private cluster that adds
+custom stub domains to kube-dns.
+
+It will:
+
+- Create a private cluster
+- Remove the default kube-dns configmap
+- Add a new kube-dns configmap with custom stub domains
+
+[^]: (autogen_docs_start)
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| cluster\_name\_suffix | A suffix to append to the default cluster name | string | `""` | no |
+| compute\_engine\_service\_account | Service account to associate to the nodes in the cluster | string | n/a | yes |
+| ip\_range\_pods | The secondary ip range to use for pods | string | n/a | yes |
+| ip\_range\_services | The secondary ip range to use for pods | string | n/a | yes |
+| network | The VPC network to host the cluster in | string | n/a | yes |
+| project\_id | The project ID to host the cluster in | string | n/a | yes |
+| region | The region to host the cluster in | string | n/a | yes |
+| subnetwork | The subnetwork to host the cluster in | string | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| ca\_certificate |  |
+| client\_token |  |
+| cluster\_name | Cluster name |
+| ip\_range\_pods | The secondary IP range used for pods |
+| ip\_range\_services | The secondary IP range used for services |
+| kubernetes\_endpoint |  |
+| location |  |
+| master\_kubernetes\_version | The master Kubernetes version |
+| network |  |
+| project\_id |  |
+| region |  |
+| service\_account | The service account to default running nodes as if not overridden in `node_pools`. |
+| subnetwork |  |
+| zones | List of zones in which the cluster resides |
+
+[^]: (autogen_docs_end)
+
+To provision this example, run the following from within this directory:
+
+- `terraform init` to get the plugins
+- `terraform plan` to see the infrastructure plan
+- `terraform apply` to apply the infrastructure build
+- `terraform destroy` to destroy the built infrastructure

--- a/examples/stub_domains_private/main.tf
+++ b/examples/stub_domains_private/main.tf
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+provider "google-beta" {
+  version = "~> 2.2"
+  region  = "${var.region}"
+}
+
+provider "random" {
+  version = "~> 2.1"
+}
+
+data "google_compute_subnetwork" "subnetwork" {
+  name    = "${var.subnetwork}"
+  project = "${var.project_id}"
+  region  = "${var.region}"
+}
+
+module "gke" {
+  source = "../../modules/private-cluster"
+
+  ip_range_pods     = "${var.ip_range_pods}"
+  ip_range_services = "${var.ip_range_services}"
+  name              = "stub-domains-private-cluster${var.cluster_name_suffix}"
+  network           = "${var.network}"
+  project_id        = "${var.project_id}"
+  region            = "${var.region}"
+  subnetwork        = "${var.subnetwork}"
+
+  deploy_using_private_endpoint = "true"
+  enable_private_endpoint       = "false"
+  enable_private_nodes          = "true"
+
+  master_authorized_networks_config = [{
+    cidr_blocks = [{
+      cidr_block   = "${data.google_compute_subnetwork.subnetwork.ip_cidr_range}"
+      display_name = "VPC"
+    }]
+  }]
+
+  master_ipv4_cidr_block = "172.16.0.0/28"
+
+  network_policy  = "true"
+  service_account = "${var.compute_engine_service_account}"
+
+  stub_domains {
+    "example.com" = [
+      "10.254.154.11",
+      "10.254.154.12",
+    ]
+
+    "example.net" = [
+      "10.254.154.11",
+      "10.254.154.12",
+    ]
+  }
+}
+
+data "google_client_config" "default" {}

--- a/examples/stub_domains_private/outputs.tf
+++ b/examples/stub_domains_private/outputs.tf
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "kubernetes_endpoint" {
+  sensitive = true
+  value     = "${module.gke.endpoint}"
+}
+
+output "client_token" {
+  sensitive = true
+  value     = "${base64encode(data.google_client_config.default.access_token)}"
+}
+
+output "ca_certificate" {
+  value = "${module.gke.ca_certificate}"
+}
+
+output "service_account" {
+  description = "The service account to default running nodes as if not overridden in `node_pools`."
+  value       = "${module.gke.service_account}"
+}

--- a/examples/stub_domains_private/test_outputs.tf
+++ b/examples/stub_domains_private/test_outputs.tf
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// These outputs are used to test the module with kitchen-terraform
+// They do not need to be included in real-world uses of this module
+
+output "project_id" {
+  value = "${var.project_id}"
+}
+
+output "region" {
+  value = "${module.gke.region}"
+}
+
+output "cluster_name" {
+  description = "Cluster name"
+  value       = "${module.gke.name}"
+}
+
+output "network" {
+  value = "${var.network}"
+}
+
+output "subnetwork" {
+  value = "${var.subnetwork}"
+}
+
+output "location" {
+  value = "${module.gke.location}"
+}
+
+output "ip_range_pods" {
+  description = "The secondary IP range used for pods"
+  value       = "${var.ip_range_pods}"
+}
+
+output "ip_range_services" {
+  description = "The secondary IP range used for services"
+  value       = "${var.ip_range_services}"
+}
+
+output "zones" {
+  description = "List of zones in which the cluster resides"
+  value       = "${module.gke.zones}"
+}
+
+output "master_kubernetes_version" {
+  description = "The master Kubernetes version"
+  value       = "${module.gke.master_version}"
+}

--- a/examples/stub_domains_private/variables.tf
+++ b/examples/stub_domains_private/variables.tf
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The project ID to host the cluster in"
+}
+
+variable "cluster_name_suffix" {
+  description = "A suffix to append to the default cluster name"
+  default     = ""
+}
+
+variable "region" {
+  description = "The region to host the cluster in"
+}
+
+variable "network" {
+  description = "The VPC network to host the cluster in"
+}
+
+variable "subnetwork" {
+  description = "The subnetwork to host the cluster in"
+}
+
+variable "ip_range_pods" {
+  description = "The secondary ip range to use for pods"
+}
+
+variable "ip_range_services" {
+  description = "The secondary ip range to use for pods"
+}
+
+variable "compute_engine_service_account" {
+  description = "Service account to associate to the nodes in the cluster"
+}

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -121,6 +121,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 |------|-------------|:----:|:-----:|:-----:|
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |
+| deploy\_using\_private\_endpoint | (Beta) A toggle for Terraform and kubectl to connect to the master's internal IP address during deployment. | string | `"false"` | no |
 | description | The description of the cluster | string | `""` | no |
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | string | `"true"` | no |
 | enable\_private\_endpoint | (Beta) Whether the master's internal IP address is used as the cluster endpoint | string | `"false"` | no |

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -64,8 +64,15 @@ locals {
   }
 
   cluster_type_output_endpoint = {
-    regional = "${element(concat(google_container_cluster.primary.*.endpoint, list("")), 0)}"
-    zonal    = "${element(concat(google_container_cluster.zonal_primary.*.endpoint, list("")), 0)}"
+    regional = "${element(concat((
+      var.deploy_using_private_endpoint ? google_container_cluster.primary.*.private_endpoint :
+      google_container_cluster.primary.*.endpoint
+    ), list("")), 0)}"
+
+    zonal = "${element(concat((
+      var.deploy_using_private_endpoint ? google_container_cluster.zonal_primary.*.private_endpoint :
+      google_container_cluster.zonal_primary.*.endpoint
+    ), list("")), 0)}"
   }
 
   cluster_type_output_master_auth = {

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -64,15 +64,17 @@ locals {
   }
 
   cluster_type_output_endpoint = {
-    regional = "${element(concat((
-      var.deploy_using_private_endpoint ? google_container_cluster.primary.*.private_endpoint :
-      google_container_cluster.primary.*.endpoint
-    ), list("")), 0)}"
+    regional = "${
+      var.deploy_using_private_endpoint ?
+      element(concat(google_container_cluster.primary.*.private_cluster_config.0.private_endpoint, list("")), 0) :
+      element(concat(google_container_cluster.primary.*.endpoint, list("")), 0)
+    }"
 
-    zonal = "${element(concat((
-      var.deploy_using_private_endpoint ? google_container_cluster.zonal_primary.*.private_endpoint :
-      google_container_cluster.zonal_primary.*.endpoint
-    ), list("")), 0)}"
+    zonal = "${
+      var.deploy_using_private_endpoint ?
+      element(concat(google_container_cluster.zonal_primary.*.private_cluster_config.0.private_endpoint, list("")), 0) :
+      element(concat(google_container_cluster.zonal_primary.*.endpoint, list("")), 0)
+    }"
   }
 
   cluster_type_output_master_auth = {

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -227,6 +227,11 @@ variable "service_account" {
   default     = "create"
 }
 
+variable "deploy_using_private_endpoint" {
+  description = "(Beta) A toggle for Terraform and kubectl to connect to the master's internal IP address during deployment."
+  default     = "false"
+}
+
 variable "enable_private_endpoint" {
   description = "(Beta) Whether the master's internal IP address is used as the cluster endpoint"
   default     = false

--- a/test/fixtures/stub_domains_private/main.tf
+++ b/test/fixtures/stub_domains_private/main.tf
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "random_string" "suffix" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+resource "google_compute_network" "main" {
+  name = "cft-gke-test-${random_string.suffix.result}"
+
+  auto_create_subnetworks = "false"
+  project                 = "${var.project_id}"
+}
+
+resource "google_compute_subnetwork" "main" {
+  ip_cidr_range = "10.0.0.0/17"
+  name          = "cft-gke-test-${random_string.suffix.result}"
+  network       = "${google_compute_network.main.self_link}"
+
+  project = "${var.project_id}"
+  region  = "${var.region}"
+
+  secondary_ip_range {
+    range_name    = "cft-gke-test-pods-${random_string.suffix.result}"
+    ip_cidr_range = "192.168.0.0/18"
+  }
+
+  secondary_ip_range {
+    range_name    = "cft-gke-test-services-${random_string.suffix.result}"
+    ip_cidr_range = "192.168.64.0/18"
+  }
+}
+
+module "example" {
+  source = "../../../examples/stub_domains_private"
+
+  compute_engine_service_account = "${var.compute_engine_service_account}"
+  ip_range_pods                  = "${google_compute_subnetwork.main.secondary_ip_range.0.range_name}"
+  ip_range_services              = "${google_compute_subnetwork.main.secondary_ip_range.1.range_name}"
+  network                        = "${google_compute_network.main.name}"
+  project_id                     = "${var.project_id}"
+  cluster_name_suffix            = "-${random_string.suffix.result}"
+  region                         = "${var.region}"
+  subnetwork                     = "${google_compute_subnetwork.main.name}"
+}

--- a/test/fixtures/stub_domains_private/outputs.tf
+++ b/test/fixtures/stub_domains_private/outputs.tf
@@ -1,0 +1,1 @@
+../shared/outputs.tf

--- a/test/fixtures/stub_domains_private/variables.tf
+++ b/test/fixtures/stub_domains_private/variables.tf
@@ -1,0 +1,1 @@
+../shared/variables.tf

--- a/test/integration/stub_domains_private/controls/gcloud.rb
+++ b/test/integration/stub_domains_private/controls/gcloud.rb
@@ -1,0 +1,57 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+control "gcloud" do
+  title "Google Compute Engine GKE configuration"
+  describe command(
+    "gcloud --project=#{attribute("project_id")} container clusters --zone=#{attribute("location")} describe " \
+    "#{attribute("cluster_name")} --format=json"
+  ) do
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq "" }
+
+    let!(:data) do
+      if subject.exit_status == 0
+        JSON.parse(subject.stdout)
+      else
+        {}
+      end
+    end
+
+    describe "cluster" do
+      it "is running" do
+        expect(data["status"]).to eq "RUNNING"
+      end
+
+      it "does not use the private endpoint" do
+        expect(data["privateClusterConfig"]["enablePrivateEndpoint"]).to eq false
+      end
+
+      it "uses private nodes" do
+        expect(data["privateClusterConfig"]["enablePrivateNodes"]).to eq true
+      end
+
+      it "has the expected addon settings" do
+        expect(data["addonsConfig"]).to eq({
+          "horizontalPodAutoscaling" => {},
+          "httpLoadBalancing" => {},
+          "kubernetesDashboard" => {
+            "disabled" => true,
+          },
+          "networkPolicyConfig" => {},
+        })
+      end
+    end
+  end
+end

--- a/test/integration/stub_domains_private/controls/kubectl.rb
+++ b/test/integration/stub_domains_private/controls/kubectl.rb
@@ -1,0 +1,84 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require "base64"
+require "kubeclient"
+require "rest-client"
+
+control "kubectl" do
+  title "Kubernetes configuration"
+
+  describe "kubernetes" do
+    let(:kubernetes_http_endpoint) { "https://#{attribute("kubernetes_endpoint")}/api" }
+
+    let(:client) do
+      cert_store = OpenSSL::X509::Store.new
+      cert_store.add_cert(OpenSSL::X509::Certificate.new(Base64.decode64(attribute("ca_certificate"))))
+      Kubeclient::Client.new(
+        kubernetes_http_endpoint,
+        "v1",
+        ssl_options: {
+          cert_store: cert_store,
+          verify_ssl: OpenSSL::SSL::VERIFY_PEER,
+        },
+        auth_options: {
+          bearer_token: Base64.decode64(attribute("client_token")),
+        },
+      )
+    end
+
+    describe "configmap" do
+      describe "kube-dns" do
+        let(:kubedns_configmap) { client.get_config_map("kube-dns", "kube-system") }
+
+        it "is created by Terraform" do
+          expect(kubedns_configmap.metadata.labels.maintained_by).to eq "terraform"
+        end
+
+        it "reflects the stub_domains configuration" do
+          expect(JSON.parse(kubedns_configmap.data.stubDomains)).to eq({
+            "example.com" => [
+              "10.254.154.11",
+              "10.254.154.12",
+            ],
+            "example.net" => [
+              "10.254.154.11",
+              "10.254.154.12",
+            ],
+          })
+        end
+      end
+
+      describe "ipmasq" do
+        let(:ipmasq_configmap) { client.get_config_map("ip-masq-agent", "kube-system") }
+
+        it "is created by Terraform" do
+          expect(ipmasq_configmap.metadata.labels.maintained_by).to eq "terraform"
+        end
+
+        it "is configured properly" do
+          expect(YAML.load(ipmasq_configmap.data.config)).to eq({
+            "nonMasqueradeCIDRs" => [
+              "10.0.0.0/8",
+              "172.16.0.0/12",
+              "192.168.0.0/16",
+            ],
+            "resyncInterval" => "60s",
+            "masqLinkLocal" => false,
+          })
+        end
+      end
+    end
+  end
+end

--- a/test/integration/stub_domains_private/inspec.yml
+++ b/test/integration/stub_domains_private/inspec.yml
@@ -1,0 +1,20 @@
+name: stub_domains_private
+attributes:
+  - name: ca_certificate
+    required: true
+    type: string
+  - name: client_token
+    required: true
+    type: string
+  - name: cluster_name
+    required: true
+    type: string
+  - name: kubernetes_endpoint
+    required: true
+    type: string
+  - name: location
+    required: true
+    type: string
+  - name: project_id
+    required: true
+    type: string


### PR DESCRIPTION
This branch adds the ability to deploy a cluster using the private endpoint from within the cluster subnet while still exposing the public endpoint.