### PR TITLE
Simplify examples somewhat

### DIFF
--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2"
+  version = "~> 2.2.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2"
+  version = "~> 2.2.0"
   region  = "${var.region}"
 }
 

--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2.0"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2.0"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 

--- a/examples/disable_client_cert/main.tf
+++ b/examples/disable_client_cert/main.tf
@@ -19,6 +19,7 @@ locals {
 }
 
 provider "google" {
+  version      = "~> 2.3.0"
   credentials = "${file(var.credentials_path)}"
   region      = "${var.region}"
 }

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2"
+  version = "~> 2.2.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2"
+  version = "~> 2.2.0"
   region  = "${var.region}"
 }
 

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2.0"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2.0"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2"
+  version = "~> 2.2.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2"
+  version = "~> 2.2.0"
   region  = "${var.region}"
 }
 

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2.0"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2.0"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 

--- a/examples/simple_regional/main.tf
+++ b/examples/simple_regional/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 
@@ -38,7 +38,6 @@ module "gke" {
   subnetwork        = "${var.subnetwork}"
   ip_range_pods     = "${var.ip_range_pods}"
   ip_range_services = "${var.ip_range_services}"
-  service_account   = "${var.compute_engine_service_account}"
 }
 
 data "google_client_config" "default" {}

--- a/examples/simple_regional/variables.tf
+++ b/examples/simple_regional/variables.tf
@@ -42,7 +42,3 @@ variable "ip_range_pods" {
 variable "ip_range_services" {
   description = "The secondary ip range to use for pods"
 }
-
-variable "compute_engine_service_account" {
-  description = "Service account to associate to the nodes in the cluster"
-}

--- a/examples/simple_regional_private/main.tf
+++ b/examples/simple_regional_private/main.tf
@@ -18,8 +18,13 @@ locals {
   cluster_type = "simple-regional-private"
 }
 
+provider "google" {
+  version = "~> 2.2.0"
+  region  = "${var.region}"
+}
+
 provider "google-beta" {
-  version = "~> 2.2"
+  version = "~> 2.2.0"
   region  = "${var.region}"
 }
 

--- a/examples/simple_regional_private/main.tf
+++ b/examples/simple_regional_private/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2.0"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2.0"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 

--- a/examples/simple_zonal/main.tf
+++ b/examples/simple_zonal/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2"
+  version = "~> 2.2.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2"
+  version = "~> 2.2.0"
   region  = "${var.region}"
 }
 

--- a/examples/simple_zonal/main.tf
+++ b/examples/simple_zonal/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2.0"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2.0"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 

--- a/examples/simple_zonal_private/main.tf
+++ b/examples/simple_zonal_private/main.tf
@@ -18,8 +18,13 @@ locals {
   cluster_type = "simple-regional-private"
 }
 
+provider "google" {
+  version = "~> 2.2.0"
+  region  = "${var.region}"
+}
+
 provider "google-beta" {
-  version = "~> 2.2"
+  version = "~> 2.2.0"
   region  = "${var.region}"
 }
 

--- a/examples/simple_zonal_private/main.tf
+++ b/examples/simple_zonal_private/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2.0"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2.0"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 

--- a/examples/stub_domains/main.tf
+++ b/examples/stub_domains/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2"
+  version = "~> 2.2.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2"
+  version = "~> 2.2.0"
   region  = "${var.region}"
 }
 

--- a/examples/stub_domains/main.tf
+++ b/examples/stub_domains/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2.0"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2.0"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 

--- a/test/fixtures/simple_regional/example.tf
+++ b/test/fixtures/simple_regional/example.tf
@@ -24,5 +24,4 @@ module "example" {
   subnetwork                     = "${google_compute_subnetwork.main.name}"
   ip_range_pods                  = "${google_compute_subnetwork.main.secondary_ip_range.0.range_name}"
   ip_range_services              = "${google_compute_subnetwork.main.secondary_ip_range.1.range_name}"
-  compute_engine_service_account = "${var.compute_engine_service_account}"
 }

--- a/test/fixtures/simple_regional_private/example.tf
+++ b/test/fixtures/simple_regional_private/example.tf
@@ -24,5 +24,4 @@ module "example" {
   subnetwork                     = "${google_compute_subnetwork.main.name}"
   ip_range_pods                  = "${google_compute_subnetwork.main.secondary_ip_range.0.range_name}"
   ip_range_services              = "${google_compute_subnetwork.main.secondary_ip_range.1.range_name}"
-  compute_engine_service_account = "${var.compute_engine_service_account}"
 }

--- a/test/make.sh
+++ b/test/make.sh
@@ -14,75 +14,112 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This function checks to make sure that every
-# shebang has a '- e' flag, which causes it
-# to exit on error
-function check_bash() {
-  find . -name "*.sh" | while IFS= read -d '' -r file; do
-    if [[ "$file" != *"bash -e"* ]]; then
-      echo "$file is missing shebang with -e"
-      exit 1
-    fi
-  done
+# Please note that this file was generated from [terraform-google-module-template](https://github.com/terraform-google-modules/terraform-google-module-template).
+# Please make sure to contribute relevant changes upstream!
+
+# Create a temporary directory that's auto-cleaned, even if the process aborts.
+DELETE_AT_EXIT="$(mktemp -d)"
+finish() {
+  [[ -d "${DELETE_AT_EXIT}" ]] && rm -rf "${DELETE_AT_EXIT}"
+}
+trap finish EXIT
+# Create a temporary file in the auto-cleaned up directory while avoiding
+# overwriting TMPDIR for other processes.
+# shellcheck disable=SC2120 # (Arguments may be passed, e.g. maketemp -d)
+maketemp() {
+  TMPDIR="${DELETE_AT_EXIT}" mktemp "$@"
+}
+
+# find_files is a helper to exclude .git directories and match only regular
+# files to avoid double-processing symlinks.
+find_files() {
+  local pth="$1"
+  shift
+  find "${pth}" '(' -path '*/.git' -o -path '*/.terraform' ')' \
+    -prune -o -type f "$@"
+}
+
+# Compatibility with both GNU and BSD style xargs.
+compat_xargs() {
+  local compat=()
+  # Test if xargs is GNU or BSD style.  GNU xargs will succeed with status 0
+  # when given --no-run-if-empty and no input on STDIN.  BSD xargs will fail and
+  # exit status non-zero If xargs fails, assume it is BSD style and proceed.
+  # stderr is silently redirected to avoid console log spam.
+  if xargs --no-run-if-empty </dev/null 2>/dev/null; then
+    compat=("--no-run-if-empty")
+  fi
+  xargs "${compat[@]}" "$@"
 }
 
 # This function makes sure that the required files for
 # releasing to OSS are present
 function basefiles() {
-  echo "Checking for required files"
-  test -f LICENSE || echo "Missing LICENSE"
-  test -f README.md || echo "Missing README.md"
+  local fn required_files="LICENSE README.md"
+  echo "Checking for required files ${required_files}"
+  for fn in ${required_files}; do
+    test -f "${fn}" || echo "Missing required file ${fn}"
+  done
 }
 
 # This function runs the hadolint linter on
 # every file named 'Dockerfile'
 function docker() {
   echo "Running hadolint on Dockerfiles"
-  find . -name "Dockerfile" -exec hadolint {} \;
+  find_files . -name "Dockerfile" -print0 \
+    | compat_xargs -0 hadolint
 }
 
-# This function runs 'terraform validate' against all
-# files ending in '.tf'
+# This function runs 'terraform validate' and 'terraform fmt'
+# against all directory paths which contain *.tf files.
 function check_terraform() {
   echo "Running terraform validate"
-  #shellcheck disable=SC2156
-  find . -name "*.tf" -not -path "./autogen/*" -not -path "./test/fixtures/shared/*" -not -path "./test/fixtures/all_examples/*" -exec bash -c 'terraform validate --check-variables=false $(dirname "{}")' \;
+  find_files . -not -path "./test/fixtures/shared/*" -not -path "./autogen/*" -not -path "./test/fixtures/all_examples/*" -name "*.tf" -print0 \
+    | compat_xargs -0 -n1 dirname \
+    | sort -u \
+    | compat_xargs -t -n1 terraform validate --check-variables=false
   echo "Running terraform fmt"
-  #shellcheck disable=SC2156
-  find . -name "*.tf" -not -path "./autogen/*" -not -path "./test/fixtures/shared/*" -not -path "./test/fixtures/all_examples/*" -exec bash -c 'terraform fmt -check=true -write=false "{}"' \;
+  find_files . -not -path "./test/fixtures/shared/*" -not -path "./autogen/*" -not -path "./test/fixtures/all_examples/*" -name "*.tf" -print0 \
+    | compat_xargs -0 -n1 dirname \
+    | sort -u \
+    | compat_xargs -t -n1 terraform fmt -check=true -write=false
 }
 
 # This function runs 'go fmt' and 'go vet' on every file
 # that ends in '.go'
 function golang() {
   echo "Running go fmt and go vet"
-  find . -name "*.go" -exec go fmt {} \;
-  find . -name "*.go" -exec go vet {} \;
+  find_files . -name "*.go" -print0 | compat_xargs -0 -n1 go fmt
+  find_files . -name "*.go" -print0 | compat_xargs -0 -n1 go vet
 }
 
 # This function runs the flake8 linter on every file
 # ending in '.py'
 function check_python() {
   echo "Running flake8"
-  find . -name "*.py" -exec flake8 {} \;
+  find_files . -name "*.py" -print0 | compat_xargs -0 flake8
+  return 0
 }
 
 # This function runs the shellcheck linter on every
 # file ending in '.sh'
 function check_shell() {
   echo "Running shellcheck"
-  find . -name "*.sh" -exec shellcheck -x {} \;
+  find_files . -name "*.sh" -print0 | compat_xargs -0 shellcheck -x
 }
 
 # This function makes sure that there is no trailing whitespace
 # in any files in the project.
 # There are some exclusions
 function check_trailing_whitespace() {
-  echo "The following lines have trailing whitespace"
-  grep -r '[[:blank:]]$' --exclude-dir=".terraform" --exclude-dir=".kitchen" --exclude="*.png" --exclude="*.pyc" --exclude-dir=".git" .
+  local rc
+  echo "Checking for trailing whitespace"
+  find_files . -print \
+    | grep -v -E '\.(pyc|png)$' \
+    | compat_xargs grep -H -n '[[:blank:]]$'
   rc=$?
-  if [ $rc = 0 ]; then
-    exit 1
+  if [[ ${rc} -eq 0 ]]; then
+    return 1
   fi
 }
 
@@ -93,13 +130,20 @@ function generate() {
 
 function generate_docs() {
   echo "Generating markdown docs with terraform-docs"
-  TMPFILE=$(mktemp)
-  #shellcheck disable=2006,2086
-  for j in $(find ./ -name '*.tf' -type f -exec dirname '{}' \; | sort -u | grep -v ./autogen); do
-    terraform-docs markdown "$j" >"$TMPFILE"
-    python helpers/combine_docfiles.py "$j"/README.md "$TMPFILE"
-  done
-  rm -f "$TMPFILE"
+  local path tmpfile
+  while read -r path; do
+    if [[ -e "${path}/README.md" ]]; then
+      # shellcheck disable=SC2119
+      tmpfile="$(maketemp)"
+      echo "terraform-docs markdown ${path}"
+      terraform-docs markdown "${path}" > "${tmpfile}"
+      helpers/combine_docfiles.py "${path}"/README.md "${tmpfile}"
+    else
+      echo "Skipping ${path} because README.md does not exist."
+    fi
+  done < <(find_files . -name '*.tf' -print0 \
+    | compat_xargs -0 -n1 dirname \
+    | sort -u)
 }
 
 function check_generate() {
@@ -144,4 +188,12 @@ function check_generate_docs() {
   echo "Docs were generated properly"
 
   exit $rc
+}
+
+
+function check_headers() {
+  echo "Checking file headers"
+  # Use the exclusion behavior of find_files
+  find_files . -type f -print0 \
+    | compat_xargs -0 python test/verify_boilerplate.py
 }


### PR DESCRIPTION
Right now our examples and test fixtures are a bit complex and brittle.

This is a simple fix:

- Pin the `2.2.x` version instead of 2.x.x` versions
- Remove the unnecessary `compute_engine_service_account` from the `simple_regional_example`