### PR TITLE
Version-pin all Google providers in examples to ~> 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 - [kubectl](https://github.com/kubernetes/kubernetes/releases) 1.9.x
 #### Terraform and Plugins
 - [Terraform](https://www.terraform.io/downloads.html) 0.11.x
-- [terraform-provider-google](https://github.com/terraform-providers/terraform-provider-google) v2.0.0
+- [terraform-provider-google](https://github.com/terraform-providers/terraform-provider-google) v2.3
 
 ### Configure a Service Account
 In order to execute this module you must have a Service Account with the

--- a/autogen/README.md
+++ b/autogen/README.md
@@ -138,9 +138,9 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 #### Terraform and Plugins
 - [Terraform](https://www.terraform.io/downloads.html) 0.11.x
 {% if private_cluster %}
-- [terraform-provider-google-beta](https://github.com/terraform-providers/terraform-provider-google-beta) v2.0.0
+- [terraform-provider-google-beta](https://github.com/terraform-providers/terraform-provider-google-beta) v2.3
 {% else %}
-- [terraform-provider-google](https://github.com/terraform-providers/terraform-provider-google) v2.0.0
+- [terraform-provider-google](https://github.com/terraform-providers/terraform-provider-google) v2.3
 {% endif %}
 
 ### Configure a Service Account

--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 

--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -45,8 +45,6 @@ module "gke" {
   network    = "${var.network}"
   subnetwork = "${var.subnetwork}"
 
-  kubernetes_version = "1.11.7-gke.12"
-
   ip_range_pods     = "${var.ip_range_pods}"
   ip_range_services = "${var.ip_range_services}"
   service_account   = "${var.compute_engine_service_account}"

--- a/examples/disable_client_cert/main.tf
+++ b/examples/disable_client_cert/main.tf
@@ -19,6 +19,7 @@ locals {
 }
 
 provider "google" {
+  version     = "~> 2.3.0"
   credentials = "${file(var.credentials_path)}"
   region      = "${var.region}"
 }

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 

--- a/examples/simple_regional/main.tf
+++ b/examples/simple_regional/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 

--- a/examples/simple_regional_private/main.tf
+++ b/examples/simple_regional_private/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 2.2"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 

--- a/examples/simple_zonal/main.tf
+++ b/examples/simple_zonal/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 

--- a/examples/simple_zonal_private/main.tf
+++ b/examples/simple_zonal_private/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 2.2"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 

--- a/examples/stub_domains/main.tf
+++ b/examples/stub_domains/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.2"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 
 provider "google-beta" {
-  version = "~> 2.2"
+  version = "~> 2.3.0"
   region  = "${var.region}"
 }
 

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -202,7 +202,7 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 - [kubectl](https://github.com/kubernetes/kubernetes/releases) 1.9.x
 #### Terraform and Plugins
 - [Terraform](https://www.terraform.io/downloads.html) 0.11.x
-- [terraform-provider-google-beta](https://github.com/terraform-providers/terraform-provider-google-beta) v2.0.0
+- [terraform-provider-google-beta](https://github.com/terraform-providers/terraform-provider-google-beta) v2.3
 
 ### Configure a Service Account
 In order to execute this module you must have a Service Account with the


### PR DESCRIPTION
Intended to address issues with providers `>= 2.4.0`