### PR TITLE
Add initial_node_count variable for scaling the default node pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | string | `"true"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | string | `"true"` | no |
 | http\_load\_balancing | Enable httpload balancer addon | string | `"true"` | no |
+| initial\_node\_count | The number of nodes to create in this cluster's default node pool. | string | `"0"` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | string | `"false"` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | string | `"60s"` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | string | n/a | yes |

--- a/autogen/cluster_regional.tf
+++ b/autogen/cluster_regional.tf
@@ -87,7 +87,8 @@ resource "google_container_cluster" "primary" {
   }
 
   node_pool {
-    name = "default-pool"
+    name               = "default-pool"
+    initial_node_count = "${var.initial_node_count}"
 
     node_config {
       service_account = "${lookup(var.node_pools[0], "service_account", local.service_account)}"

--- a/autogen/cluster_zonal.tf
+++ b/autogen/cluster_zonal.tf
@@ -87,7 +87,8 @@ resource "google_container_cluster" "zonal_primary" {
   }
 
   node_pool {
-    name = "default-pool"
+    name               = "default-pool"
+    initial_node_count = "${var.initial_node_count}"
 
     node_config {
       service_account = "${lookup(var.node_pools[0], "service_account", local.service_account)}"

--- a/autogen/variables.tf
+++ b/autogen/variables.tf
@@ -119,6 +119,11 @@ variable "ip_range_services" {
   description = "The _name_ of the secondary subnet range to use for services"
 }
 
+variable "initial_node_count" {
+  description = "The number of nodes to create in this cluster's default node pool."
+  default     = 0
+}
+
 variable "remove_default_node_pool" {
   description = "Remove default node pool while setting up the cluster"
   default     = false

--- a/cluster_regional.tf
+++ b/cluster_regional.tf
@@ -87,7 +87,8 @@ resource "google_container_cluster" "primary" {
   }
 
   node_pool {
-    name = "default-pool"
+    name               = "default-pool"
+    initial_node_count = "${var.initial_node_count}"
 
     node_config {
       service_account = "${lookup(var.node_pools[0], "service_account", local.service_account)}"

--- a/cluster_zonal.tf
+++ b/cluster_zonal.tf
@@ -87,7 +87,8 @@ resource "google_container_cluster" "zonal_primary" {
   }
 
   node_pool {
-    name = "default-pool"
+    name               = "default-pool"
+    initial_node_count = "${var.initial_node_count}"
 
     node_config {
       service_account = "${lookup(var.node_pools[0], "service_account", local.service_account)}"

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -128,6 +128,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | enable\_private\_nodes | (Beta) Whether nodes have internal IP addresses only | string | `"false"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | string | `"true"` | no |
 | http\_load\_balancing | Enable httpload balancer addon | string | `"true"` | no |
+| initial\_node\_count | The number of nodes to create in this cluster's default node pool. | string | `"0"` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | string | `"false"` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | string | `"60s"` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | string | n/a | yes |

--- a/modules/private-cluster/cluster_regional.tf
+++ b/modules/private-cluster/cluster_regional.tf
@@ -87,7 +87,8 @@ resource "google_container_cluster" "primary" {
   }
 
   node_pool {
-    name = "default-pool"
+    name               = "default-pool"
+    initial_node_count = "${var.initial_node_count}"
 
     node_config {
       service_account = "${lookup(var.node_pools[0], "service_account", local.service_account)}"

--- a/modules/private-cluster/cluster_zonal.tf
+++ b/modules/private-cluster/cluster_zonal.tf
@@ -87,7 +87,8 @@ resource "google_container_cluster" "zonal_primary" {
   }
 
   node_pool {
-    name = "default-pool"
+    name               = "default-pool"
+    initial_node_count = "${var.initial_node_count}"
 
     node_config {
       service_account = "${lookup(var.node_pools[0], "service_account", local.service_account)}"

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -119,6 +119,11 @@ variable "ip_range_services" {
   description = "The _name_ of the secondary subnet range to use for services"
 }
 
+variable "initial_node_count" {
+  description = "The number of nodes to create in this cluster's default node pool."
+  default     = 0
+}
+
 variable "remove_default_node_pool" {
   description = "Remove default node pool while setting up the cluster"
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -119,6 +119,11 @@ variable "ip_range_services" {
   description = "The _name_ of the secondary subnet range to use for services"
 }
 
+variable "initial_node_count" {
+  description = "The number of nodes to create in this cluster's default node pool."
+  default     = 0
+}
+
 variable "remove_default_node_pool" {
   description = "Remove default node pool while setting up the cluster"
   default     = false


### PR DESCRIPTION
Adds a variable to be able to configure the number of nodes in the default node pool. It defaults to 0 so it should not change existing behaviour.