### PR TITLE
Add network_policy to google_container_cluster

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -35,10 +35,6 @@ suites:
       systems:
         - name: deploy_service
           backend: local
-    lifecycle:
-      pre_verify:
-        - echo "Sleeping for 60 seconds to allow resources to converge"
-        - sleep 60
   - name: "disable_client_cert"
     driver:
       root_module_directory: test/fixtures/disable_client_cert

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,93 +30,54 @@ platforms:
 suites:
   - name: "deploy_service"
     driver:
-      name: "terraform"
-      command_timeout: 1800
       root_module_directory: test/fixtures/deploy_service
     verifier:
-      name: terraform
-      color: false
       systems:
         - name: deploy_service
           backend: local
     lifecycle:
       pre_verify:
-        - sleep 10
-    provisioner:
-      name: terraform
+        - echo "Sleeping for 60 seconds to allow resources to converge"
+        - sleep 60
   - name: "disable_client_cert"
     driver:
-      name: "terraform"
-      command_timeout: 1800
       root_module_directory: test/fixtures/disable_client_cert
     verifier:
-      name: terraform
-      color: false
       systems:
         - name: disable_client_cert
           backend: local
-    provisioner:
-      name: terraform
   - name: "node_pool"
     driver:
-      name: "terraform"
-      command_timeout: 1800
       root_module_directory: test/fixtures/node_pool
     verifier:
-      name: terraform
-      color: false
       systems:
         - name: node_pool
           backend: local
-    provisioner:
-      name: terraform
   - name: "shared_vpc"
     driver:
-      name: "terraform"
-      command_timeout: 1800
       root_module_directory: test/fixtures/shared_vpc
     verifier:
-      name: terraform
-      color: false
       systems:
         - name: shared_vpc
           backend: local
-    provisioner:
-      name: terraform
   - name: "simple_regional"
     driver:
-      name: "terraform"
-      command_timeout: 1800
       root_module_directory: test/fixtures/simple_regional
     verifier:
-      name: terraform
-      color: false
       systems:
         - name: simple_regional
           backend: local
-    provisioner:
-      name: terraform
   - name: "simple_regional_private"
     driver:
-      name: "terraform"
-      command_timeout: 1800
       root_module_directory: test/fixtures/simple_regional_private
     verifier:
-      name: terraform
-      color: false
       systems:
         - name: simple_regional_private
           backend: local
-    provisioner:
-      name: terraform
   - name: "simple_zonal"
     driver:
-      name: "terraform"
-      command_timeout: 1800
       root_module_directory: test/fixtures/simple_zonal
     verifier:
-      name: terraform
-      color: false
       systems:
         - name: gcloud
           backend: local
@@ -126,34 +87,20 @@ suites:
           backend: gcp
           controls:
             - gcp
-    provisioner:
-      name: terraform
   - name: "simple_zonal_private"
     driver:
-      name: "terraform"
-      command_timeout: 1800
       root_module_directory: test/fixtures/simple_zonal_private
     verifier:
-      name: terraform
-      color: false
       systems:
         - name: simple_zonal_private
           backend: local
-    provisioner:
-      name: terraform
   - name: "stub_domains"
     driver:
-      name: "terraform"
-      command_timeout: 1800
       root_module_directory: test/fixtures/stub_domains
     verifier:
-      name: terraform
-      color: false
       systems:
         - name: stub_domains
           backend: local
-    provisioner:
-      name: terraform
   - name: stub_domains_private
     driver:
       root_module_directory: test/fixtures/stub_domains_private

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | name | The name of the cluster (required) | string | n/a | yes |
 | network | The VPC network to host the cluster in (required) | string | n/a | yes |
 | network\_policy | Enable network policy addon | string | `"false"` | no |
+| network\_policy\_provider | The network policy provider. | string | `"PROVIDER_UNSPECIFIED"` | no |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | string | `""` | no |
 | node\_pools | List of maps containing node pools | list | `<list>` | no |
 | node\_pools\_labels | Map of maps containing node labels by node-pool name | map | `<map>` | no |

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | name | The name of the cluster (required) | string | n/a | yes |
 | network | The VPC network to host the cluster in (required) | string | n/a | yes |
 | network\_policy | Enable network policy addon | string | `"false"` | no |
-| network\_policy\_provider | The network policy provider. | string | `"PROVIDER_UNSPECIFIED"` | no |
+| network\_policy\_provider | The network policy provider. | string | `"CALICO"` | no |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | string | `""` | no |
 | node\_pools | List of maps containing node pools | list | `<list>` | no |
 | node\_pools\_labels | Map of maps containing node labels by node-pool name | map | `<map>` | no |

--- a/autogen/cluster_regional.tf
+++ b/autogen/cluster_regional.tf
@@ -29,7 +29,13 @@ resource "google_container_cluster" "primary" {
   region         = "${var.region}"
   node_locations = ["${coalescelist(compact(var.zones), sort(random_shuffle.available_zones.result))}"]
 
-  network            = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
+  network = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
+
+  network_policy {
+    enabled  = "${var.network_policy}"
+    provider = "${var.network_policy_provider}"
+  }
+
   subnetwork         = "${replace(data.google_compute_subnetwork.gke_subnetwork.self_link, "https://www.googleapis.com/compute/v1/", "")}"
   min_master_version = "${local.kubernetes_version_regional}"
 

--- a/autogen/cluster_zonal.tf
+++ b/autogen/cluster_zonal.tf
@@ -29,7 +29,13 @@ resource "google_container_cluster" "zonal_primary" {
   zone           = "${var.zones[0]}"
   node_locations = ["${slice(var.zones,1,length(var.zones))}"]
 
-  network            = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
+  network = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
+
+  network_policy {
+    enabled  = "${var.network_policy}"
+    provider = "${var.network_policy_provider}"
+  }
+
   subnetwork         = "${replace(data.google_compute_subnetwork.gke_subnetwork.self_link, "https://www.googleapis.com/compute/v1/", "")}"
   min_master_version = "${local.kubernetes_version_zonal}"
 

--- a/autogen/variables.tf
+++ b/autogen/variables.tf
@@ -106,6 +106,11 @@ variable "network_policy" {
   default     = false
 }
 
+variable "network_policy_provider" {
+  description = "The network policy provider."
+  default     = "PROVIDER_UNSPECIFIED"
+}
+
 variable "maintenance_start_time" {
   description = "Time window specified for daily maintenance operations in RFC3339 format"
   default     = "05:00"

--- a/autogen/variables.tf
+++ b/autogen/variables.tf
@@ -108,7 +108,7 @@ variable "network_policy" {
 
 variable "network_policy_provider" {
   description = "The network policy provider."
-  default     = "PROVIDER_UNSPECIFIED"
+  default     = "CALICO"
 }
 
 variable "maintenance_start_time" {

--- a/cluster_regional.tf
+++ b/cluster_regional.tf
@@ -29,7 +29,13 @@ resource "google_container_cluster" "primary" {
   region         = "${var.region}"
   node_locations = ["${coalescelist(compact(var.zones), sort(random_shuffle.available_zones.result))}"]
 
-  network            = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
+  network = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
+
+  network_policy {
+    enabled  = "${var.network_policy}"
+    provider = "${var.network_policy_provider}"
+  }
+
   subnetwork         = "${replace(data.google_compute_subnetwork.gke_subnetwork.self_link, "https://www.googleapis.com/compute/v1/", "")}"
   min_master_version = "${local.kubernetes_version_regional}"
 

--- a/cluster_zonal.tf
+++ b/cluster_zonal.tf
@@ -29,7 +29,13 @@ resource "google_container_cluster" "zonal_primary" {
   zone           = "${var.zones[0]}"
   node_locations = ["${slice(var.zones,1,length(var.zones))}"]
 
-  network            = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
+  network = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
+
+  network_policy {
+    enabled  = "${var.network_policy}"
+    provider = "${var.network_policy_provider}"
+  }
+
   subnetwork         = "${replace(data.google_compute_subnetwork.gke_subnetwork.self_link, "https://www.googleapis.com/compute/v1/", "")}"
   min_master_version = "${local.kubernetes_version_zonal}"
 

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -144,6 +144,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | name | The name of the cluster (required) | string | n/a | yes |
 | network | The VPC network to host the cluster in (required) | string | n/a | yes |
 | network\_policy | Enable network policy addon | string | `"false"` | no |
+| network\_policy\_provider | The network policy provider. | string | `"PROVIDER_UNSPECIFIED"` | no |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | string | `""` | no |
 | node\_pools | List of maps containing node pools | list | `<list>` | no |
 | node\_pools\_labels | Map of maps containing node labels by node-pool name | map | `<map>` | no |

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -144,7 +144,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | name | The name of the cluster (required) | string | n/a | yes |
 | network | The VPC network to host the cluster in (required) | string | n/a | yes |
 | network\_policy | Enable network policy addon | string | `"false"` | no |
-| network\_policy\_provider | The network policy provider. | string | `"PROVIDER_UNSPECIFIED"` | no |
+| network\_policy\_provider | The network policy provider. | string | `"CALICO"` | no |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | string | `""` | no |
 | node\_pools | List of maps containing node pools | list | `<list>` | no |
 | node\_pools\_labels | Map of maps containing node labels by node-pool name | map | `<map>` | no |

--- a/modules/private-cluster/cluster_regional.tf
+++ b/modules/private-cluster/cluster_regional.tf
@@ -29,7 +29,13 @@ resource "google_container_cluster" "primary" {
   region         = "${var.region}"
   node_locations = ["${coalescelist(compact(var.zones), sort(random_shuffle.available_zones.result))}"]
 
-  network            = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
+  network = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
+
+  network_policy {
+    enabled  = "${var.network_policy}"
+    provider = "${var.network_policy_provider}"
+  }
+
   subnetwork         = "${replace(data.google_compute_subnetwork.gke_subnetwork.self_link, "https://www.googleapis.com/compute/v1/", "")}"
   min_master_version = "${local.kubernetes_version_regional}"
 

--- a/modules/private-cluster/cluster_zonal.tf
+++ b/modules/private-cluster/cluster_zonal.tf
@@ -29,7 +29,13 @@ resource "google_container_cluster" "zonal_primary" {
   zone           = "${var.zones[0]}"
   node_locations = ["${slice(var.zones,1,length(var.zones))}"]
 
-  network            = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
+  network = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
+
+  network_policy {
+    enabled  = "${var.network_policy}"
+    provider = "${var.network_policy_provider}"
+  }
+
   subnetwork         = "${replace(data.google_compute_subnetwork.gke_subnetwork.self_link, "https://www.googleapis.com/compute/v1/", "")}"
   min_master_version = "${local.kubernetes_version_zonal}"
 

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -106,6 +106,11 @@ variable "network_policy" {
   default     = false
 }
 
+variable "network_policy_provider" {
+  description = "The network policy provider."
+  default     = "PROVIDER_UNSPECIFIED"
+}
+
 variable "maintenance_start_time" {
   description = "Time window specified for daily maintenance operations in RFC3339 format"
   default     = "05:00"

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -108,7 +108,7 @@ variable "network_policy" {
 
 variable "network_policy_provider" {
   description = "The network policy provider."
-  default     = "PROVIDER_UNSPECIFIED"
+  default     = "CALICO"
 }
 
 variable "maintenance_start_time" {

--- a/test/ci_integration.sh
+++ b/test/ci_integration.sh
@@ -61,7 +61,6 @@ main() {
   # Execute the test lifecycle
   kitchen create "$SUITE"
   kitchen converge "$SUITE"
-  kitchen converge "$SUITE"
   kitchen verify "$SUITE"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -106,6 +106,11 @@ variable "network_policy" {
   default     = false
 }
 
+variable "network_policy_provider" {
+  description = "The network policy provider."
+  default     = "PROVIDER_UNSPECIFIED"
+}
+
 variable "maintenance_start_time" {
   description = "Time window specified for daily maintenance operations in RFC3339 format"
   default     = "05:00"

--- a/variables.tf
+++ b/variables.tf
@@ -108,7 +108,7 @@ variable "network_policy" {
 
 variable "network_policy_provider" {
   description = "The network policy provider."
-  default     = "PROVIDER_UNSPECIFIED"
+  default     = "CALICO"
 }
 
 variable "maintenance_start_time" {


### PR DESCRIPTION
This branch adds an explicit `network_policy` block to the `google_container_cluster`, as recommended by https://github.com/terraform-providers/terraform-provider-google/issues/3673. This solves the issue of the partially converged suites which obviates the need for a second converge.