### PR TITLE
Restrict node access to cluster metadata service

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | network\_policy | Enable network policy addon | string | `"false"` | no |
 | network\_policy\_provider | The network policy provider. | string | `"CALICO"` | no |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | string | `""` | no |
+| node\_metadata | Specifies how node metadata is exposed to the workload running on the node | string | `"UNSPECIFIED"` | no |
 | node\_pools | List of maps containing node pools | list | `<list>` | no |
 | node\_pools\_labels | Map of maps containing node labels by node-pool name | map | `<map>` | no |
 | node\_pools\_metadata | Map of maps containing node metadata by node-pool name | map | `<map>` | no |

--- a/autogen/cluster_regional.tf
+++ b/autogen/cluster_regional.tf
@@ -102,6 +102,10 @@ resource "google_container_cluster" "primary" {
 
     node_config {
       service_account = "${lookup(var.node_pools[0], "service_account", local.service_account)}"
+
+      workload_metadata_config {
+        node_metadata = "${var.node_metadata}"
+      }
     }
   }
 {% if private_cluster %}
@@ -160,6 +164,10 @@ resource "google_container_node_pool" "pools" {
     guest_accelerator {
       type  = "${lookup(var.node_pools[count.index], "accelerator_type", "")}"
       count = "${lookup(var.node_pools[count.index], "accelerator_count", 0)}"
+    }
+
+    workload_metadata_config {
+      node_metadata = "${var.node_metadata}"
     }
   }
 

--- a/autogen/cluster_zonal.tf
+++ b/autogen/cluster_zonal.tf
@@ -102,6 +102,10 @@ resource "google_container_cluster" "zonal_primary" {
 
     node_config {
       service_account = "${lookup(var.node_pools[0], "service_account", local.service_account)}"
+
+      workload_metadata_config {
+        node_metadata = "${var.node_metadata}"
+      }
     }
   }
 {% if private_cluster %}
@@ -160,6 +164,10 @@ resource "google_container_node_pool" "zonal_pools" {
     guest_accelerator {
       type  = "${lookup(var.node_pools[count.index], "accelerator_type", "")}"
       count = "${lookup(var.node_pools[count.index], "accelerator_count", 0)}"
+    }
+
+    workload_metadata_config {
+      node_metadata = "${var.node_metadata}"
     }
   }
 

--- a/autogen/variables.tf
+++ b/autogen/variables.tf
@@ -67,6 +67,11 @@ variable "node_version" {
   default     = ""
 }
 
+variable "node_metadata" {
+  description = "Specifies how node metadata is exposed to the workload running on the node"
+  default     = "UNSPECIFIED"
+}
+
 variable "master_authorized_networks_config" {
   type = "list"
 

--- a/cluster_regional.tf
+++ b/cluster_regional.tf
@@ -98,6 +98,10 @@ resource "google_container_cluster" "primary" {
 
     node_config {
       service_account = "${lookup(var.node_pools[0], "service_account", local.service_account)}"
+
+      workload_metadata_config {
+        node_metadata = "${var.node_metadata}"
+      }
     }
   }
 
@@ -148,6 +152,10 @@ resource "google_container_node_pool" "pools" {
     guest_accelerator {
       type  = "${lookup(var.node_pools[count.index], "accelerator_type", "")}"
       count = "${lookup(var.node_pools[count.index], "accelerator_count", 0)}"
+    }
+
+    workload_metadata_config {
+      node_metadata = "${var.node_metadata}"
     }
   }
 

--- a/cluster_zonal.tf
+++ b/cluster_zonal.tf
@@ -98,6 +98,10 @@ resource "google_container_cluster" "zonal_primary" {
 
     node_config {
       service_account = "${lookup(var.node_pools[0], "service_account", local.service_account)}"
+
+      workload_metadata_config {
+        node_metadata = "${var.node_metadata}"
+      }
     }
   }
 
@@ -148,6 +152,10 @@ resource "google_container_node_pool" "zonal_pools" {
     guest_accelerator {
       type  = "${lookup(var.node_pools[count.index], "accelerator_type", "")}"
       count = "${lookup(var.node_pools[count.index], "accelerator_count", 0)}"
+    }
+
+    workload_metadata_config {
+      node_metadata = "${var.node_metadata}"
     }
   }
 

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -147,6 +147,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | network\_policy | Enable network policy addon | string | `"false"` | no |
 | network\_policy\_provider | The network policy provider. | string | `"CALICO"` | no |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | string | `""` | no |
+| node\_metadata | Specifies how node metadata is exposed to the workload running on the node | string | `"UNSPECIFIED"` | no |
 | node\_pools | List of maps containing node pools | list | `<list>` | no |
 | node\_pools\_labels | Map of maps containing node labels by node-pool name | map | `<map>` | no |
 | node\_pools\_metadata | Map of maps containing node metadata by node-pool name | map | `<map>` | no |

--- a/modules/private-cluster/cluster_regional.tf
+++ b/modules/private-cluster/cluster_regional.tf
@@ -100,6 +100,10 @@ resource "google_container_cluster" "primary" {
 
     node_config {
       service_account = "${lookup(var.node_pools[0], "service_account", local.service_account)}"
+
+      workload_metadata_config {
+        node_metadata = "${var.node_metadata}"
+      }
     }
   }
 
@@ -156,6 +160,10 @@ resource "google_container_node_pool" "pools" {
     guest_accelerator {
       type  = "${lookup(var.node_pools[count.index], "accelerator_type", "")}"
       count = "${lookup(var.node_pools[count.index], "accelerator_count", 0)}"
+    }
+
+    workload_metadata_config {
+      node_metadata = "${var.node_metadata}"
     }
   }
 

--- a/modules/private-cluster/cluster_zonal.tf
+++ b/modules/private-cluster/cluster_zonal.tf
@@ -100,6 +100,10 @@ resource "google_container_cluster" "zonal_primary" {
 
     node_config {
       service_account = "${lookup(var.node_pools[0], "service_account", local.service_account)}"
+
+      workload_metadata_config {
+        node_metadata = "${var.node_metadata}"
+      }
     }
   }
 
@@ -156,6 +160,10 @@ resource "google_container_node_pool" "zonal_pools" {
     guest_accelerator {
       type  = "${lookup(var.node_pools[count.index], "accelerator_type", "")}"
       count = "${lookup(var.node_pools[count.index], "accelerator_count", 0)}"
+    }
+
+    workload_metadata_config {
+      node_metadata = "${var.node_metadata}"
     }
   }
 

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -159,7 +159,7 @@ locals {
   cluster_http_load_balancing_enabled        = "${local.cluster_type_output_http_load_balancing_enabled[local.cluster_type] ? false : true}"
   cluster_horizontal_pod_autoscaling_enabled = "${local.cluster_type_output_horizontal_pod_autoscaling_enabled[local.cluster_type] ? false : true}"
   cluster_kubernetes_dashboard_enabled       = "${local.cluster_type_output_kubernetes_dashboard_enabled[local.cluster_type] ? false : true}"
-  cluster_pod_security_policy_enabled        = "${local.cluster_type_output_pod_security_policy_enabled[local.cluster_type] ? false : true}"
+  cluster_pod_security_policy_enabled        = "${local.cluster_type_output_pod_security_policy_enabled[local.cluster_type] ? true : false}"
 }
 
 /******************************************

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -67,6 +67,11 @@ variable "node_version" {
   default     = ""
 }
 
+variable "node_metadata" {
+  description = "Specifies how node metadata is exposed to the workload running on the node"
+  default     = "UNSPECIFIED"
+}
+
 variable "master_authorized_networks_config" {
   type = "list"
 

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,11 @@ variable "node_version" {
   default     = ""
 }
 
+variable "node_metadata" {
+  description = "Specifies how node metadata is exposed to the workload running on the node"
+  default     = "UNSPECIFIED"
+}
+
 variable "master_authorized_networks_config" {
   type = "list"
 


### PR DESCRIPTION
I was recently had my private GKE cluster pen test and one of the issues that were reported by this test was POD's had access the metadata service which exposes sensitive data:-

```bash
# curl -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/instance/attributes/kube-env'
ALLOCATE_NODE_CIDRS: "true"                                                                                                                                            API_SERVER_TEST_LOG_LEVEL: --v=3
...
...
KUBE_PROXY_TOKEN: h9gjoyXnyaB2MDnBeOPmJG3OEJ0zS7GKXtU-9xMJRTw=
KUBELET_CERT: XXXXXXXXXX
KUBELET_KEY: XXXXXXXXX
KUBERNETES_MASTER: "false"
KUBERNETES_MASTER_NAME: 10.17.5.2
LOGGING_DESTINATION: gcp
...
...
```

By default, GKE clusters expose "UNSPECIFIED". However, you can switch this off by setting `node_metadata` to "SECURE".

```bash
$ curl -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/instance/attributes/kube-env'
This metadata endpoint is concealed.

$ curl -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/instance/attributes/disable-legacy-endpoints'
false
```

This PR will allow the clusters to move along as normal but will give anyone the ability to shut off metadata service by specifying "SECURE" instead of the default "UNSPECIFIED".

I have tested this on our internal zonal cluster and it worked as expected.