### PR TITLE
Add default_max_pods_per_node and max_pods_per_node

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 |------|-------------|:----:|:-----:|:-----:|
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |
+| default\_max\_pods\_per\_node | The maximum number of pods to schedule per node | string | `"110"` | no |
 | description | The description of the cluster | string | `""` | no |
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | string | `"true"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | string | `"true"` | no |

--- a/autogen/cluster_regional.tf
+++ b/autogen/cluster_regional.tf
@@ -74,6 +74,7 @@ resource "google_container_cluster" "primary" {
       disabled = "${var.network_policy ? 0 : 1}"
     }
   }
+  default_max_pods_per_node = "${var.default_max_pods_per_node}"
 
   ip_allocation_policy {
     cluster_secondary_range_name  = "${var.ip_range_pods}"

--- a/autogen/cluster_regional.tf
+++ b/autogen/cluster_regional.tf
@@ -20,7 +20,8 @@
   Create regional cluster
  *****************************************/
 resource "google_container_cluster" "primary" {
-  provider    = "{% if private_cluster %}google-beta{%else %}google{% endif %}"
+  //provider    = "{% if private_cluster %}google-beta{%else %}google{% endif %}"
+  provider = "google-beta"
   count       = "${var.regional ? 1 : 0}"
   name        = "${var.name}"
   description = "${var.description}"

--- a/autogen/cluster_regional.tf
+++ b/autogen/cluster_regional.tf
@@ -129,6 +129,7 @@ resource "google_container_node_pool" "pools" {
   cluster            = "${google_container_cluster.primary.name}"
   version            = "${lookup(var.node_pools[count.index], "auto_upgrade", false) ? "" : lookup(var.node_pools[count.index], "version", local.node_version_regional)}"
   initial_node_count = "${lookup(var.node_pools[count.index], "initial_node_count", lookup(var.node_pools[count.index], "min_count", 1))}"
+  max_pods_per_node  = "${lookup(var.node_pools[count.index], "max_pods_per_node", lookup(var.node_pools[count.index], "max_pods_per_node", 110))}"
 
   autoscaling {
     min_node_count = "${lookup(var.node_pools[count.index], "min_count", 1)}"

--- a/autogen/cluster_zonal.tf
+++ b/autogen/cluster_zonal.tf
@@ -129,6 +129,7 @@ resource "google_container_node_pool" "zonal_pools" {
   cluster            = "${google_container_cluster.zonal_primary.name}"
   version            = "${lookup(var.node_pools[count.index], "auto_upgrade", false) ? "" : lookup(var.node_pools[count.index], "version", local.node_version_zonal)}"
   initial_node_count = "${lookup(var.node_pools[count.index], "initial_node_count", lookup(var.node_pools[count.index], "min_count", 1))}"
+  max_pods_per_node  = "${lookup(var.node_pools[count.index], "max_pods_per_node", lookup(var.node_pools[count.index], "max_pods_per_node", 110))}"
 
   autoscaling {
     min_node_count = "${lookup(var.node_pools[count.index], "min_count", 1)}"

--- a/autogen/cluster_zonal.tf
+++ b/autogen/cluster_zonal.tf
@@ -73,6 +73,7 @@ resource "google_container_cluster" "zonal_primary" {
       disabled = "${var.network_policy ? 0 : 1}"
     }
   }
+  default_max_pods_per_node = "${var.default_max_pods_per_node}"
 
   ip_allocation_policy {
     cluster_secondary_range_name  = "${var.ip_range_pods}"

--- a/autogen/cluster_zonal.tf
+++ b/autogen/cluster_zonal.tf
@@ -20,7 +20,8 @@
   Create zonal cluster
  *****************************************/
 resource "google_container_cluster" "zonal_primary" {
-  provider    = "{% if private_cluster %}google-beta{%else %}google{% endif %}"
+  //provider    = "{% if private_cluster %}google-beta{%else %}google{% endif %}"
+  provider = "google-beta"
   count       = "${var.regional ? 0 : 1}"
   name        = "${var.name}"
   description = "${var.description}"

--- a/autogen/variables.tf
+++ b/autogen/variables.tf
@@ -130,6 +130,10 @@ variable "ip_range_pods" {
 variable "ip_range_services" {
   description = "The _name_ of the secondary subnet range to use for services"
 }
+variable "default_max_pods_per_node" {
+  description = "The maximum number of pods to schedule per node"
+  default     = 110
+}
 
 variable "initial_node_count" {
   description = "The number of nodes to create in this cluster's default node pool."

--- a/autogen/variables.tf
+++ b/autogen/variables.tf
@@ -130,6 +130,7 @@ variable "ip_range_pods" {
 variable "ip_range_services" {
   description = "The _name_ of the secondary subnet range to use for services"
 }
+
 variable "default_max_pods_per_node" {
   description = "The maximum number of pods to schedule per node"
   default     = 110

--- a/cluster_regional.tf
+++ b/cluster_regional.tf
@@ -118,6 +118,7 @@ resource "google_container_node_pool" "pools" {
   cluster            = "${google_container_cluster.primary.name}"
   version            = "${lookup(var.node_pools[count.index], "auto_upgrade", false) ? "" : lookup(var.node_pools[count.index], "version", local.node_version_regional)}"
   initial_node_count = "${lookup(var.node_pools[count.index], "initial_node_count", lookup(var.node_pools[count.index], "min_count", 1))}"
+  max_pods_per_node  = "${lookup(var.node_pools[count.index], "max_pods_per_node", lookup(var.node_pools[count.index], "max_pods_per_node", 110))}"
 
   autoscaling {
     min_node_count = "${lookup(var.node_pools[count.index], "min_count", 1)}"

--- a/cluster_regional.tf
+++ b/cluster_regional.tf
@@ -20,7 +20,8 @@
   Create regional cluster
  *****************************************/
 resource "google_container_cluster" "primary" {
-  provider    = "google"
+  //provider    = "google"
+  provider = "google-beta"
   count       = "${var.regional ? 1 : 0}"
   name        = "${var.name}"
   description = "${var.description}"

--- a/cluster_regional.tf
+++ b/cluster_regional.tf
@@ -71,6 +71,7 @@ resource "google_container_cluster" "primary" {
       disabled = "${var.network_policy ? 0 : 1}"
     }
   }
+  default_max_pods_per_node = "${var.default_max_pods_per_node}"
 
   ip_allocation_policy {
     cluster_secondary_range_name  = "${var.ip_range_pods}"

--- a/cluster_zonal.tf
+++ b/cluster_zonal.tf
@@ -70,6 +70,7 @@ resource "google_container_cluster" "zonal_primary" {
       disabled = "${var.network_policy ? 0 : 1}"
     }
   }
+  default_max_pods_per_node = "${var.default_max_pods_per_node}"
 
   ip_allocation_policy {
     cluster_secondary_range_name  = "${var.ip_range_pods}"

--- a/cluster_zonal.tf
+++ b/cluster_zonal.tf
@@ -118,6 +118,7 @@ resource "google_container_node_pool" "zonal_pools" {
   cluster            = "${google_container_cluster.zonal_primary.name}"
   version            = "${lookup(var.node_pools[count.index], "auto_upgrade", false) ? "" : lookup(var.node_pools[count.index], "version", local.node_version_zonal)}"
   initial_node_count = "${lookup(var.node_pools[count.index], "initial_node_count", lookup(var.node_pools[count.index], "min_count", 1))}"
+  max_pods_per_node  = "${lookup(var.node_pools[count.index], "max_pods_per_node", lookup(var.node_pools[count.index], "max_pods_per_node", 110))}"
 
   autoscaling {
     min_node_count = "${lookup(var.node_pools[count.index], "min_count", 1)}"

--- a/cluster_zonal.tf
+++ b/cluster_zonal.tf
@@ -20,7 +20,8 @@
   Create zonal cluster
  *****************************************/
 resource "google_container_cluster" "zonal_primary" {
-  provider    = "google"
+  //provider    = "google"
+  provider = "google-beta"
   count       = "${var.regional ? 0 : 1}"
   name        = "${var.name}"
   description = "${var.description}"

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -121,6 +121,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 |------|-------------|:----:|:-----:|:-----:|
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |
+| default\_max\_pods\_per\_node | The maximum number of pods to schedule per node | string | `"110"` | no |
 | deploy\_using\_private\_endpoint | (Beta) A toggle for Terraform and kubectl to connect to the master's internal IP address during deployment. | string | `"false"` | no |
 | description | The description of the cluster | string | `""` | no |
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | string | `"true"` | no |

--- a/modules/private-cluster/cluster_regional.tf
+++ b/modules/private-cluster/cluster_regional.tf
@@ -20,7 +20,8 @@
   Create regional cluster
  *****************************************/
 resource "google_container_cluster" "primary" {
-  provider    = "google-beta"
+  //provider    = "google-beta"
+  provider = "google-beta"
   count       = "${var.regional ? 1 : 0}"
   name        = "${var.name}"
   description = "${var.description}"

--- a/modules/private-cluster/cluster_regional.tf
+++ b/modules/private-cluster/cluster_regional.tf
@@ -72,6 +72,7 @@ resource "google_container_cluster" "primary" {
       disabled = "${var.network_policy ? 0 : 1}"
     }
   }
+  default_max_pods_per_node = "${var.default_max_pods_per_node}"
 
   ip_allocation_policy {
     cluster_secondary_range_name  = "${var.ip_range_pods}"

--- a/modules/private-cluster/cluster_regional.tf
+++ b/modules/private-cluster/cluster_regional.tf
@@ -125,6 +125,7 @@ resource "google_container_node_pool" "pools" {
   cluster            = "${google_container_cluster.primary.name}"
   version            = "${lookup(var.node_pools[count.index], "auto_upgrade", false) ? "" : lookup(var.node_pools[count.index], "version", local.node_version_regional)}"
   initial_node_count = "${lookup(var.node_pools[count.index], "initial_node_count", lookup(var.node_pools[count.index], "min_count", 1))}"
+  max_pods_per_node  = "${lookup(var.node_pools[count.index], "max_pods_per_node", lookup(var.node_pools[count.index], "max_pods_per_node", 110))}"
 
   autoscaling {
     min_node_count = "${lookup(var.node_pools[count.index], "min_count", 1)}"

--- a/modules/private-cluster/cluster_zonal.tf
+++ b/modules/private-cluster/cluster_zonal.tf
@@ -125,6 +125,7 @@ resource "google_container_node_pool" "zonal_pools" {
   cluster            = "${google_container_cluster.zonal_primary.name}"
   version            = "${lookup(var.node_pools[count.index], "auto_upgrade", false) ? "" : lookup(var.node_pools[count.index], "version", local.node_version_zonal)}"
   initial_node_count = "${lookup(var.node_pools[count.index], "initial_node_count", lookup(var.node_pools[count.index], "min_count", 1))}"
+  max_pods_per_node  = "${lookup(var.node_pools[count.index], "max_pods_per_node", lookup(var.node_pools[count.index], "max_pods_per_node", 110))}"
 
   autoscaling {
     min_node_count = "${lookup(var.node_pools[count.index], "min_count", 1)}"

--- a/modules/private-cluster/cluster_zonal.tf
+++ b/modules/private-cluster/cluster_zonal.tf
@@ -20,7 +20,8 @@
   Create zonal cluster
  *****************************************/
 resource "google_container_cluster" "zonal_primary" {
-  provider    = "google-beta"
+  //provider    = "google-beta"
+  provider = "google-beta"
   count       = "${var.regional ? 0 : 1}"
   name        = "${var.name}"
   description = "${var.description}"

--- a/modules/private-cluster/cluster_zonal.tf
+++ b/modules/private-cluster/cluster_zonal.tf
@@ -71,6 +71,7 @@ resource "google_container_cluster" "zonal_primary" {
       disabled = "${var.network_policy ? 0 : 1}"
     }
   }
+  default_max_pods_per_node = "${var.default_max_pods_per_node}"
 
   ip_allocation_policy {
     cluster_secondary_range_name  = "${var.ip_range_pods}"

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -129,6 +129,11 @@ variable "ip_range_services" {
   description = "The _name_ of the secondary subnet range to use for services"
 }
 
+variable "default_max_pods_per_node" {
+  description = "The maximum number of pods to schedule per node"
+  default     = 110
+}
+
 variable "initial_node_count" {
   description = "The number of nodes to create in this cluster's default node pool."
   default     = 0

--- a/variables.tf
+++ b/variables.tf
@@ -123,6 +123,7 @@ variable "ip_range_pods" {
 variable "ip_range_services" {
   description = "The _name_ of the secondary subnet range to use for services"
 }
+
 variable "default_max_pods_per_node" {
   description = "The maximum number of pods to schedule per node"
   default     = 110

--- a/variables.tf
+++ b/variables.tf
@@ -123,6 +123,10 @@ variable "ip_range_pods" {
 variable "ip_range_services" {
   description = "The _name_ of the secondary subnet range to use for services"
 }
+variable "default_max_pods_per_node" {
+  description = "The maximum number of pods to schedule per node"
+  default     = 110
+}
 
 variable "initial_node_count" {
   description = "The number of nodes to create in this cluster's default node pool."


### PR DESCRIPTION
This change adds support for `default_max_pods_per_node` at the cluster level and for `max_pods_per_node` at the pool level.

Merging this will also explicitly set the provider to `google-beta` and drop the private/public cluster conditional in the regional cluster (original code commented).