### PR TITLE
Add Terraform and Kitchen state files to Dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.terraform
+.terraform.d
+.kitchen
+terraform.tfstate.d
+test/fixtures/*/.terraform
+test/fixtures/*/terraform.tfstate.d
+examples/.kitchen
+examples/*/.terraform
+examples/*/terraform.tfstate.d

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ docker_run:
 		-e SERVICE_ACCOUNT_JSON \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
-		-v $(CURDIR):/cft/workdir \
+		-v "$(CURDIR)":/cft/workdir \
 		${DOCKER_IMAGE_KITCHEN_TERRAFORM}:${DOCKER_TAG_KITCHEN_TERRAFORM} \
 		/bin/bash -c "source test/ci_integration.sh && setup_environment && exec /bin/bash"
 
@@ -139,7 +139,7 @@ docker_create: docker_build_kitchen_terraform
 		-e SERVICE_ACCOUNT_JSON \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
-		-v $(CURDIR):/cft/workdir \
+		-v "$(CURDIR)":/cft/workdir \
 		${DOCKER_IMAGE_KITCHEN_TERRAFORM}:${DOCKER_TAG_KITCHEN_TERRAFORM} \
 		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen create"
 
@@ -153,7 +153,7 @@ docker_converge:
 		-e SERVICE_ACCOUNT_JSON \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
-		-v $(CURDIR):/cft/workdir \
+		-v "$(CURDIR)":/cft/workdir \
 		${DOCKER_IMAGE_KITCHEN_TERRAFORM}:${DOCKER_TAG_KITCHEN_TERRAFORM} \
 		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen converge && kitchen converge"
 
@@ -167,7 +167,7 @@ docker_verify:
 		-e SERVICE_ACCOUNT_JSON \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
-		-v $(CURDIR):/cft/workdir \
+		-v "$(CURDIR)":/cft/workdir \
 		${DOCKER_IMAGE_KITCHEN_TERRAFORM}:${DOCKER_TAG_KITCHEN_TERRAFORM} \
 		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen verify"
 
@@ -181,7 +181,7 @@ docker_destroy:
 		-e SERVICE_ACCOUNT_JSON \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
-		-v $(CURDIR):/cft/workdir \
+		-v "$(CURDIR)":/cft/workdir \
 		${DOCKER_IMAGE_KITCHEN_TERRAFORM}:${DOCKER_TAG_KITCHEN_TERRAFORM} \
 		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen destroy"
 
@@ -193,6 +193,6 @@ test_integration_docker:
 		-e REGION \
 		-e ZONES \
 		-e SERVICE_ACCOUNT_JSON \
-		-v $(CURDIR):/cft/workdir \
+		-v "$(CURDIR)":/cft/workdir \
 		${DOCKER_IMAGE_KITCHEN_TERRAFORM}:${DOCKER_TAG_KITCHEN_TERRAFORM} \
 		/bin/bash -c "test/ci_integration.sh"


### PR DESCRIPTION
Significantly reduces the time needed to build the testing Docker image.

Before:

```
❯ make docker_build_kitchen_terraform
docker build -f build/docker/kitchen_terraform/Dockerfile \
		--build-arg BASE_IMAGE=gcr.io/cloud-foundation-cicd/cft/kitchen-terraform:1.3.0 \
		-t gcr.io/cloud-foundation-cicd/cft/kitchen-terraform_terraform-google-kubernetes-engine:1.3.0 .
Sending build context to Docker daemon  2.866GB
Step 1/9 : ARG BASE_IMAGE
Step 2/9 : FROM $BASE_IMAGE
 ---> 37b95e37e5c1
Step 3/9 : RUN apk add --no-cache     ca-certificates=20190108-r0
 ---> Using cache
 ---> 02e795605df7
Step 4/9 : ADD https://storage.googleapis.com/kubernetes-release/release/v1.12.2/bin/linux/amd64/kubectl /usr/local/bin/kubectl
Downloading [==================================================>]  57.35MB/57.35MB

 ---> Using cache
 ---> e24bc7f410de
Step 5/9 : RUN chmod +x /usr/local/bin/kubectl
 ---> Using cache
 ---> 679c5cb60b0a
Step 6/9 : WORKDIR /opt/kitchen
 ---> Using cache
 ---> 4bc26a64bcbd
Step 7/9 : COPY Gemfile .
 ---> Using cache
 ---> 2764f9eff252
Step 8/9 : RUN bundle install
 ---> Using cache
 ---> 2bb5ec407c49
Step 9/9 : WORKDIR $APP_BASE_DIR/workdir
 ---> Using cache
 ---> 1385b28157df
Successfully built 1385b28157df
Successfully tagged gcr.io/cloud-foundation-cicd/cft/kitchen-terraform_terraform-google-kubernetes-engine:1.3.0
make docker_build_kitchen_terraform  7.49s user 10.75s system 54% cpu 33.609 total
```

After:
```
❯ make docker_build_kitchen_terraform
docker build -f build/docker/kitchen_terraform/Dockerfile \
		--build-arg BASE_IMAGE=gcr.io/cloud-foundation-cicd/cft/kitchen-terraform:1.3.0 \
		-t gcr.io/cloud-foundation-cicd/cft/kitchen-terraform_terraform-google-kubernetes-engine:1.3.0 .
Sending build context to Docker daemon  623.1kB
Step 1/9 : ARG BASE_IMAGE
Step 2/9 : FROM $BASE_IMAGE
 ---> 37b95e37e5c1
Step 3/9 : RUN apk add --no-cache     ca-certificates=20190108-r0
 ---> Using cache
 ---> 02e795605df7
Step 4/9 : ADD https://storage.googleapis.com/kubernetes-release/release/v1.12.2/bin/linux/amd64/kubectl /usr/local/bin/kubectl
Downloading [==================================================>]  57.35MB/57.35MB

 ---> Using cache
 ---> e24bc7f410de
Step 5/9 : RUN chmod +x /usr/local/bin/kubectl
 ---> Using cache
 ---> 679c5cb60b0a
Step 6/9 : WORKDIR /opt/kitchen
 ---> Using cache
 ---> 4bc26a64bcbd
Step 7/9 : COPY Gemfile .
 ---> Using cache
 ---> 2764f9eff252
Step 8/9 : RUN bundle install
 ---> Using cache
 ---> 2bb5ec407c49
Step 9/9 : WORKDIR $APP_BASE_DIR/workdir
 ---> Using cache
 ---> 1385b28157df
Successfully built 1385b28157df
Successfully tagged gcr.io/cloud-foundation-cicd/cft/kitchen-terraform_terraform-google-kubernetes-engine:1.3.0
```

Time elapsed on `after` was 7s.