### PR TITLE
Change to use pip3

### DIFF
--- a/test/make.sh
+++ b/test/make.sh
@@ -87,7 +87,7 @@ function check_trailing_whitespace() {
 }
 
 function generate() {
-  pip install --user -r ./helpers/generate_modules/requirements.txt
+  pip3 install --user -r ./helpers/generate_modules/requirements.txt
   ./helpers/generate_modules/generate_modules.py
 }
 


### PR DESCRIPTION
This changes "pip" to "pip3" in make.sh.

On systems that have both python2 and python3 installed, we may want to use
a call to pip3 for installing modules, rather than just pip.

On my mac, it was not happy as I have both pip and pip3 installed.