### PR TITLE
Creation of new variable configure_ip_masq controlling ip masq install

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |
 | cluster\_ipv4\_cidr | The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR. | string | `""` | no |
+| configure\_ip\_masq | Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server. | string | `"false"` | no |
 | description | The description of the cluster | string | `""` | no |
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | string | `"true"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | string | `"true"` | no |

--- a/autogen/masq.tf
+++ b/autogen/masq.tf
@@ -20,7 +20,7 @@
   Create ip-masq-agent confimap
  *****************************************/
 resource "kubernetes_config_map" "ip-masq-agent" {
-  count = "${var.network_policy ? 1 : 0}"
+  count = "${var.configure_ip_masq ? 1 : 0}"
 
   metadata {
     name      = "ip-masq-agent"

--- a/autogen/variables.tf
+++ b/autogen/variables.tf
@@ -237,6 +237,11 @@ variable "ip_masq_link_local" {
   default     = "false"
 }
 
+variable "configure_ip_masq" {
+  description = "Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server."
+  default     = "false"
+}
+
 variable "logging_service" {
   description = "The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none"
   default     = "logging.googleapis.com"

--- a/examples/stub_domains/main.tf
+++ b/examples/stub_domains/main.tf
@@ -40,6 +40,8 @@ module "gke" {
   network_policy    = true
   service_account   = "${var.compute_engine_service_account}"
 
+  configure_ip_masq = true
+
   stub_domains {
     "example.com" = [
       "10.254.154.11",

--- a/masq.tf
+++ b/masq.tf
@@ -20,7 +20,7 @@
   Create ip-masq-agent confimap
  *****************************************/
 resource "kubernetes_config_map" "ip-masq-agent" {
-  count = "${var.network_policy ? 1 : 0}"
+  count = "${var.configure_ip_masq ? 1 : 0}"
 
   metadata {
     name      = "ip-masq-agent"

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -125,6 +125,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |
 | cloudrun | (Beta) Enable CloudRun addon | string | `"false"` | no |
 | cluster\_ipv4\_cidr | The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR. | string | `""` | no |
+| configure\_ip\_masq | Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server. | string | `"false"` | no |
 | database\_encryption | Application-layer Secrets Encryption settings. Example:   database_encryption = [{     state = "ENCRYPTED",     key_name = "projects/my-project/locations/global/keyRings/my-ring/cryptoKeys/my-key"   }] | list | `<list>` | no |
 | deploy\_using\_private\_endpoint | (Beta) A toggle for Terraform and kubectl to connect to the master's internal IP address during deployment. | string | `"false"` | no |
 | description | The description of the cluster | string | `""` | no |

--- a/modules/beta-private-cluster/masq.tf
+++ b/modules/beta-private-cluster/masq.tf
@@ -20,7 +20,7 @@
   Create ip-masq-agent confimap
  *****************************************/
 resource "kubernetes_config_map" "ip-masq-agent" {
-  count = "${var.network_policy ? 1 : 0}"
+  count = "${var.configure_ip_masq ? 1 : 0}"
 
   metadata {
     name      = "ip-masq-agent"

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -235,6 +235,11 @@ variable "ip_masq_link_local" {
   default     = "false"
 }
 
+variable "configure_ip_masq" {
+  description = "Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server."
+  default     = "false"
+}
+
 variable "logging_service" {
   description = "The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none"
   default     = "logging.googleapis.com"

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -120,6 +120,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |
 | cloudrun | (Beta) Enable CloudRun addon | string | `"false"` | no |
 | cluster\_ipv4\_cidr | The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR. | string | `""` | no |
+| configure\_ip\_masq | Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server. | string | `"false"` | no |
 | database\_encryption | Application-layer Secrets Encryption settings. Example:   database_encryption = [{     state = "ENCRYPTED",     key_name = "projects/my-project/locations/global/keyRings/my-ring/cryptoKeys/my-key"   }] | list | `<list>` | no |
 | description | The description of the cluster | string | `""` | no |
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | string | `"true"` | no |

--- a/modules/beta-public-cluster/masq.tf
+++ b/modules/beta-public-cluster/masq.tf
@@ -20,7 +20,7 @@
   Create ip-masq-agent confimap
  *****************************************/
 resource "kubernetes_config_map" "ip-masq-agent" {
-  count = "${var.network_policy ? 1 : 0}"
+  count = "${var.configure_ip_masq ? 1 : 0}"
 
   metadata {
     name      = "ip-masq-agent"

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -222,6 +222,11 @@ variable "ip_masq_link_local" {
   default     = "false"
 }
 
+variable "configure_ip_masq" {
+  description = "Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server."
+  default     = "false"
+}
+
 variable "logging_service" {
   description = "The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none"
   default     = "logging.googleapis.com"

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -122,6 +122,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |
 | cluster\_ipv4\_cidr | The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR. | string | `""` | no |
+| configure\_ip\_masq | Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server. | string | `"false"` | no |
 | deploy\_using\_private\_endpoint | (Beta) A toggle for Terraform and kubectl to connect to the master's internal IP address during deployment. | string | `"false"` | no |
 | description | The description of the cluster | string | `""` | no |
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | string | `"true"` | no |

--- a/modules/private-cluster/masq.tf
+++ b/modules/private-cluster/masq.tf
@@ -20,7 +20,7 @@
   Create ip-masq-agent confimap
  *****************************************/
 resource "kubernetes_config_map" "ip-masq-agent" {
-  count = "${var.network_policy ? 1 : 0}"
+  count = "${var.configure_ip_masq ? 1 : 0}"
 
   metadata {
     name      = "ip-masq-agent"

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -235,6 +235,11 @@ variable "ip_masq_link_local" {
   default     = "false"
 }
 
+variable "configure_ip_masq" {
+  description = "Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server."
+  default     = "false"
+}
+
 variable "logging_service" {
   description = "The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none"
   default     = "logging.googleapis.com"

--- a/test/integration/stub_domains_private/controls/kubectl.rb
+++ b/test/integration/stub_domains_private/controls/kubectl.rb
@@ -59,26 +59,6 @@ control "kubectl" do
           })
         end
       end
-
-      describe "ipmasq" do
-        let(:ipmasq_configmap) { client.get_config_map("ip-masq-agent", "kube-system") }
-
-        it "is created by Terraform" do
-          expect(ipmasq_configmap.metadata.labels.maintained_by).to eq "terraform"
-        end
-
-        it "is configured properly" do
-          expect(YAML.load(ipmasq_configmap.data.config)).to eq({
-            "nonMasqueradeCIDRs" => [
-              "10.0.0.0/8",
-              "172.16.0.0/12",
-              "192.168.0.0/16",
-            ],
-            "resyncInterval" => "60s",
-            "masqLinkLocal" => false,
-          })
-        end
-      end
     end
   end
 end

--- a/variables.tf
+++ b/variables.tf
@@ -222,6 +222,11 @@ variable "ip_masq_link_local" {
   default     = "false"
 }
 
+variable "configure_ip_masq" {
+  description = "Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server."
+  default     = "false"
+}
+
 variable "logging_service" {
   description = "The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none"
   default     = "logging.googleapis.com"


### PR DESCRIPTION
Aliased IP addresses do not require ip masquerading anymore.  There are  few use cases where we would need ip masq, but usually it is not recommended to install ip masquerading. This variable allows
for fine gain control on the installation of ip masq as it was always installed via the
network_policy variable previously.

configure_ip_masq defaults to false.

Fixes: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/172

TODO:

- [x] test locally

Added a new field 'configure_ip_masq' to public stub domain example.  Removed the
integration control to check for ip masq in the private cluster as well.