### PR TITLE
Enabling two features in beta clusters

### DIFF
--- a/autogen/cluster_regional.tf
+++ b/autogen/cluster_regional.tf
@@ -42,10 +42,10 @@ resource "google_container_cluster" "primary" {
   logging_service    = "${var.logging_service}"
   monitoring_service = "${var.monitoring_service}"
 
-{% if private_cluster %}
+  {% if beta_cluster %}
   enable_binary_authorization       = "${var.enable_binary_authorization}"
   pod_security_policy_config        = "${var.pod_security_policy_config}"
-{% endif %}
+  {% endif %}
   master_authorized_networks_config = ["${var.master_authorized_networks_config}"]
 
   master_auth {

--- a/autogen/cluster_zonal.tf
+++ b/autogen/cluster_zonal.tf
@@ -42,10 +42,11 @@ resource "google_container_cluster" "zonal_primary" {
   logging_service    = "${var.logging_service}"
   monitoring_service = "${var.monitoring_service}"
 
-{% if private_cluster %}
+  {% if beta_cluster %}
   enable_binary_authorization       = "${var.enable_binary_authorization}"
   pod_security_policy_config        = "${var.pod_security_policy_config}"
-{% endif %}
+  {% endif %}
+
   master_authorized_networks_config = ["${var.master_authorized_networks_config}"]
 
   master_auth {

--- a/autogen/main.tf
+++ b/autogen/main.tf
@@ -140,6 +140,10 @@ locals {
     regional = "${element(concat(google_container_cluster.primary.*.addons_config.0.cloudrun_config.0.disabled, list("")), 0)}"
     zonal    = "${element(concat(google_container_cluster.zonal_primary.*.addons_config.0.cloudrun_config.0.disabled, list("")), 0)}"
   }
+  cluster_type_output_pod_security_policy_enabled = {
+    regional = "${element(concat(google_container_cluster.primary.*.pod_security_policy_config.0.enabled, list("")), 0)}"
+    zonal    = "${element(concat(google_container_cluster.zonal_primary.*.pod_security_policy_config.0.enabled, list("")), 0)}"
+  }
   # /BETA features
   {% endif %}
 
@@ -153,13 +157,6 @@ locals {
     zonal    = "${concat(google_container_node_pool.zonal_pools.*.version, list(""))}"
   }
 
-{% if private_cluster %}
-  cluster_type_output_pod_security_policy_enabled = {
-    regional = "${element(concat(google_container_cluster.primary.*.pod_security_policy_config.0.enabled, list("")), 0)}"
-    zonal    = "${element(concat(google_container_cluster.zonal_primary.*.pod_security_policy_config.0.enabled, list("")), 0)}"
-  }
-
-{% endif %}
   cluster_master_auth_list_layer1 = "${local.cluster_type_output_master_auth[local.cluster_type]}"
   cluster_master_auth_list_layer2 = "${local.cluster_master_auth_list_layer1[0]}"
   cluster_master_auth_map         = "${local.cluster_master_auth_list_layer2[0]}"
@@ -184,10 +181,9 @@ locals {
   # BETA features
   cluster_istio_enabled    = "${local.cluster_type_output_istio_enabled[local.cluster_type] ? false : true}"
   cluster_cloudrun_enabled = "${local.cluster_type_output_cloudrun_enabled[local.cluster_type] ? false : true}"
-  # /BETA features
-{% endif %}
-{% if private_cluster %}
+
   cluster_pod_security_policy_enabled        = "${local.cluster_type_output_pod_security_policy_enabled[local.cluster_type] ? true : false}"
+  # /BETA features
 {% endif %}
 }
 

--- a/autogen/outputs.tf
+++ b/autogen/outputs.tf
@@ -113,7 +113,6 @@ output "service_account" {
   value       = "${local.service_account}"
 }
 {% if beta_cluster %}
-
 output "istio_enabled" {
   description = "Whether Istio is enabled"
   value       = "${local.cluster_istio_enabled}"
@@ -123,8 +122,6 @@ output "cloudrun_enabled" {
   description = "Whether CloudRun enabled"
   value       = "${local.cluster_cloudrun_enabled}"
 }
-{% endif %}
-{% if private_cluster %}
 
 output "pod_security_policy_enabled" {
   description = "Whether pod security policy is enabled"

--- a/autogen/variables.tf
+++ b/autogen/variables.tf
@@ -86,21 +86,6 @@ variable "master_authorized_networks_config" {
   default = []
 }
 
-{% if private_cluster %}
-variable "enable_binary_authorization" {
-  description = "Enable BinAuthZ Admission controller"
-  default     = false
-}
-
-variable "pod_security_policy_config" {
-  description = "enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created."
-
-  default     = [{
-    "enabled" = false
-  }]
-}
-
-{% endif %}
 variable "horizontal_pod_autoscaling" {
   description = "Enable horizontal pod autoscaling addon"
   default     = true
@@ -279,7 +264,6 @@ variable "master_ipv4_cidr_block" {
 }
 {% endif %}
 {% if beta_cluster %}
-
 variable "istio" {
   description = "(Beta) Enable Istio addon"
   default     = false
@@ -302,6 +286,18 @@ variable "database_encryption" {
   default     = [{
     state     = "DECRYPTED"
     key_name  = ""
+  }]
+}
+
+variable "enable_binary_authorization" {
+  description = "Enable BinAuthZ Admission controller"
+  default     = false
+}
+
+variable "pod_security_policy_config" {
+  description = "enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created."
+  default     = [{
+    "enabled" = false
   }]
 }
 {% endif %}

--- a/cluster_zonal.tf
+++ b/cluster_zonal.tf
@@ -42,6 +42,7 @@ resource "google_container_cluster" "zonal_primary" {
   logging_service    = "${var.logging_service}"
   monitoring_service = "${var.monitoring_service}"
 
+
   master_authorized_networks_config = ["${var.master_authorized_networks_config}"]
 
   master_auth {

--- a/modules/beta-private-cluster/cluster_zonal.tf
+++ b/modules/beta-private-cluster/cluster_zonal.tf
@@ -44,6 +44,7 @@ resource "google_container_cluster" "zonal_primary" {
 
   enable_binary_authorization       = "${var.enable_binary_authorization}"
   pod_security_policy_config        = "${var.pod_security_policy_config}"
+
   master_authorized_networks_config = ["${var.master_authorized_networks_config}"]
 
   master_auth {

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -133,6 +133,11 @@ locals {
     zonal    = "${element(concat(google_container_cluster.zonal_primary.*.addons_config.0.cloudrun_config.0.disabled, list("")), 0)}"
   }
 
+  cluster_type_output_pod_security_policy_enabled = {
+    regional = "${element(concat(google_container_cluster.primary.*.pod_security_policy_config.0.enabled, list("")), 0)}"
+    zonal    = "${element(concat(google_container_cluster.zonal_primary.*.pod_security_policy_config.0.enabled, list("")), 0)}"
+  }
+
   # /BETA features
 
   cluster_type_output_node_pools_names = {
@@ -142,10 +147,6 @@ locals {
   cluster_type_output_node_pools_versions = {
     regional = "${concat(google_container_node_pool.pools.*.version, list(""))}"
     zonal    = "${concat(google_container_node_pool.zonal_pools.*.version, list(""))}"
-  }
-  cluster_type_output_pod_security_policy_enabled = {
-    regional = "${element(concat(google_container_cluster.primary.*.pod_security_policy_config.0.enabled, list("")), 0)}"
-    zonal    = "${element(concat(google_container_cluster.zonal_primary.*.pod_security_policy_config.0.enabled, list("")), 0)}"
   }
   cluster_master_auth_list_layer1 = "${local.cluster_type_output_master_auth[local.cluster_type]}"
   cluster_master_auth_list_layer2 = "${local.cluster_master_auth_list_layer1[0]}"
@@ -170,8 +171,9 @@ locals {
   # BETA features
   cluster_istio_enabled    = "${local.cluster_type_output_istio_enabled[local.cluster_type] ? false : true}"
   cluster_cloudrun_enabled = "${local.cluster_type_output_cloudrun_enabled[local.cluster_type] ? false : true}"
-  # /BETA features
   cluster_pod_security_policy_enabled = "${local.cluster_type_output_pod_security_policy_enabled[local.cluster_type] ? true : false}"
+
+  # /BETA features
 }
 
 /******************************************

--- a/modules/beta-private-cluster/outputs.tf
+++ b/modules/beta-private-cluster/outputs.tf
@@ -112,7 +112,6 @@ output "service_account" {
   description = "The service account to default running nodes as if not overridden in `node_pools`."
   value       = "${local.service_account}"
 }
-
 output "istio_enabled" {
   description = "Whether Istio is enabled"
   value       = "${local.cluster_istio_enabled}"

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -86,19 +86,6 @@ variable "master_authorized_networks_config" {
   default = []
 }
 
-variable "enable_binary_authorization" {
-  description = "Enable BinAuthZ Admission controller"
-  default     = false
-}
-
-variable "pod_security_policy_config" {
-  description = "enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created."
-
-  default = [{
-    "enabled" = false
-  }]
-}
-
 variable "horizontal_pod_autoscaling" {
   description = "Enable horizontal pod autoscaling addon"
   default     = true
@@ -299,6 +286,19 @@ variable "database_encryption" {
   default = [{
     state    = "DECRYPTED"
     key_name = ""
+  }]
+}
+
+variable "enable_binary_authorization" {
+  description = "Enable BinAuthZ Admission controller"
+  default     = false
+}
+
+variable "pod_security_policy_config" {
+  description = "enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created."
+
+  default = [{
+    "enabled" = false
   }]
 }
 

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -124,6 +124,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | database\_encryption | Application-layer Secrets Encryption settings. Example:   database_encryption = [{     state = "ENCRYPTED",     key_name = "projects/my-project/locations/global/keyRings/my-ring/cryptoKeys/my-key"   }] | list | `<list>` | no |
 | description | The description of the cluster | string | `""` | no |
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | string | `"true"` | no |
+| enable\_binary\_authorization | Enable BinAuthZ Admission controller | string | `"false"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | string | `"true"` | no |
 | http\_load\_balancing | Enable httpload balancer addon | string | `"true"` | no |
 | initial\_node\_count | The number of nodes to create in this cluster's default node pool. | string | `"0"` | no |
@@ -152,6 +153,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | node\_pools\_taints | Map of lists containing node taints by node-pool name | map | `<map>` | no |
 | node\_version | The Kubernetes version of the node pools. Defaults kubernetes_version (master) variable and can be overridden for individual node pools by setting the `version` key on them. Must be empyty or set the same as master at cluster creation. | string | `""` | no |
 | non\_masquerade\_cidrs | List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading. | list | `<list>` | no |
+| pod\_security\_policy\_config | enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. | list | `<list>` | no |
 | project\_id | The project ID to host the cluster in (required) | string | n/a | yes |
 | region | The region to host the cluster in (required) | string | n/a | yes |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | string | `"true"` | no |
@@ -182,6 +184,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | network\_policy\_enabled | Whether network policy enabled |
 | node\_pools\_names | List of node pools names |
 | node\_pools\_versions | List of node pools versions |
+| pod\_security\_policy\_enabled | Whether pod security policy is enabled |
 | region | Cluster region |
 | service\_account | The service account to default running nodes as if not overridden in `node_pools`. |
 | type | Cluster type (regional / zonal) |

--- a/modules/beta-public-cluster/cluster_regional.tf
+++ b/modules/beta-public-cluster/cluster_regional.tf
@@ -42,6 +42,8 @@ resource "google_container_cluster" "primary" {
   logging_service    = "${var.logging_service}"
   monitoring_service = "${var.monitoring_service}"
 
+  enable_binary_authorization       = "${var.enable_binary_authorization}"
+  pod_security_policy_config        = "${var.pod_security_policy_config}"
   master_authorized_networks_config = ["${var.master_authorized_networks_config}"]
 
   master_auth {

--- a/modules/beta-public-cluster/cluster_zonal.tf
+++ b/modules/beta-public-cluster/cluster_zonal.tf
@@ -42,6 +42,9 @@ resource "google_container_cluster" "zonal_primary" {
   logging_service    = "${var.logging_service}"
   monitoring_service = "${var.monitoring_service}"
 
+  enable_binary_authorization       = "${var.enable_binary_authorization}"
+  pod_security_policy_config        = "${var.pod_security_policy_config}"
+
   master_authorized_networks_config = ["${var.master_authorized_networks_config}"]
 
   master_auth {

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -124,6 +124,11 @@ locals {
     zonal    = "${element(concat(google_container_cluster.zonal_primary.*.addons_config.0.cloudrun_config.0.disabled, list("")), 0)}"
   }
 
+  cluster_type_output_pod_security_policy_enabled = {
+    regional = "${element(concat(google_container_cluster.primary.*.pod_security_policy_config.0.enabled, list("")), 0)}"
+    zonal    = "${element(concat(google_container_cluster.zonal_primary.*.pod_security_policy_config.0.enabled, list("")), 0)}"
+  }
+
   # /BETA features
 
   cluster_type_output_node_pools_names = {
@@ -157,6 +162,7 @@ locals {
   # BETA features
   cluster_istio_enabled    = "${local.cluster_type_output_istio_enabled[local.cluster_type] ? false : true}"
   cluster_cloudrun_enabled = "${local.cluster_type_output_cloudrun_enabled[local.cluster_type] ? false : true}"
+  cluster_pod_security_policy_enabled = "${local.cluster_type_output_pod_security_policy_enabled[local.cluster_type] ? true : false}"
 
   # /BETA features
 }

--- a/modules/beta-public-cluster/outputs.tf
+++ b/modules/beta-public-cluster/outputs.tf
@@ -112,7 +112,6 @@ output "service_account" {
   description = "The service account to default running nodes as if not overridden in `node_pools`."
   value       = "${local.service_account}"
 }
-
 output "istio_enabled" {
   description = "Whether Istio is enabled"
   value       = "${local.cluster_istio_enabled}"
@@ -121,4 +120,9 @@ output "istio_enabled" {
 output "cloudrun_enabled" {
   description = "Whether CloudRun enabled"
   value       = "${local.cluster_cloudrun_enabled}"
+}
+
+output "pod_security_policy_enabled" {
+  description = "Whether pod security policy is enabled"
+  value       = "${local.cluster_pod_security_policy_enabled}"
 }

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -269,6 +269,19 @@ variable "database_encryption" {
   }]
 }
 
+variable "enable_binary_authorization" {
+  description = "Enable BinAuthZ Admission controller"
+  default     = false
+}
+
+variable "pod_security_policy_config" {
+  description = "enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created."
+
+  default = [{
+    "enabled" = false
+  }]
+}
+
 variable "basic_auth_username" {
   description = "The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration."
   default     = ""

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -126,7 +126,6 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | deploy\_using\_private\_endpoint | (Beta) A toggle for Terraform and kubectl to connect to the master's internal IP address during deployment. | string | `"false"` | no |
 | description | The description of the cluster | string | `""` | no |
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | string | `"true"` | no |
-| enable\_binary\_authorization | Enable BinAuthZ Admission controller | string | `"false"` | no |
 | enable\_private\_endpoint | (Beta) Whether the master's internal IP address is used as the cluster endpoint | string | `"false"` | no |
 | enable\_private\_nodes | (Beta) Whether nodes have internal IP addresses only | string | `"false"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | string | `"true"` | no |
@@ -157,7 +156,6 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | node\_pools\_taints | Map of lists containing node taints by node-pool name | map | `<map>` | no |
 | node\_version | The Kubernetes version of the node pools. Defaults kubernetes_version (master) variable and can be overridden for individual node pools by setting the `version` key on them. Must be empyty or set the same as master at cluster creation. | string | `""` | no |
 | non\_masquerade\_cidrs | List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading. | list | `<list>` | no |
-| pod\_security\_policy\_config | enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. | list | `<list>` | no |
 | project\_id | The project ID to host the cluster in (required) | string | n/a | yes |
 | region | The region to host the cluster in (required) | string | n/a | yes |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | string | `"true"` | no |
@@ -186,7 +184,6 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | network\_policy\_enabled | Whether network policy enabled |
 | node\_pools\_names | List of node pools names |
 | node\_pools\_versions | List of node pools versions |
-| pod\_security\_policy\_enabled | Whether pod security policy is enabled |
 | region | Cluster region |
 | service\_account | The service account to default running nodes as if not overridden in `node_pools`. |
 | type | Cluster type (regional / zonal) |

--- a/modules/private-cluster/cluster_regional.tf
+++ b/modules/private-cluster/cluster_regional.tf
@@ -42,8 +42,6 @@ resource "google_container_cluster" "primary" {
   logging_service    = "${var.logging_service}"
   monitoring_service = "${var.monitoring_service}"
 
-  enable_binary_authorization       = "${var.enable_binary_authorization}"
-  pod_security_policy_config        = "${var.pod_security_policy_config}"
   master_authorized_networks_config = ["${var.master_authorized_networks_config}"]
 
   master_auth {

--- a/modules/private-cluster/cluster_zonal.tf
+++ b/modules/private-cluster/cluster_zonal.tf
@@ -42,8 +42,7 @@ resource "google_container_cluster" "zonal_primary" {
   logging_service    = "${var.logging_service}"
   monitoring_service = "${var.monitoring_service}"
 
-  enable_binary_authorization       = "${var.enable_binary_authorization}"
-  pod_security_policy_config        = "${var.pod_security_policy_config}"
+
   master_authorized_networks_config = ["${var.master_authorized_networks_config}"]
 
   master_auth {

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -132,11 +132,6 @@ locals {
     zonal    = "${concat(google_container_node_pool.zonal_pools.*.version, list(""))}"
   }
 
-  cluster_type_output_pod_security_policy_enabled = {
-    regional = "${element(concat(google_container_cluster.primary.*.pod_security_policy_config.0.enabled, list("")), 0)}"
-    zonal    = "${element(concat(google_container_cluster.zonal_primary.*.pod_security_policy_config.0.enabled, list("")), 0)}"
-  }
-
   cluster_master_auth_list_layer1 = "${local.cluster_type_output_master_auth[local.cluster_type]}"
   cluster_master_auth_list_layer2 = "${local.cluster_master_auth_list_layer1[0]}"
   cluster_master_auth_map         = "${local.cluster_master_auth_list_layer2[0]}"
@@ -158,7 +153,6 @@ locals {
   cluster_http_load_balancing_enabled        = "${local.cluster_type_output_http_load_balancing_enabled[local.cluster_type] ? false : true}"
   cluster_horizontal_pod_autoscaling_enabled = "${local.cluster_type_output_horizontal_pod_autoscaling_enabled[local.cluster_type] ? false : true}"
   cluster_kubernetes_dashboard_enabled       = "${local.cluster_type_output_kubernetes_dashboard_enabled[local.cluster_type] ? false : true}"
-  cluster_pod_security_policy_enabled        = "${local.cluster_type_output_pod_security_policy_enabled[local.cluster_type] ? true : false}"
 }
 
 /******************************************

--- a/modules/private-cluster/outputs.tf
+++ b/modules/private-cluster/outputs.tf
@@ -112,8 +112,3 @@ output "service_account" {
   description = "The service account to default running nodes as if not overridden in `node_pools`."
   value       = "${local.service_account}"
 }
-
-output "pod_security_policy_enabled" {
-  description = "Whether pod security policy is enabled"
-  value       = "${local.cluster_pod_security_policy_enabled}"
-}

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -86,19 +86,6 @@ variable "master_authorized_networks_config" {
   default = []
 }
 
-variable "enable_binary_authorization" {
-  description = "Enable BinAuthZ Admission controller"
-  default     = false
-}
-
-variable "pod_security_policy_config" {
-  description = "enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created."
-
-  default = [{
-    "enabled" = false
-  }]
-}
-
 variable "horizontal_pod_autoscaling" {
   description = "Enable horizontal pod autoscaling addon"
   default     = true


### PR DESCRIPTION
  This allows pod security policies and binary authorization to be used
  by both beta private and  beta public clusters. Previously these two features
  where limited to only private clusters, and this commit also removes
 that functionality from private clusters.