### PR TITLE
Adding various beta features and code hygiene

### DIFF
--- a/autogen/cluster_regional.tf
+++ b/autogen/cluster_regional.tf
@@ -43,9 +43,18 @@ resource "google_container_cluster" "primary" {
   monitoring_service = "${var.monitoring_service}"
 
   {% if beta_cluster %}
-  enable_binary_authorization       = "${var.enable_binary_authorization}"
-  pod_security_policy_config        = "${var.pod_security_policy_config}"
+  database_encryption      = ["${var.database_encryption}"]
+  vertical_pod_autoscaling = "${list(map("enabled", var.vertical_pod_autoscaling))}"
+  workload_identity_config = "${list(map("identity_namespace", var.workload_identity_config))}"
+
+  authenticator_groups_config = "${var.authenticator_groups_config}"
+  default_max_pods_per_node   = "${var.default_max_pods_per_node}"
+  enable_intranode_visibility = "${var.enable_intranode_visibility}"
+  enable_binary_authorization = "${var.enable_binary_authorization}"
+  pod_security_policy_config  = "${var.pod_security_policy_config}"
   {% endif %}
+
+
   master_authorized_networks_config = ["${var.master_authorized_networks_config}"]
 
   master_auth {
@@ -124,9 +133,6 @@ resource "google_container_cluster" "primary" {
 {% endif %}
 
   remove_default_node_pool = "${var.remove_default_node_pool}"
-{% if beta_cluster %}
-  database_encryption      = ["${var.database_encryption}"]
-{% endif %}
 }
 
 /******************************************
@@ -185,6 +191,7 @@ resource "google_container_node_pool" "pools" {
     update = "30m"
     delete = "30m"
   }
+
 }
 
 resource "null_resource" "wait_for_regional_cluster" {

--- a/autogen/cluster_zonal.tf
+++ b/autogen/cluster_zonal.tf
@@ -43,8 +43,15 @@ resource "google_container_cluster" "zonal_primary" {
   monitoring_service = "${var.monitoring_service}"
 
   {% if beta_cluster %}
-  enable_binary_authorization       = "${var.enable_binary_authorization}"
-  pod_security_policy_config        = "${var.pod_security_policy_config}"
+  database_encryption      = ["${var.database_encryption}"]
+  vertical_pod_autoscaling = "${list(map("enabled", var.vertical_pod_autoscaling))}"
+  workload_identity_config = "${list(map("identity_namespace", var.workload_identity_config))}"
+
+  authenticator_groups_config = "${var.authenticator_groups_config}"
+  default_max_pods_per_node   = "${var.default_max_pods_per_node}"
+  enable_intranode_visibility = "${var.enable_intranode_visibility}"
+  enable_binary_authorization = "${var.enable_binary_authorization}"
+  pod_security_policy_config  = "${var.pod_security_policy_config}"
   {% endif %}
 
   master_authorized_networks_config = ["${var.master_authorized_networks_config}"]
@@ -75,7 +82,6 @@ resource "google_container_cluster" "zonal_primary" {
       disabled = "${var.network_policy ? 0 : 1}"
     }
     {% if beta_cluster %}
-
     istio_config {
       disabled = "${var.istio ? 0 : 1}"
     }
@@ -125,9 +131,6 @@ resource "google_container_cluster" "zonal_primary" {
 {% endif %}
 
   remove_default_node_pool = "${var.remove_default_node_pool}"
-{% if beta_cluster %}
-  database_encryption      = ["${var.database_encryption}"]
-{% endif %}
 }
 
 /******************************************

--- a/autogen/variables.tf
+++ b/autogen/variables.tf
@@ -300,6 +300,33 @@ variable "pod_security_policy_config" {
     "enabled" = false
   }]
 }
+
+variable "authenticator_groups_config" {
+  description = "Configuration for the Google Groups for GKE feature.  This block has a field named 'security_group' which lists RBAC security group for use with Google security groups in Kubernetes RBAC."
+  default = []
+}
+
+
+variable "vertical_pod_autoscaling" {
+  description = "Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it."
+  default     =  false
+}
+
+// TODO document "UNSPECIFIED", "SECURE", "EXPOSE", "GKE_METADATA_SERVER"
+variable "workload_identity_config" {
+  description = "Workload Identity allows Kubernetes service accounts to act as a user-managed Google IAM Service Account."
+  default = "UNSPECIFIED"
+}
+
+variable "enable_intranode_visibility" {
+  description = "Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network."
+  default = "false"
+}
+
+variable "default_max_pods_per_node" {
+  description = "The default maximum number of pods per node in this cluster. Note that this does not work on node pools which are 'route-based' - that is, node pools belonging to clusters that do not have IP Aliasing enabled."
+  default = "110"
+}
 {% endif %}
 
 variable "basic_auth_username" {

--- a/cluster_regional.tf
+++ b/cluster_regional.tf
@@ -42,6 +42,8 @@ resource "google_container_cluster" "primary" {
   logging_service    = "${var.logging_service}"
   monitoring_service = "${var.monitoring_service}"
 
+
+
   master_authorized_networks_config = ["${var.master_authorized_networks_config}"]
 
   master_auth {
@@ -160,6 +162,7 @@ resource "google_container_node_pool" "pools" {
     update = "30m"
     delete = "30m"
   }
+
 }
 
 resource "null_resource" "wait_for_regional_cluster" {

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -121,16 +121,19 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| authenticator\_groups\_config | Configuration for the Google Groups for GKE feature.  This block has a field named 'security_group' which lists RBAC security group for use with Google security groups in Kubernetes RBAC. | list | `<list>` | no |
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |
 | cloudrun | (Beta) Enable CloudRun addon | string | `"false"` | no |
 | cluster\_ipv4\_cidr | The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR. | string | `""` | no |
 | configure\_ip\_masq | Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server. | string | `"false"` | no |
 | database\_encryption | Application-layer Secrets Encryption settings. Example:   database_encryption = [{     state = "ENCRYPTED",     key_name = "projects/my-project/locations/global/keyRings/my-ring/cryptoKeys/my-key"   }] | list | `<list>` | no |
+| default\_max\_pods\_per\_node | The default maximum number of pods per node in this cluster. Note that this does not work on node pools which are 'route-based' - that is, node pools belonging to clusters that do not have IP Aliasing enabled. | string | `"110"` | no |
 | deploy\_using\_private\_endpoint | (Beta) A toggle for Terraform and kubectl to connect to the master's internal IP address during deployment. | string | `"false"` | no |
 | description | The description of the cluster | string | `""` | no |
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | string | `"true"` | no |
 | enable\_binary\_authorization | Enable BinAuthZ Admission controller | string | `"false"` | no |
+| enable\_intranode\_visibility | Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network. | string | `"false"` | no |
 | enable\_private\_endpoint | (Beta) Whether the master's internal IP address is used as the cluster endpoint | string | `"false"` | no |
 | enable\_private\_nodes | (Beta) Whether nodes have internal IP addresses only | string | `"false"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | string | `"true"` | no |
@@ -170,6 +173,8 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | service\_account | The service account to run nodes as if not overridden in `node_pools`. The default value will cause a cluster-specific service account to be created. | string | `"create"` | no |
 | stub\_domains | Map of stub domains and their resolvers to forward DNS queries for a certain domain to an external DNS server | map | `<map>` | no |
 | subnetwork | The subnetwork to host the cluster in (required) | string | n/a | yes |
+| vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it. | string | `"false"` | no |
+| workload\_identity\_config | Workload Identity allows Kubernetes service accounts to act as a user-managed Google IAM Service Account. | string | `"UNSPECIFIED"` | no |
 | zones | The zones to host the cluster in (optional if regional cluster / required if zonal) | list | `<list>` | no |
 
 ## Outputs

--- a/modules/beta-private-cluster/cluster_regional.tf
+++ b/modules/beta-private-cluster/cluster_regional.tf
@@ -42,8 +42,17 @@ resource "google_container_cluster" "primary" {
   logging_service    = "${var.logging_service}"
   monitoring_service = "${var.monitoring_service}"
 
-  enable_binary_authorization       = "${var.enable_binary_authorization}"
-  pod_security_policy_config        = "${var.pod_security_policy_config}"
+  database_encryption      = ["${var.database_encryption}"]
+  vertical_pod_autoscaling = "${list(map("enabled", var.vertical_pod_autoscaling))}"
+  workload_identity_config = "${list(map("identity_namespace", var.workload_identity_config))}"
+
+  authenticator_groups_config = "${var.authenticator_groups_config}"
+  default_max_pods_per_node   = "${var.default_max_pods_per_node}"
+  enable_intranode_visibility = "${var.enable_intranode_visibility}"
+  enable_binary_authorization = "${var.enable_binary_authorization}"
+  pod_security_policy_config  = "${var.pod_security_policy_config}"
+
+
   master_authorized_networks_config = ["${var.master_authorized_networks_config}"]
 
   master_auth {
@@ -118,7 +127,6 @@ resource "google_container_cluster" "primary" {
   }
 
   remove_default_node_pool = "${var.remove_default_node_pool}"
-  database_encryption      = ["${var.database_encryption}"]
 }
 
 /******************************************
@@ -177,6 +185,7 @@ resource "google_container_node_pool" "pools" {
     update = "30m"
     delete = "30m"
   }
+
 }
 
 resource "null_resource" "wait_for_regional_cluster" {

--- a/modules/beta-private-cluster/cluster_zonal.tf
+++ b/modules/beta-private-cluster/cluster_zonal.tf
@@ -42,8 +42,15 @@ resource "google_container_cluster" "zonal_primary" {
   logging_service    = "${var.logging_service}"
   monitoring_service = "${var.monitoring_service}"
 
-  enable_binary_authorization       = "${var.enable_binary_authorization}"
-  pod_security_policy_config        = "${var.pod_security_policy_config}"
+  database_encryption      = ["${var.database_encryption}"]
+  vertical_pod_autoscaling = "${list(map("enabled", var.vertical_pod_autoscaling))}"
+  workload_identity_config = "${list(map("identity_namespace", var.workload_identity_config))}"
+
+  authenticator_groups_config = "${var.authenticator_groups_config}"
+  default_max_pods_per_node   = "${var.default_max_pods_per_node}"
+  enable_intranode_visibility = "${var.enable_intranode_visibility}"
+  enable_binary_authorization = "${var.enable_binary_authorization}"
+  pod_security_policy_config  = "${var.pod_security_policy_config}"
 
   master_authorized_networks_config = ["${var.master_authorized_networks_config}"]
 
@@ -72,7 +79,6 @@ resource "google_container_cluster" "zonal_primary" {
     network_policy_config {
       disabled = "${var.network_policy ? 0 : 1}"
     }
-
     istio_config {
       disabled = "${var.istio ? 0 : 1}"
     }
@@ -119,7 +125,6 @@ resource "google_container_cluster" "zonal_primary" {
   }
 
   remove_default_node_pool = "${var.remove_default_node_pool}"
-  database_encryption      = ["${var.database_encryption}"]
 }
 
 /******************************************

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -302,6 +302,32 @@ variable "pod_security_policy_config" {
   }]
 }
 
+variable "authenticator_groups_config" {
+  description = "Configuration for the Google Groups for GKE feature.  This block has a field named 'security_group' which lists RBAC security group for use with Google security groups in Kubernetes RBAC."
+  default     = []
+}
+
+variable "vertical_pod_autoscaling" {
+  description = "Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it."
+  default     = false
+}
+
+// TODO document "UNSPECIFIED", "SECURE", "EXPOSE", "GKE_METADATA_SERVER"
+variable "workload_identity_config" {
+  description = "Workload Identity allows Kubernetes service accounts to act as a user-managed Google IAM Service Account."
+  default     = "UNSPECIFIED"
+}
+
+variable "enable_intranode_visibility" {
+  description = "Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network."
+  default     = "false"
+}
+
+variable "default_max_pods_per_node" {
+  description = "The default maximum number of pods per node in this cluster. Note that this does not work on node pools which are 'route-based' - that is, node pools belonging to clusters that do not have IP Aliasing enabled."
+  default     = "110"
+}
+
 variable "basic_auth_username" {
   description = "The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration."
   default     = ""

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -116,15 +116,18 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| authenticator\_groups\_config | Configuration for the Google Groups for GKE feature.  This block has a field named 'security_group' which lists RBAC security group for use with Google security groups in Kubernetes RBAC. | list | `<list>` | no |
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |
 | cloudrun | (Beta) Enable CloudRun addon | string | `"false"` | no |
 | cluster\_ipv4\_cidr | The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR. | string | `""` | no |
 | configure\_ip\_masq | Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server. | string | `"false"` | no |
 | database\_encryption | Application-layer Secrets Encryption settings. Example:   database_encryption = [{     state = "ENCRYPTED",     key_name = "projects/my-project/locations/global/keyRings/my-ring/cryptoKeys/my-key"   }] | list | `<list>` | no |
+| default\_max\_pods\_per\_node | The default maximum number of pods per node in this cluster. Note that this does not work on node pools which are 'route-based' - that is, node pools belonging to clusters that do not have IP Aliasing enabled. | string | `"110"` | no |
 | description | The description of the cluster | string | `""` | no |
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | string | `"true"` | no |
 | enable\_binary\_authorization | Enable BinAuthZ Admission controller | string | `"false"` | no |
+| enable\_intranode\_visibility | Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network. | string | `"false"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | string | `"true"` | no |
 | http\_load\_balancing | Enable httpload balancer addon | string | `"true"` | no |
 | initial\_node\_count | The number of nodes to create in this cluster's default node pool. | string | `"0"` | no |
@@ -161,6 +164,8 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | service\_account | The service account to run nodes as if not overridden in `node_pools`. The default value will cause a cluster-specific service account to be created. | string | `"create"` | no |
 | stub\_domains | Map of stub domains and their resolvers to forward DNS queries for a certain domain to an external DNS server | map | `<map>` | no |
 | subnetwork | The subnetwork to host the cluster in (required) | string | n/a | yes |
+| vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it. | string | `"false"` | no |
+| workload\_identity\_config | Workload Identity allows Kubernetes service accounts to act as a user-managed Google IAM Service Account. | string | `"UNSPECIFIED"` | no |
 | zones | The zones to host the cluster in (optional if regional cluster / required if zonal) | list | `<list>` | no |
 
 ## Outputs

--- a/modules/beta-public-cluster/cluster_regional.tf
+++ b/modules/beta-public-cluster/cluster_regional.tf
@@ -42,8 +42,17 @@ resource "google_container_cluster" "primary" {
   logging_service    = "${var.logging_service}"
   monitoring_service = "${var.monitoring_service}"
 
-  enable_binary_authorization       = "${var.enable_binary_authorization}"
-  pod_security_policy_config        = "${var.pod_security_policy_config}"
+  database_encryption      = ["${var.database_encryption}"]
+  vertical_pod_autoscaling = "${list(map("enabled", var.vertical_pod_autoscaling))}"
+  workload_identity_config = "${list(map("identity_namespace", var.workload_identity_config))}"
+
+  authenticator_groups_config = "${var.authenticator_groups_config}"
+  default_max_pods_per_node   = "${var.default_max_pods_per_node}"
+  enable_intranode_visibility = "${var.enable_intranode_visibility}"
+  enable_binary_authorization = "${var.enable_binary_authorization}"
+  pod_security_policy_config  = "${var.pod_security_policy_config}"
+
+
   master_authorized_networks_config = ["${var.master_authorized_networks_config}"]
 
   master_auth {
@@ -112,7 +121,6 @@ resource "google_container_cluster" "primary" {
   }
 
   remove_default_node_pool = "${var.remove_default_node_pool}"
-  database_encryption      = ["${var.database_encryption}"]
 }
 
 /******************************************
@@ -171,6 +179,7 @@ resource "google_container_node_pool" "pools" {
     update = "30m"
     delete = "30m"
   }
+
 }
 
 resource "null_resource" "wait_for_regional_cluster" {

--- a/modules/beta-public-cluster/cluster_zonal.tf
+++ b/modules/beta-public-cluster/cluster_zonal.tf
@@ -42,8 +42,15 @@ resource "google_container_cluster" "zonal_primary" {
   logging_service    = "${var.logging_service}"
   monitoring_service = "${var.monitoring_service}"
 
-  enable_binary_authorization       = "${var.enable_binary_authorization}"
-  pod_security_policy_config        = "${var.pod_security_policy_config}"
+  database_encryption      = ["${var.database_encryption}"]
+  vertical_pod_autoscaling = "${list(map("enabled", var.vertical_pod_autoscaling))}"
+  workload_identity_config = "${list(map("identity_namespace", var.workload_identity_config))}"
+
+  authenticator_groups_config = "${var.authenticator_groups_config}"
+  default_max_pods_per_node   = "${var.default_max_pods_per_node}"
+  enable_intranode_visibility = "${var.enable_intranode_visibility}"
+  enable_binary_authorization = "${var.enable_binary_authorization}"
+  pod_security_policy_config  = "${var.pod_security_policy_config}"
 
   master_authorized_networks_config = ["${var.master_authorized_networks_config}"]
 
@@ -72,7 +79,6 @@ resource "google_container_cluster" "zonal_primary" {
     network_policy_config {
       disabled = "${var.network_policy ? 0 : 1}"
     }
-
     istio_config {
       disabled = "${var.istio ? 0 : 1}"
     }
@@ -113,7 +119,6 @@ resource "google_container_cluster" "zonal_primary" {
   }
 
   remove_default_node_pool = "${var.remove_default_node_pool}"
-  database_encryption      = ["${var.database_encryption}"]
 }
 
 /******************************************

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -282,6 +282,32 @@ variable "pod_security_policy_config" {
   }]
 }
 
+variable "authenticator_groups_config" {
+  description = "Configuration for the Google Groups for GKE feature.  This block has a field named 'security_group' which lists RBAC security group for use with Google security groups in Kubernetes RBAC."
+  default     = []
+}
+
+variable "vertical_pod_autoscaling" {
+  description = "Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it."
+  default     = false
+}
+
+// TODO document "UNSPECIFIED", "SECURE", "EXPOSE", "GKE_METADATA_SERVER"
+variable "workload_identity_config" {
+  description = "Workload Identity allows Kubernetes service accounts to act as a user-managed Google IAM Service Account."
+  default     = "UNSPECIFIED"
+}
+
+variable "enable_intranode_visibility" {
+  description = "Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network."
+  default     = "false"
+}
+
+variable "default_max_pods_per_node" {
+  description = "The default maximum number of pods per node in this cluster. Note that this does not work on node pools which are 'route-based' - that is, node pools belonging to clusters that do not have IP Aliasing enabled."
+  default     = "110"
+}
+
 variable "basic_auth_username" {
   description = "The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration."
   default     = ""

--- a/modules/private-cluster/cluster_regional.tf
+++ b/modules/private-cluster/cluster_regional.tf
@@ -42,6 +42,8 @@ resource "google_container_cluster" "primary" {
   logging_service    = "${var.logging_service}"
   monitoring_service = "${var.monitoring_service}"
 
+
+
   master_authorized_networks_config = ["${var.master_authorized_networks_config}"]
 
   master_auth {
@@ -166,6 +168,7 @@ resource "google_container_node_pool" "pools" {
     update = "30m"
     delete = "30m"
   }
+
 }
 
 resource "null_resource" "wait_for_regional_cluster" {


### PR DESCRIPTION
This PR completes some basic code hygiene. We moved the database
encryption block in the same if statement as the other beta components.

With this commit we include various beta features that are supported at this time:

Cluster Configurations

- authenticator_groups_config
- vertical_pod_autoscaling
- workload_identity_config
- enable_intranode_visibility
- default_max_pods_per_node

We have TPU, some nodepool options, and other beta features that I have not put in this PR.
Will revisit in later PRs.

This has been tested using the 2.9.1 google provider.  Upgrading the examples to that
provider will occur in a different PR.