### PR TITLE
Patch breaking changes

### DIFF
--- a/autogen/cluster_regional.tf
+++ b/autogen/cluster_regional.tf
@@ -30,11 +30,7 @@ resource "google_container_cluster" "primary" {
   node_locations    = ["${coalescelist(compact(var.zones), sort(random_shuffle.available_zones.result))}"]
   cluster_ipv4_cidr = "${var.cluster_ipv4_cidr}"
   network           = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
-
-  network_policy {
-    enabled  = "${var.network_policy}"
-    provider = "${var.network_policy_provider}"
-  }
+  network_policy    = "${local.cluster_network_policy["${var.network_policy ? "enabled" : "disabled"}"]}"
 
   subnetwork         = "${replace(data.google_compute_subnetwork.gke_subnetwork.self_link, "https://www.googleapis.com/compute/v1/", "")}"
   min_master_version = "${local.kubernetes_version_regional}"

--- a/autogen/cluster_regional.tf
+++ b/autogen/cluster_regional.tf
@@ -75,9 +75,7 @@ resource "google_container_cluster" "primary" {
       disabled = "${var.istio ? 0 : 1}"
     }
 
-    cloudrun_config {
-      disabled = "${var.cloudrun ? 0 : 1}"
-    }
+    cloudrun_config = "${local.cluster_cloudrun_config["${var.cloudrun ? "enabled" : "disabled"}"]}"
     {% endif %}
   }
 

--- a/autogen/cluster_zonal.tf
+++ b/autogen/cluster_zonal.tf
@@ -30,11 +30,7 @@ resource "google_container_cluster" "zonal_primary" {
   node_locations    = ["${slice(var.zones,1,length(var.zones))}"]
   cluster_ipv4_cidr = "${var.cluster_ipv4_cidr}"
   network           = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
-
-  network_policy {
-    enabled  = "${var.network_policy}"
-    provider = "${var.network_policy_provider}"
-  }
+  network_policy    = "${local.cluster_network_policy["${var.network_policy ? "enabled" : "disabled"}"]}"
 
   subnetwork         = "${replace(data.google_compute_subnetwork.gke_subnetwork.self_link, "https://www.googleapis.com/compute/v1/", "")}"
   min_master_version = "${local.kubernetes_version_zonal}"

--- a/autogen/cluster_zonal.tf
+++ b/autogen/cluster_zonal.tf
@@ -76,9 +76,7 @@ resource "google_container_cluster" "zonal_primary" {
       disabled = "${var.istio ? 0 : 1}"
     }
 
-    cloudrun_config {
-      disabled = "${var.cloudrun ? 0 : 1}"
-    }
+    cloudrun_config = "${local.cluster_cloudrun_config["${var.cloudrun ? "enabled" : "disabled"}"]}"
     {% endif %}
   }
 

--- a/autogen/main.tf
+++ b/autogen/main.tf
@@ -48,6 +48,11 @@ locals {
     disabled = [{enabled = "false"}]
   }
 
+  cluster_cloudrun_config = {
+    enabled  = [{disabled = "false"}]
+    disabled = []
+  }
+
   cluster_type_output_name = {
     regional = "${element(concat(google_container_cluster.primary.*.name, list("")), 0)}"
     zonal    = "${element(concat(google_container_cluster.zonal_primary.*.name, list("")), 0)}"
@@ -144,10 +149,6 @@ locals {
     zonal    = "${element(concat(google_container_cluster.zonal_primary.*.addons_config.0.istio_config.0.disabled, list("")), 0)}"
   }
 
-  cluster_type_output_cloudrun_enabled = {
-    regional = "${element(concat(google_container_cluster.primary.*.addons_config.0.cloudrun_config.0.disabled, list("")), 0)}"
-    zonal    = "${element(concat(google_container_cluster.zonal_primary.*.addons_config.0.cloudrun_config.0.disabled, list("")), 0)}"
-  }
   cluster_type_output_pod_security_policy_enabled = {
     regional = "${element(concat(google_container_cluster.primary.*.pod_security_policy_config.0.enabled, list("")), 0)}"
     zonal    = "${element(concat(google_container_cluster.zonal_primary.*.pod_security_policy_config.0.enabled, list("")), 0)}"
@@ -188,7 +189,7 @@ locals {
 {% if beta_cluster %}
   # BETA features
   cluster_istio_enabled    = "${local.cluster_type_output_istio_enabled[local.cluster_type] ? false : true}"
-  cluster_cloudrun_enabled = "${local.cluster_type_output_cloudrun_enabled[local.cluster_type] ? false : true}"
+  cluster_cloudrun_enabled = "${var.cloudrun}"
 
   cluster_pod_security_policy_enabled        = "${local.cluster_type_output_pod_security_policy_enabled[local.cluster_type] ? true : false}"
   # /BETA features

--- a/autogen/main.tf
+++ b/autogen/main.tf
@@ -40,6 +40,14 @@ locals {
 
   cluster_type = "${var.regional ? "regional" : "zonal"}"
 
+  cluster_network_policy = {
+    enabled = [{
+      enabled  = "true"
+      provider = "${var.network_policy_provider}"
+    }]
+    disabled = [{enabled = "false"}]
+  }
+
   cluster_type_output_name = {
     regional = "${element(concat(google_container_cluster.primary.*.name, list("")), 0)}"
     zonal    = "${element(concat(google_container_cluster.zonal_primary.*.name, list("")), 0)}"

--- a/cluster_regional.tf
+++ b/cluster_regional.tf
@@ -30,11 +30,7 @@ resource "google_container_cluster" "primary" {
   node_locations    = ["${coalescelist(compact(var.zones), sort(random_shuffle.available_zones.result))}"]
   cluster_ipv4_cidr = "${var.cluster_ipv4_cidr}"
   network           = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
-
-  network_policy {
-    enabled  = "${var.network_policy}"
-    provider = "${var.network_policy_provider}"
-  }
+  network_policy    = "${local.cluster_network_policy["${var.network_policy ? "enabled" : "disabled"}"]}"
 
   subnetwork         = "${replace(data.google_compute_subnetwork.gke_subnetwork.self_link, "https://www.googleapis.com/compute/v1/", "")}"
   min_master_version = "${local.kubernetes_version_regional}"

--- a/cluster_zonal.tf
+++ b/cluster_zonal.tf
@@ -30,11 +30,7 @@ resource "google_container_cluster" "zonal_primary" {
   node_locations    = ["${slice(var.zones,1,length(var.zones))}"]
   cluster_ipv4_cidr = "${var.cluster_ipv4_cidr}"
   network           = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
-
-  network_policy {
-    enabled  = "${var.network_policy}"
-    provider = "${var.network_policy_provider}"
-  }
+  network_policy    = "${local.cluster_network_policy["${var.network_policy ? "enabled" : "disabled"}"]}"
 
   subnetwork         = "${replace(data.google_compute_subnetwork.gke_subnetwork.self_link, "https://www.googleapis.com/compute/v1/", "")}"
   min_master_version = "${local.kubernetes_version_zonal}"

--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,25 @@ locals {
 
   cluster_type = "${var.regional ? "regional" : "zonal"}"
 
+  cluster_network_policy = {
+    enabled = [{
+      enabled  = "true"
+      provider = "${var.network_policy_provider}"
+    }]
+
+    disabled = [{
+      enabled = "false"
+    }]
+  }
+
+  cluster_cloudrun_config = {
+    enabled = [{
+      disabled = "false"
+    }]
+
+    disabled = []
+  }
+
   cluster_type_output_name = {
     regional = "${element(concat(google_container_cluster.primary.*.name, list("")), 0)}"
     zonal    = "${element(concat(google_container_cluster.zonal_primary.*.name, list("")), 0)}"

--- a/modules/beta-private-cluster/cluster_regional.tf
+++ b/modules/beta-private-cluster/cluster_regional.tf
@@ -30,11 +30,7 @@ resource "google_container_cluster" "primary" {
   node_locations    = ["${coalescelist(compact(var.zones), sort(random_shuffle.available_zones.result))}"]
   cluster_ipv4_cidr = "${var.cluster_ipv4_cidr}"
   network           = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
-
-  network_policy {
-    enabled  = "${var.network_policy}"
-    provider = "${var.network_policy_provider}"
-  }
+  network_policy    = "${local.cluster_network_policy["${var.network_policy ? "enabled" : "disabled"}"]}"
 
   subnetwork         = "${replace(data.google_compute_subnetwork.gke_subnetwork.self_link, "https://www.googleapis.com/compute/v1/", "")}"
   min_master_version = "${local.kubernetes_version_regional}"
@@ -76,9 +72,7 @@ resource "google_container_cluster" "primary" {
       disabled = "${var.istio ? 0 : 1}"
     }
 
-    cloudrun_config {
-      disabled = "${var.cloudrun ? 0 : 1}"
-    }
+    cloudrun_config = "${local.cluster_cloudrun_config["${var.cloudrun ? "enabled" : "disabled"}"]}"
   }
 
   ip_allocation_policy {

--- a/modules/beta-private-cluster/cluster_zonal.tf
+++ b/modules/beta-private-cluster/cluster_zonal.tf
@@ -30,11 +30,7 @@ resource "google_container_cluster" "zonal_primary" {
   node_locations    = ["${slice(var.zones,1,length(var.zones))}"]
   cluster_ipv4_cidr = "${var.cluster_ipv4_cidr}"
   network           = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
-
-  network_policy {
-    enabled  = "${var.network_policy}"
-    provider = "${var.network_policy_provider}"
-  }
+  network_policy    = "${local.cluster_network_policy["${var.network_policy ? "enabled" : "disabled"}"]}"
 
   subnetwork         = "${replace(data.google_compute_subnetwork.gke_subnetwork.self_link, "https://www.googleapis.com/compute/v1/", "")}"
   min_master_version = "${local.kubernetes_version_zonal}"
@@ -77,9 +73,7 @@ resource "google_container_cluster" "zonal_primary" {
       disabled = "${var.istio ? 0 : 1}"
     }
 
-    cloudrun_config {
-      disabled = "${var.cloudrun ? 0 : 1}"
-    }
+    cloudrun_config = "${local.cluster_cloudrun_config["${var.cloudrun ? "enabled" : "disabled"}"]}"
   }
 
   ip_allocation_policy {

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -40,6 +40,25 @@ locals {
 
   cluster_type = "${var.regional ? "regional" : "zonal"}"
 
+  cluster_network_policy = {
+    enabled = [{
+      enabled  = "true"
+      provider = "${var.network_policy_provider}"
+    }]
+
+    disabled = [{
+      enabled = "false"
+    }]
+  }
+
+  cluster_cloudrun_config = {
+    enabled = [{
+      disabled = "false"
+    }]
+
+    disabled = []
+  }
+
   cluster_type_output_name = {
     regional = "${element(concat(google_container_cluster.primary.*.name, list("")), 0)}"
     zonal    = "${element(concat(google_container_cluster.zonal_primary.*.name, list("")), 0)}"
@@ -128,11 +147,6 @@ locals {
     zonal    = "${element(concat(google_container_cluster.zonal_primary.*.addons_config.0.istio_config.0.disabled, list("")), 0)}"
   }
 
-  cluster_type_output_cloudrun_enabled = {
-    regional = "${element(concat(google_container_cluster.primary.*.addons_config.0.cloudrun_config.0.disabled, list("")), 0)}"
-    zonal    = "${element(concat(google_container_cluster.zonal_primary.*.addons_config.0.cloudrun_config.0.disabled, list("")), 0)}"
-  }
-
   cluster_type_output_pod_security_policy_enabled = {
     regional = "${element(concat(google_container_cluster.primary.*.pod_security_policy_config.0.enabled, list("")), 0)}"
     zonal    = "${element(concat(google_container_cluster.zonal_primary.*.pod_security_policy_config.0.enabled, list("")), 0)}"
@@ -170,7 +184,7 @@ locals {
   cluster_kubernetes_dashboard_enabled       = "${local.cluster_type_output_kubernetes_dashboard_enabled[local.cluster_type] ? false : true}"
   # BETA features
   cluster_istio_enabled    = "${local.cluster_type_output_istio_enabled[local.cluster_type] ? false : true}"
-  cluster_cloudrun_enabled = "${local.cluster_type_output_cloudrun_enabled[local.cluster_type] ? false : true}"
+  cluster_cloudrun_enabled = "${var.cloudrun}"
   cluster_pod_security_policy_enabled = "${local.cluster_type_output_pod_security_policy_enabled[local.cluster_type] ? true : false}"
 
   # /BETA features

--- a/modules/beta-public-cluster/cluster_regional.tf
+++ b/modules/beta-public-cluster/cluster_regional.tf
@@ -30,11 +30,7 @@ resource "google_container_cluster" "primary" {
   node_locations    = ["${coalescelist(compact(var.zones), sort(random_shuffle.available_zones.result))}"]
   cluster_ipv4_cidr = "${var.cluster_ipv4_cidr}"
   network           = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
-
-  network_policy {
-    enabled  = "${var.network_policy}"
-    provider = "${var.network_policy_provider}"
-  }
+  network_policy    = "${local.cluster_network_policy["${var.network_policy ? "enabled" : "disabled"}"]}"
 
   subnetwork         = "${replace(data.google_compute_subnetwork.gke_subnetwork.self_link, "https://www.googleapis.com/compute/v1/", "")}"
   min_master_version = "${local.kubernetes_version_regional}"
@@ -76,9 +72,7 @@ resource "google_container_cluster" "primary" {
       disabled = "${var.istio ? 0 : 1}"
     }
 
-    cloudrun_config {
-      disabled = "${var.cloudrun ? 0 : 1}"
-    }
+    cloudrun_config = "${local.cluster_cloudrun_config["${var.cloudrun ? "enabled" : "disabled"}"]}"
   }
 
   ip_allocation_policy {

--- a/modules/beta-public-cluster/cluster_zonal.tf
+++ b/modules/beta-public-cluster/cluster_zonal.tf
@@ -30,11 +30,7 @@ resource "google_container_cluster" "zonal_primary" {
   node_locations    = ["${slice(var.zones,1,length(var.zones))}"]
   cluster_ipv4_cidr = "${var.cluster_ipv4_cidr}"
   network           = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
-
-  network_policy {
-    enabled  = "${var.network_policy}"
-    provider = "${var.network_policy_provider}"
-  }
+  network_policy    = "${local.cluster_network_policy["${var.network_policy ? "enabled" : "disabled"}"]}"
 
   subnetwork         = "${replace(data.google_compute_subnetwork.gke_subnetwork.self_link, "https://www.googleapis.com/compute/v1/", "")}"
   min_master_version = "${local.kubernetes_version_zonal}"
@@ -77,9 +73,7 @@ resource "google_container_cluster" "zonal_primary" {
       disabled = "${var.istio ? 0 : 1}"
     }
 
-    cloudrun_config {
-      disabled = "${var.cloudrun ? 0 : 1}"
-    }
+    cloudrun_config = "${local.cluster_cloudrun_config["${var.cloudrun ? "enabled" : "disabled"}"]}"
   }
 
   ip_allocation_policy {

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -40,6 +40,25 @@ locals {
 
   cluster_type = "${var.regional ? "regional" : "zonal"}"
 
+  cluster_network_policy = {
+    enabled = [{
+      enabled  = "true"
+      provider = "${var.network_policy_provider}"
+    }]
+
+    disabled = [{
+      enabled = "false"
+    }]
+  }
+
+  cluster_cloudrun_config = {
+    enabled = [{
+      disabled = "false"
+    }]
+
+    disabled = []
+  }
+
   cluster_type_output_name = {
     regional = "${element(concat(google_container_cluster.primary.*.name, list("")), 0)}"
     zonal    = "${element(concat(google_container_cluster.zonal_primary.*.name, list("")), 0)}"
@@ -119,11 +138,6 @@ locals {
     zonal    = "${element(concat(google_container_cluster.zonal_primary.*.addons_config.0.istio_config.0.disabled, list("")), 0)}"
   }
 
-  cluster_type_output_cloudrun_enabled = {
-    regional = "${element(concat(google_container_cluster.primary.*.addons_config.0.cloudrun_config.0.disabled, list("")), 0)}"
-    zonal    = "${element(concat(google_container_cluster.zonal_primary.*.addons_config.0.cloudrun_config.0.disabled, list("")), 0)}"
-  }
-
   cluster_type_output_pod_security_policy_enabled = {
     regional = "${element(concat(google_container_cluster.primary.*.pod_security_policy_config.0.enabled, list("")), 0)}"
     zonal    = "${element(concat(google_container_cluster.zonal_primary.*.pod_security_policy_config.0.enabled, list("")), 0)}"
@@ -161,7 +175,7 @@ locals {
   cluster_kubernetes_dashboard_enabled       = "${local.cluster_type_output_kubernetes_dashboard_enabled[local.cluster_type] ? false : true}"
   # BETA features
   cluster_istio_enabled    = "${local.cluster_type_output_istio_enabled[local.cluster_type] ? false : true}"
-  cluster_cloudrun_enabled = "${local.cluster_type_output_cloudrun_enabled[local.cluster_type] ? false : true}"
+  cluster_cloudrun_enabled = "${var.cloudrun}"
   cluster_pod_security_policy_enabled = "${local.cluster_type_output_pod_security_policy_enabled[local.cluster_type] ? true : false}"
 
   # /BETA features

--- a/modules/private-cluster/cluster_regional.tf
+++ b/modules/private-cluster/cluster_regional.tf
@@ -30,11 +30,7 @@ resource "google_container_cluster" "primary" {
   node_locations    = ["${coalescelist(compact(var.zones), sort(random_shuffle.available_zones.result))}"]
   cluster_ipv4_cidr = "${var.cluster_ipv4_cidr}"
   network           = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
-
-  network_policy {
-    enabled  = "${var.network_policy}"
-    provider = "${var.network_policy_provider}"
-  }
+  network_policy    = "${local.cluster_network_policy["${var.network_policy ? "enabled" : "disabled"}"]}"
 
   subnetwork         = "${replace(data.google_compute_subnetwork.gke_subnetwork.self_link, "https://www.googleapis.com/compute/v1/", "")}"
   min_master_version = "${local.kubernetes_version_regional}"

--- a/modules/private-cluster/cluster_zonal.tf
+++ b/modules/private-cluster/cluster_zonal.tf
@@ -30,11 +30,7 @@ resource "google_container_cluster" "zonal_primary" {
   node_locations    = ["${slice(var.zones,1,length(var.zones))}"]
   cluster_ipv4_cidr = "${var.cluster_ipv4_cidr}"
   network           = "${replace(data.google_compute_network.gke_network.self_link, "https://www.googleapis.com/compute/v1/", "")}"
-
-  network_policy {
-    enabled  = "${var.network_policy}"
-    provider = "${var.network_policy_provider}"
-  }
+  network_policy    = "${local.cluster_network_policy["${var.network_policy ? "enabled" : "disabled"}"]}"
 
   subnetwork         = "${replace(data.google_compute_subnetwork.gke_subnetwork.self_link, "https://www.googleapis.com/compute/v1/", "")}"
   min_master_version = "${local.kubernetes_version_zonal}"

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -40,6 +40,25 @@ locals {
 
   cluster_type = "${var.regional ? "regional" : "zonal"}"
 
+  cluster_network_policy = {
+    enabled = [{
+      enabled  = "true"
+      provider = "${var.network_policy_provider}"
+    }]
+
+    disabled = [{
+      enabled = "false"
+    }]
+  }
+
+  cluster_cloudrun_config = {
+    enabled = [{
+      disabled = "false"
+    }]
+
+    disabled = []
+  }
+
   cluster_type_output_name = {
     regional = "${element(concat(google_container_cluster.primary.*.name, list("")), 0)}"
     zonal    = "${element(concat(google_container_cluster.zonal_primary.*.name, list("")), 0)}"


### PR DESCRIPTION
This branch patches the network policy and CloudRun config implementations so that they are backwards compatible and do not force the recreation of a cluster. A consequence of these changes is that the `cloudrun_enabled` output is no longer dependent on the clusters as the `cloudrun_config` argument is  omitted in the disabled case which breaks the existing output logic.