### PR TITLE
Add support for upstreamNameservers

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -104,6 +104,20 @@ suites:
       systems:
         - name: stub_domains_private
           backend: local
+  - name: "upstream_nameservers"
+    driver:
+      root_module_directory: test/fixtures/upstream_nameservers
+    verifier:
+        systems:
+          - name: upstream_nameservers
+            backend: local
+  - name: "stub_domains_upstream_nameservers"
+    driver:
+      root_module_directory: test/fixtures/stub_domains_upstream_nameservers
+    verifier:
+        systems:
+          - name: stub_domains_upstream_nameservers
+            backend: local
   - name: "workload_metadata_config"
     driver:
       root_module_directory: test/fixtures/workload_metadata_config

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | service\_account | The service account to run nodes as if not overridden in `node_pools`. The default value will cause a cluster-specific service account to be created. | string | `"create"` | no |
 | stub\_domains | Map of stub domains and their resolvers to forward DNS queries for a certain domain to an external DNS server | map | `<map>` | no |
 | subnetwork | The subnetwork to host the cluster in (required) | string | n/a | yes |
+| upstream\_nameservers | If specified, the values replace the nameservers taken by default from the node’s /etc/resolv.conf | list | `<list>` | no |
 | zones | The zones to host the cluster in (optional if regional cluster / required if zonal) | list | `<list>` | no |
 
 ## Outputs

--- a/autogen/dns.tf
+++ b/autogen/dns.tf
@@ -20,7 +20,7 @@
   Delete default kube-dns configmap
  *****************************************/
 resource "null_resource" "delete_default_kube_dns_configmap" {
-  count = "${local.custom_kube_dns_config ? 1 : 0}"
+  count = "${local.custom_kube_dns_config || local.upstream_nameservers_config ? 1 : 0}"
 
   provisioner "local-exec" {
     command = "${path.module}/scripts/kubectl_wrapper.sh https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
@@ -33,7 +33,7 @@ resource "null_resource" "delete_default_kube_dns_configmap" {
   Create kube-dns confimap
  *****************************************/
 resource "kubernetes_config_map" "kube-dns" {
-  count = "${local.custom_kube_dns_config ? 1 : 0}"
+  count = "${local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0}"
 
   metadata {
     name      = "kube-dns"
@@ -45,6 +45,51 @@ resource "kubernetes_config_map" "kube-dns" {
   }
 
   data {
+    stubDomains = <<EOF
+${jsonencode(var.stub_domains)}
+EOF
+  }
+
+  depends_on = ["null_resource.delete_default_kube_dns_configmap", "data.google_client_config.default", "google_container_cluster.primary", "google_container_node_pool.pools", "google_container_cluster.zonal_primary", "google_container_node_pool.zonal_pools"]
+}
+
+resource "kubernetes_config_map" "kube-dns-upstream-namservers" {
+  count = "${!local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0}"
+
+  metadata {
+    name      = "kube-dns"
+    namespace = "kube-system"
+
+    labels {
+      maintained_by = "terraform"
+    }
+  }
+
+  data {
+    upstreamNameservers = <<EOF
+${jsonencode(var.upstream_nameservers)}
+EOF
+  }
+
+  depends_on = ["null_resource.delete_default_kube_dns_configmap", "data.google_client_config.default", "google_container_cluster.primary", "google_container_node_pool.pools", "google_container_cluster.zonal_primary", "google_container_node_pool.zonal_pools"]
+}
+
+resource "kubernetes_config_map" "kube-dns-upstream-nameservers-and-stub-domains" {
+  count = "${local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0}"
+
+  metadata {
+    name      = "kube-dns"
+    namespace = "kube-system"
+
+    labels {
+      maintained_by = "terraform"
+    }
+  }
+
+  data {
+    upstreamNameservers = <<EOF
+${jsonencode(var.upstream_nameservers)}
+EOF
     stubDomains = <<EOF
 ${jsonencode(var.stub_domains)}
 EOF

--- a/autogen/main.tf
+++ b/autogen/main.tf
@@ -36,6 +36,7 @@ locals {
   node_version_regional       = "${var.node_version != "" && var.regional ? var.node_version : local.kubernetes_version_regional}"
   node_version_zonal          = "${var.node_version != "" && !var.regional ? var.node_version : local.kubernetes_version_zonal}"
   custom_kube_dns_config      = "${length(keys(var.stub_domains)) > 0 ? true : false}"
+  upstream_nameservers_config = "${length(var.upstream_nameservers) > 0 ? true : false}"
   network_project_id          = "${var.network_project_id != "" ? var.network_project_id : var.project_id}"
 
   cluster_type = "${var.regional ? "regional" : "zonal"}"

--- a/autogen/variables.tf
+++ b/autogen/variables.tf
@@ -206,6 +206,12 @@ variable "stub_domains" {
   default     = {}
 }
 
+variable "upstream_nameservers" {
+  type        = "list"
+  description = "If specified, the values replace the nameservers taken by default from the node’s /etc/resolv.conf"
+  default     = []
+}
+
 variable "non_masquerade_cidrs" {
   type        = "list"
   description = "List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading."

--- a/dns.tf
+++ b/dns.tf
@@ -20,7 +20,7 @@
   Delete default kube-dns configmap
  *****************************************/
 resource "null_resource" "delete_default_kube_dns_configmap" {
-  count = "${local.custom_kube_dns_config ? 1 : 0}"
+  count = "${local.custom_kube_dns_config || local.upstream_nameservers_config ? 1 : 0}"
 
   provisioner "local-exec" {
     command = "${path.module}/scripts/kubectl_wrapper.sh https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
@@ -33,7 +33,7 @@ resource "null_resource" "delete_default_kube_dns_configmap" {
   Create kube-dns confimap
  *****************************************/
 resource "kubernetes_config_map" "kube-dns" {
-  count = "${local.custom_kube_dns_config ? 1 : 0}"
+  count = "${local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0}"
 
   metadata {
     name      = "kube-dns"
@@ -45,6 +45,51 @@ resource "kubernetes_config_map" "kube-dns" {
   }
 
   data {
+    stubDomains = <<EOF
+${jsonencode(var.stub_domains)}
+EOF
+  }
+
+  depends_on = ["null_resource.delete_default_kube_dns_configmap", "data.google_client_config.default", "google_container_cluster.primary", "google_container_node_pool.pools", "google_container_cluster.zonal_primary", "google_container_node_pool.zonal_pools"]
+}
+
+resource "kubernetes_config_map" "kube-dns-upstream-namservers" {
+  count = "${!local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0}"
+
+  metadata {
+    name      = "kube-dns"
+    namespace = "kube-system"
+
+    labels {
+      maintained_by = "terraform"
+    }
+  }
+
+  data {
+    upstreamNameservers = <<EOF
+${jsonencode(var.upstream_nameservers)}
+EOF
+  }
+
+  depends_on = ["null_resource.delete_default_kube_dns_configmap", "data.google_client_config.default", "google_container_cluster.primary", "google_container_node_pool.pools", "google_container_cluster.zonal_primary", "google_container_node_pool.zonal_pools"]
+}
+
+resource "kubernetes_config_map" "kube-dns-upstream-nameservers-and-stub-domains" {
+  count = "${local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0}"
+
+  metadata {
+    name      = "kube-dns"
+    namespace = "kube-system"
+
+    labels {
+      maintained_by = "terraform"
+    }
+  }
+
+  data {
+    upstreamNameservers = <<EOF
+${jsonencode(var.upstream_nameservers)}
+EOF
     stubDomains = <<EOF
 ${jsonencode(var.stub_domains)}
 EOF

--- a/examples/stub_domains_upstream_nameservers/README.md
+++ b/examples/stub_domains_upstream_nameservers/README.md
@@ -1,0 +1,50 @@
+# Stub Domains and Upstream Nameservers Cluster
+
+This example illustrates how to create a cluster that adds custom stub domains and custom upstream nameservers to kube-dns.
+
+It will:
+- Create a cluster
+- Remove the default kube-dns configmap
+- Add a new kube-dns configmap with custom stub domains and upstream nameservers
+
+[^]: (autogen_docs_start)
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| cluster\_name\_suffix | A suffix to append to the default cluster name | string | `""` | no |
+| compute\_engine\_service\_account | Service account to associate to the nodes in the cluster | string | n/a | yes |
+| ip\_range\_pods | The secondary ip range to use for pods | string | n/a | yes |
+| ip\_range\_services | The secondary ip range to use for pods | string | n/a | yes |
+| network | The VPC network to host the cluster in | string | n/a | yes |
+| project\_id | The project ID to host the cluster in | string | n/a | yes |
+| region | The region to host the cluster in | string | n/a | yes |
+| subnetwork | The subnetwork to host the cluster in | string | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| ca\_certificate |  |
+| client\_token |  |
+| cluster\_name | Cluster name |
+| ip\_range\_pods | The secondary IP range used for pods |
+| ip\_range\_services | The secondary IP range used for services |
+| kubernetes\_endpoint |  |
+| location |  |
+| master\_kubernetes\_version | The master Kubernetes version |
+| network |  |
+| project\_id |  |
+| region |  |
+| service\_account | The service account to default running nodes as if not overridden in `node_pools`. |
+| subnetwork |  |
+| zones | List of zones in which the cluster resides |
+
+[^]: (autogen_docs_end)
+
+To provision this example, run the following from within this directory:
+- `terraform init` to get the plugins
+- `terraform plan` to see the infrastructure plan
+- `terraform apply` to apply the infrastructure build
+- `terraform destroy` to destroy the built infrastructure

--- a/examples/stub_domains_upstream_nameservers/outputs.tf
+++ b/examples/stub_domains_upstream_nameservers/outputs.tf
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "kubernetes_endpoint" {
+  sensitive = true
+  value     = "${module.gke.endpoint}"
+}
+
+output "client_token" {
+  sensitive = true
+  value     = "${base64encode(data.google_client_config.default.access_token)}"
+}
+
+output "ca_certificate" {
+  value = "${module.gke.ca_certificate}"
+}
+
+output "service_account" {
+  description = "The service account to default running nodes as if not overridden in `node_pools`."
+  value       = "${module.gke.service_account}"
+}

--- a/examples/stub_domains_upstream_nameservers/test_outputs.tf
+++ b/examples/stub_domains_upstream_nameservers/test_outputs.tf
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// These outputs are used to test the module with kitchen-terraform
+// They do not need to be included in real-world uses of this module
+
+output "project_id" {
+  value = "${var.project_id}"
+}
+
+output "region" {
+  value = "${module.gke.region}"
+}
+
+output "cluster_name" {
+  description = "Cluster name"
+  value       = "${module.gke.name}"
+}
+
+output "network" {
+  value = "${var.network}"
+}
+
+output "subnetwork" {
+  value = "${var.subnetwork}"
+}
+
+output "location" {
+  value = "${module.gke.location}"
+}
+
+output "ip_range_pods" {
+  description = "The secondary IP range used for pods"
+  value       = "${var.ip_range_pods}"
+}
+
+output "ip_range_services" {
+  description = "The secondary IP range used for services"
+  value       = "${var.ip_range_services}"
+}
+
+output "zones" {
+  description = "List of zones in which the cluster resides"
+  value       = "${module.gke.zones}"
+}
+
+output "master_kubernetes_version" {
+  description = "The master Kubernetes version"
+  value       = "${module.gke.master_version}"
+}

--- a/examples/stub_domains_upstream_nameservers/variables.tf
+++ b/examples/stub_domains_upstream_nameservers/variables.tf
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The project ID to host the cluster in"
+}
+
+variable "cluster_name_suffix" {
+  description = "A suffix to append to the default cluster name"
+  default     = ""
+}
+
+variable "region" {
+  description = "The region to host the cluster in"
+}
+
+variable "network" {
+  description = "The VPC network to host the cluster in"
+}
+
+variable "subnetwork" {
+  description = "The subnetwork to host the cluster in"
+}
+
+variable "ip_range_pods" {
+  description = "The secondary ip range to use for pods"
+}
+
+variable "ip_range_services" {
+  description = "The secondary ip range to use for pods"
+}
+
+variable "compute_engine_service_account" {
+  description = "Service account to associate to the nodes in the cluster"
+}

--- a/examples/upstream_nameservers/README.md
+++ b/examples/upstream_nameservers/README.md
@@ -1,0 +1,50 @@
+# Upstream Nameservers Cluster
+
+This example illustrates how to create a cluster that adds custom upstream nameservers to kube-dns.
+
+It will:
+- Create a cluster
+- Remove the default kube-dns configmap
+- Add a new kube-dns configmap with custom upstream nameservers
+
+[^]: (autogen_docs_start)
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| cluster\_name\_suffix | A suffix to append to the default cluster name | string | `""` | no |
+| compute\_engine\_service\_account | Service account to associate to the nodes in the cluster | string | n/a | yes |
+| ip\_range\_pods | The secondary ip range to use for pods | string | n/a | yes |
+| ip\_range\_services | The secondary ip range to use for pods | string | n/a | yes |
+| network | The VPC network to host the cluster in | string | n/a | yes |
+| project\_id | The project ID to host the cluster in | string | n/a | yes |
+| region | The region to host the cluster in | string | n/a | yes |
+| subnetwork | The subnetwork to host the cluster in | string | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| ca\_certificate |  |
+| client\_token |  |
+| cluster\_name | Cluster name |
+| ip\_range\_pods | The secondary IP range used for pods |
+| ip\_range\_services | The secondary IP range used for services |
+| kubernetes\_endpoint |  |
+| location |  |
+| master\_kubernetes\_version | The master Kubernetes version |
+| network |  |
+| project\_id |  |
+| region |  |
+| service\_account | The service account to default running nodes as if not overridden in `node_pools`. |
+| subnetwork |  |
+| zones | List of zones in which the cluster resides |
+
+[^]: (autogen_docs_end)
+
+To provision this example, run the following from within this directory:
+- `terraform init` to get the plugins
+- `terraform plan` to see the infrastructure plan
+- `terraform apply` to apply the infrastructure build
+- `terraform destroy` to destroy the built infrastructure

--- a/examples/upstream_nameservers/main.tf
+++ b/examples/upstream_nameservers/main.tf
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  cluster_type = "upstream-nameservers"
+}
+
+provider "google" {
+  version = "~> 2.9.0"
+  region  = "${var.region}"
+}
+
+provider "google-beta" {
+  version = "~> 2.9.0"
+  region  = "${var.region}"
+}
+
+module "gke" {
+  source            = "../../"
+  project_id        = "${var.project_id}"
+  name              = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
+  region            = "${var.region}"
+  network           = "${var.network}"
+  subnetwork        = "${var.subnetwork}"
+  ip_range_pods     = "${var.ip_range_pods}"
+  ip_range_services = "${var.ip_range_services}"
+  network_policy    = true
+  service_account   = "${var.compute_engine_service_account}"
+
+  configure_ip_masq = true
+  upstream_nameservers = ["8.8.8.8", "8.8.4.4"]
+}
+
+data "google_client_config" "default" {}

--- a/examples/upstream_nameservers/outputs.tf
+++ b/examples/upstream_nameservers/outputs.tf
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "kubernetes_endpoint" {
+  sensitive = true
+  value     = "${module.gke.endpoint}"
+}
+
+output "client_token" {
+  sensitive = true
+  value     = "${base64encode(data.google_client_config.default.access_token)}"
+}
+
+output "ca_certificate" {
+  value = "${module.gke.ca_certificate}"
+}
+
+output "service_account" {
+  description = "The service account to default running nodes as if not overridden in `node_pools`."
+  value       = "${module.gke.service_account}"
+}

--- a/examples/upstream_nameservers/test_outputs.tf
+++ b/examples/upstream_nameservers/test_outputs.tf
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// These outputs are used to test the module with kitchen-terraform
+// They do not need to be included in real-world uses of this module
+
+output "project_id" {
+  value = "${var.project_id}"
+}
+
+output "region" {
+  value = "${module.gke.region}"
+}
+
+output "cluster_name" {
+  description = "Cluster name"
+  value       = "${module.gke.name}"
+}
+
+output "network" {
+  value = "${var.network}"
+}
+
+output "subnetwork" {
+  value = "${var.subnetwork}"
+}
+
+output "location" {
+  value = "${module.gke.location}"
+}
+
+output "ip_range_pods" {
+  description = "The secondary IP range used for pods"
+  value       = "${var.ip_range_pods}"
+}
+
+output "ip_range_services" {
+  description = "The secondary IP range used for services"
+  value       = "${var.ip_range_services}"
+}
+
+output "zones" {
+  description = "List of zones in which the cluster resides"
+  value       = "${module.gke.zones}"
+}
+
+output "master_kubernetes_version" {
+  description = "The master Kubernetes version"
+  value       = "${module.gke.master_version}"
+}

--- a/examples/upstream_nameservers/variables.tf
+++ b/examples/upstream_nameservers/variables.tf
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The project ID to host the cluster in"
+}
+
+variable "cluster_name_suffix" {
+  description = "A suffix to append to the default cluster name"
+  default     = ""
+}
+
+variable "region" {
+  description = "The region to host the cluster in"
+}
+
+variable "network" {
+  description = "The VPC network to host the cluster in"
+}
+
+variable "subnetwork" {
+  description = "The subnetwork to host the cluster in"
+}
+
+variable "ip_range_pods" {
+  description = "The secondary ip range to use for pods"
+}
+
+variable "ip_range_services" {
+  description = "The secondary ip range to use for pods"
+}
+
+variable "compute_engine_service_account" {
+  description = "Service account to associate to the nodes in the cluster"
+}

--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,7 @@ locals {
   node_version_regional       = "${var.node_version != "" && var.regional ? var.node_version : local.kubernetes_version_regional}"
   node_version_zonal          = "${var.node_version != "" && !var.regional ? var.node_version : local.kubernetes_version_zonal}"
   custom_kube_dns_config      = "${length(keys(var.stub_domains)) > 0 ? true : false}"
+  upstream_nameservers_config = "${length(var.upstream_nameservers) > 0 ? true : false}"
   network_project_id          = "${var.network_project_id != "" ? var.network_project_id : var.project_id}"
 
   cluster_type = "${var.regional ? "regional" : "zonal"}"

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -171,6 +171,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | service\_account | The service account to run nodes as if not overridden in `node_pools`. The default value will cause a cluster-specific service account to be created. | string | `"create"` | no |
 | stub\_domains | Map of stub domains and their resolvers to forward DNS queries for a certain domain to an external DNS server | map | `<map>` | no |
 | subnetwork | The subnetwork to host the cluster in (required) | string | n/a | yes |
+| upstream\_nameservers | If specified, the values replace the nameservers taken by default from the node’s /etc/resolv.conf | list | `<list>` | no |
 | zones | The zones to host the cluster in (optional if regional cluster / required if zonal) | list | `<list>` | no |
 
 ## Outputs

--- a/modules/beta-private-cluster/dns.tf
+++ b/modules/beta-private-cluster/dns.tf
@@ -20,7 +20,7 @@
   Delete default kube-dns configmap
  *****************************************/
 resource "null_resource" "delete_default_kube_dns_configmap" {
-  count = "${local.custom_kube_dns_config ? 1 : 0}"
+  count = "${local.custom_kube_dns_config || local.upstream_nameservers_config ? 1 : 0}"
 
   provisioner "local-exec" {
     command = "${path.module}/scripts/kubectl_wrapper.sh https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
@@ -33,7 +33,7 @@ resource "null_resource" "delete_default_kube_dns_configmap" {
   Create kube-dns confimap
  *****************************************/
 resource "kubernetes_config_map" "kube-dns" {
-  count = "${local.custom_kube_dns_config ? 1 : 0}"
+  count = "${local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0}"
 
   metadata {
     name      = "kube-dns"
@@ -45,6 +45,51 @@ resource "kubernetes_config_map" "kube-dns" {
   }
 
   data {
+    stubDomains = <<EOF
+${jsonencode(var.stub_domains)}
+EOF
+  }
+
+  depends_on = ["null_resource.delete_default_kube_dns_configmap", "data.google_client_config.default", "google_container_cluster.primary", "google_container_node_pool.pools", "google_container_cluster.zonal_primary", "google_container_node_pool.zonal_pools"]
+}
+
+resource "kubernetes_config_map" "kube-dns-upstream-namservers" {
+  count = "${!local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0}"
+
+  metadata {
+    name      = "kube-dns"
+    namespace = "kube-system"
+
+    labels {
+      maintained_by = "terraform"
+    }
+  }
+
+  data {
+    upstreamNameservers = <<EOF
+${jsonencode(var.upstream_nameservers)}
+EOF
+  }
+
+  depends_on = ["null_resource.delete_default_kube_dns_configmap", "data.google_client_config.default", "google_container_cluster.primary", "google_container_node_pool.pools", "google_container_cluster.zonal_primary", "google_container_node_pool.zonal_pools"]
+}
+
+resource "kubernetes_config_map" "kube-dns-upstream-nameservers-and-stub-domains" {
+  count = "${local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0}"
+
+  metadata {
+    name      = "kube-dns"
+    namespace = "kube-system"
+
+    labels {
+      maintained_by = "terraform"
+    }
+  }
+
+  data {
+    upstreamNameservers = <<EOF
+${jsonencode(var.upstream_nameservers)}
+EOF
     stubDomains = <<EOF
 ${jsonencode(var.stub_domains)}
 EOF

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -36,6 +36,7 @@ locals {
   node_version_regional       = "${var.node_version != "" && var.regional ? var.node_version : local.kubernetes_version_regional}"
   node_version_zonal          = "${var.node_version != "" && !var.regional ? var.node_version : local.kubernetes_version_zonal}"
   custom_kube_dns_config      = "${length(keys(var.stub_domains)) > 0 ? true : false}"
+  upstream_nameservers_config = "${length(var.upstream_nameservers) > 0 ? true : false}"
   network_project_id          = "${var.network_project_id != "" ? var.network_project_id : var.project_id}"
 
   cluster_type = "${var.regional ? "regional" : "zonal"}"

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -206,6 +206,12 @@ variable "stub_domains" {
   default     = {}
 }
 
+variable "upstream_nameservers" {
+  type        = "list"
+  description = "If specified, the values replace the nameservers taken by default from the node’s /etc/resolv.conf"
+  default     = []
+}
+
 variable "non_masquerade_cidrs" {
   type        = "list"
   description = "List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading."

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -162,6 +162,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | service\_account | The service account to run nodes as if not overridden in `node_pools`. The default value will cause a cluster-specific service account to be created. | string | `"create"` | no |
 | stub\_domains | Map of stub domains and their resolvers to forward DNS queries for a certain domain to an external DNS server | map | `<map>` | no |
 | subnetwork | The subnetwork to host the cluster in (required) | string | n/a | yes |
+| upstream\_nameservers | If specified, the values replace the nameservers taken by default from the node’s /etc/resolv.conf | list | `<list>` | no |
 | zones | The zones to host the cluster in (optional if regional cluster / required if zonal) | list | `<list>` | no |
 
 ## Outputs

--- a/modules/beta-public-cluster/dns.tf
+++ b/modules/beta-public-cluster/dns.tf
@@ -20,7 +20,7 @@
   Delete default kube-dns configmap
  *****************************************/
 resource "null_resource" "delete_default_kube_dns_configmap" {
-  count = "${local.custom_kube_dns_config ? 1 : 0}"
+  count = "${local.custom_kube_dns_config || local.upstream_nameservers_config ? 1 : 0}"
 
   provisioner "local-exec" {
     command = "${path.module}/scripts/kubectl_wrapper.sh https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
@@ -33,7 +33,7 @@ resource "null_resource" "delete_default_kube_dns_configmap" {
   Create kube-dns confimap
  *****************************************/
 resource "kubernetes_config_map" "kube-dns" {
-  count = "${local.custom_kube_dns_config ? 1 : 0}"
+  count = "${local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0}"
 
   metadata {
     name      = "kube-dns"
@@ -45,6 +45,51 @@ resource "kubernetes_config_map" "kube-dns" {
   }
 
   data {
+    stubDomains = <<EOF
+${jsonencode(var.stub_domains)}
+EOF
+  }
+
+  depends_on = ["null_resource.delete_default_kube_dns_configmap", "data.google_client_config.default", "google_container_cluster.primary", "google_container_node_pool.pools", "google_container_cluster.zonal_primary", "google_container_node_pool.zonal_pools"]
+}
+
+resource "kubernetes_config_map" "kube-dns-upstream-namservers" {
+  count = "${!local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0}"
+
+  metadata {
+    name      = "kube-dns"
+    namespace = "kube-system"
+
+    labels {
+      maintained_by = "terraform"
+    }
+  }
+
+  data {
+    upstreamNameservers = <<EOF
+${jsonencode(var.upstream_nameservers)}
+EOF
+  }
+
+  depends_on = ["null_resource.delete_default_kube_dns_configmap", "data.google_client_config.default", "google_container_cluster.primary", "google_container_node_pool.pools", "google_container_cluster.zonal_primary", "google_container_node_pool.zonal_pools"]
+}
+
+resource "kubernetes_config_map" "kube-dns-upstream-nameservers-and-stub-domains" {
+  count = "${local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0}"
+
+  metadata {
+    name      = "kube-dns"
+    namespace = "kube-system"
+
+    labels {
+      maintained_by = "terraform"
+    }
+  }
+
+  data {
+    upstreamNameservers = <<EOF
+${jsonencode(var.upstream_nameservers)}
+EOF
     stubDomains = <<EOF
 ${jsonencode(var.stub_domains)}
 EOF

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -36,6 +36,7 @@ locals {
   node_version_regional       = "${var.node_version != "" && var.regional ? var.node_version : local.kubernetes_version_regional}"
   node_version_zonal          = "${var.node_version != "" && !var.regional ? var.node_version : local.kubernetes_version_zonal}"
   custom_kube_dns_config      = "${length(keys(var.stub_domains)) > 0 ? true : false}"
+  upstream_nameservers_config = "${length(var.upstream_nameservers) > 0 ? true : false}"
   network_project_id          = "${var.network_project_id != "" ? var.network_project_id : var.project_id}"
 
   cluster_type = "${var.regional ? "regional" : "zonal"}"

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -206,6 +206,12 @@ variable "stub_domains" {
   default     = {}
 }
 
+variable "upstream_nameservers" {
+  type        = "list"
+  description = "If specified, the values replace the nameservers taken by default from the node’s /etc/resolv.conf"
+  default     = []
+}
+
 variable "non_masquerade_cidrs" {
   type        = "list"
   description = "List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading."

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -163,6 +163,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | service\_account | The service account to run nodes as if not overridden in `node_pools`. The default value will cause a cluster-specific service account to be created. | string | `"create"` | no |
 | stub\_domains | Map of stub domains and their resolvers to forward DNS queries for a certain domain to an external DNS server | map | `<map>` | no |
 | subnetwork | The subnetwork to host the cluster in (required) | string | n/a | yes |
+| upstream\_nameservers | If specified, the values replace the nameservers taken by default from the node’s /etc/resolv.conf | list | `<list>` | no |
 | zones | The zones to host the cluster in (optional if regional cluster / required if zonal) | list | `<list>` | no |
 
 ## Outputs

--- a/modules/private-cluster/dns.tf
+++ b/modules/private-cluster/dns.tf
@@ -20,7 +20,7 @@
   Delete default kube-dns configmap
  *****************************************/
 resource "null_resource" "delete_default_kube_dns_configmap" {
-  count = "${local.custom_kube_dns_config ? 1 : 0}"
+  count = "${local.custom_kube_dns_config || local.upstream_nameservers_config ? 1 : 0}"
 
   provisioner "local-exec" {
     command = "${path.module}/scripts/kubectl_wrapper.sh https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
@@ -33,7 +33,7 @@ resource "null_resource" "delete_default_kube_dns_configmap" {
   Create kube-dns confimap
  *****************************************/
 resource "kubernetes_config_map" "kube-dns" {
-  count = "${local.custom_kube_dns_config ? 1 : 0}"
+  count = "${local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0}"
 
   metadata {
     name      = "kube-dns"
@@ -45,6 +45,51 @@ resource "kubernetes_config_map" "kube-dns" {
   }
 
   data {
+    stubDomains = <<EOF
+${jsonencode(var.stub_domains)}
+EOF
+  }
+
+  depends_on = ["null_resource.delete_default_kube_dns_configmap", "data.google_client_config.default", "google_container_cluster.primary", "google_container_node_pool.pools", "google_container_cluster.zonal_primary", "google_container_node_pool.zonal_pools"]
+}
+
+resource "kubernetes_config_map" "kube-dns-upstream-namservers" {
+  count = "${!local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0}"
+
+  metadata {
+    name      = "kube-dns"
+    namespace = "kube-system"
+
+    labels {
+      maintained_by = "terraform"
+    }
+  }
+
+  data {
+    upstreamNameservers = <<EOF
+${jsonencode(var.upstream_nameservers)}
+EOF
+  }
+
+  depends_on = ["null_resource.delete_default_kube_dns_configmap", "data.google_client_config.default", "google_container_cluster.primary", "google_container_node_pool.pools", "google_container_cluster.zonal_primary", "google_container_node_pool.zonal_pools"]
+}
+
+resource "kubernetes_config_map" "kube-dns-upstream-nameservers-and-stub-domains" {
+  count = "${local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0}"
+
+  metadata {
+    name      = "kube-dns"
+    namespace = "kube-system"
+
+    labels {
+      maintained_by = "terraform"
+    }
+  }
+
+  data {
+    upstreamNameservers = <<EOF
+${jsonencode(var.upstream_nameservers)}
+EOF
     stubDomains = <<EOF
 ${jsonencode(var.stub_domains)}
 EOF

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -36,6 +36,7 @@ locals {
   node_version_regional       = "${var.node_version != "" && var.regional ? var.node_version : local.kubernetes_version_regional}"
   node_version_zonal          = "${var.node_version != "" && !var.regional ? var.node_version : local.kubernetes_version_zonal}"
   custom_kube_dns_config      = "${length(keys(var.stub_domains)) > 0 ? true : false}"
+  upstream_nameservers_config = "${length(var.upstream_nameservers) > 0 ? true : false}"
   network_project_id          = "${var.network_project_id != "" ? var.network_project_id : var.project_id}"
 
   cluster_type = "${var.regional ? "regional" : "zonal"}"

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -206,6 +206,12 @@ variable "stub_domains" {
   default     = {}
 }
 
+variable "upstream_nameservers" {
+  type        = "list"
+  description = "If specified, the values replace the nameservers taken by default from the node’s /etc/resolv.conf"
+  default     = []
+}
+
 variable "non_masquerade_cidrs" {
   type        = "list"
   description = "List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading."

--- a/test/ci/stub-domains-upstream-nameservers.yml
+++ b/test/ci/stub-domains-upstream-nameservers.yml
@@ -1,0 +1,18 @@
+---
+
+platform: linux
+
+inputs:
+- name: pull-request
+  path: terraform-google-kubernetes-engine
+
+run:
+  path: make
+  args: ['test_integration']
+  dir: terraform-google-kubernetes-engine
+
+params:
+  SUITE: "stub-domains-upstream-nameservers-local"
+  COMPUTE_ENGINE_SERVICE_ACCOUNT: ""
+  REGION: "us-east4"
+  ZONES: '["us-east4-a", "us-east4-b", "us-east4-c"]'

--- a/test/ci/upstream-nameservers.yml
+++ b/test/ci/upstream-nameservers.yml
@@ -1,0 +1,18 @@
+---
+
+platform: linux
+
+inputs:
+- name: pull-request
+  path: terraform-google-kubernetes-engine
+
+run:
+  path: make
+  args: ['test_integration']
+  dir: terraform-google-kubernetes-engine
+
+params:
+  SUITE: "upstream-nameservers-local"
+  COMPUTE_ENGINE_SERVICE_ACCOUNT: ""
+  REGION: "us-east4"
+  ZONES: '["us-east4-a", "us-east4-b", "us-east4-c"]'

--- a/test/fixtures/stub_domains_private/terraform.tfvars
+++ b/test/fixtures/stub_domains_private/terraform.tfvars
@@ -1,0 +1,1 @@
+../shared/terraform.tfvars

--- a/test/fixtures/stub_domains_upstream_nameservers/example.tf
+++ b/test/fixtures/stub_domains_upstream_nameservers/example.tf
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "example" {
+  source = "../../../examples/stub_domains_upstream_nameservers"
+
+  project_id                     = "${var.project_id}"
+  cluster_name_suffix            = "-${random_string.suffix.result}"
+  region                         = "${var.region}"
+  network                        = "${google_compute_network.main.name}"
+  subnetwork                     = "${google_compute_subnetwork.main.name}"
+  ip_range_pods                  = "${google_compute_subnetwork.main.secondary_ip_range.0.range_name}"
+  ip_range_services              = "${google_compute_subnetwork.main.secondary_ip_range.1.range_name}"
+  compute_engine_service_account = "${var.compute_engine_service_account}"
+}

--- a/test/fixtures/stub_domains_upstream_nameservers/network.tf
+++ b/test/fixtures/stub_domains_upstream_nameservers/network.tf
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "random_string" "suffix" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+provider "google" {
+  project     = "${var.project_id}"
+}
+
+resource "google_compute_network" "main" {
+  name                    = "cft-gke-test-${random_string.suffix.result}"
+  auto_create_subnetworks = "false"
+}
+
+resource "google_compute_subnetwork" "main" {
+  name          = "cft-gke-test-${random_string.suffix.result}"
+  ip_cidr_range = "10.0.0.0/17"
+  region        = "${var.region}"
+  network       = "${google_compute_network.main.self_link}"
+
+  secondary_ip_range {
+    range_name    = "cft-gke-test-pods-${random_string.suffix.result}"
+    ip_cidr_range = "192.168.0.0/18"
+  }
+
+  secondary_ip_range {
+    range_name    = "cft-gke-test-services-${random_string.suffix.result}"
+    ip_cidr_range = "192.168.64.0/18"
+  }
+}

--- a/test/fixtures/stub_domains_upstream_nameservers/outputs.tf
+++ b/test/fixtures/stub_domains_upstream_nameservers/outputs.tf
@@ -1,0 +1,1 @@
+../shared/outputs.tf

--- a/test/fixtures/stub_domains_upstream_nameservers/terraform.tfvars
+++ b/test/fixtures/stub_domains_upstream_nameservers/terraform.tfvars
@@ -1,0 +1,1 @@
+../shared/terraform.tfvars

--- a/test/fixtures/stub_domains_upstream_nameservers/variables.tf
+++ b/test/fixtures/stub_domains_upstream_nameservers/variables.tf
@@ -1,0 +1,1 @@
+../shared/variables.tf

--- a/test/fixtures/upstream_nameservers/example.tf
+++ b/test/fixtures/upstream_nameservers/example.tf
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "example" {
+  source = "../../../examples/upstream_nameservers"
+
+  project_id                     = "${var.project_id}"
+  cluster_name_suffix            = "-${random_string.suffix.result}"
+  region                         = "${var.region}"
+  network                        = "${google_compute_network.main.name}"
+  subnetwork                     = "${google_compute_subnetwork.main.name}"
+  ip_range_pods                  = "${google_compute_subnetwork.main.secondary_ip_range.0.range_name}"
+  ip_range_services              = "${google_compute_subnetwork.main.secondary_ip_range.1.range_name}"
+  compute_engine_service_account = "${var.compute_engine_service_account}"
+}

--- a/test/fixtures/upstream_nameservers/network.tf
+++ b/test/fixtures/upstream_nameservers/network.tf
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "random_string" "suffix" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+provider "google" {
+  project     = "${var.project_id}"
+}
+
+resource "google_compute_network" "main" {
+  name                    = "cft-gke-test-${random_string.suffix.result}"
+  auto_create_subnetworks = "false"
+}
+
+resource "google_compute_subnetwork" "main" {
+  name          = "cft-gke-test-${random_string.suffix.result}"
+  ip_cidr_range = "10.0.0.0/17"
+  region        = "${var.region}"
+  network       = "${google_compute_network.main.self_link}"
+
+  secondary_ip_range {
+    range_name    = "cft-gke-test-pods-${random_string.suffix.result}"
+    ip_cidr_range = "192.168.0.0/18"
+  }
+
+  secondary_ip_range {
+    range_name    = "cft-gke-test-services-${random_string.suffix.result}"
+    ip_cidr_range = "192.168.64.0/18"
+  }
+}

--- a/test/fixtures/upstream_nameservers/outputs.tf
+++ b/test/fixtures/upstream_nameservers/outputs.tf
@@ -1,0 +1,1 @@
+../shared/outputs.tf

--- a/test/fixtures/upstream_nameservers/terraform.tfvars
+++ b/test/fixtures/upstream_nameservers/terraform.tfvars
@@ -1,0 +1,1 @@
+../shared/terraform.tfvars

--- a/test/fixtures/upstream_nameservers/variables.tf
+++ b/test/fixtures/upstream_nameservers/variables.tf
@@ -1,0 +1,1 @@
+../shared/variables.tf

--- a/test/integration/stub_domains_upstream_nameservers/controls/gcloud.rb
+++ b/test/integration/stub_domains_upstream_nameservers/controls/gcloud.rb
@@ -1,0 +1,50 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id = attribute('project_id')
+location = attribute('location')
+cluster_name = attribute('cluster_name')
+
+control "gcloud" do
+  title "Google Compute Engine GKE configuration"
+  describe command("gcloud --project=#{project_id} container clusters --zone=#{location} describe #{cluster_name} --format=json") do
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq '' }
+
+    let!(:data) do
+      if subject.exit_status == 0
+        JSON.parse(subject.stdout)
+      else
+        {}
+      end
+    end
+
+    describe "cluster" do
+      it "is running" do
+        expect(data['status']).to eq 'RUNNING'
+      end
+
+      it "has the expected addon settings" do
+        expect(data['addonsConfig']).to eq({
+          "horizontalPodAutoscaling" => {},
+          "httpLoadBalancing" => {},
+          "kubernetesDashboard" => {
+            "disabled" => true,
+          },
+          "networkPolicyConfig" => {},
+        })
+      end
+    end
+  end
+end

--- a/test/integration/stub_domains_upstream_nameservers/controls/kubectl.rb
+++ b/test/integration/stub_domains_upstream_nameservers/controls/kubectl.rb
@@ -1,0 +1,92 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'kubeclient'
+require 'rest-client'
+
+require 'base64'
+
+kubernetes_endpoint = attribute('kubernetes_endpoint')
+client_token = attribute('client_token')
+ca_certificate = attribute('ca_certificate')
+
+control "kubectl" do
+  title "Kubernetes configuration"
+
+  describe "kubernetes" do
+    let(:kubernetes_http_endpoint) { "https://#{kubernetes_endpoint}/api" }
+    let(:client) do
+      cert_store = OpenSSL::X509::Store.new
+      cert_store.add_cert(OpenSSL::X509::Certificate.new(Base64.decode64(ca_certificate)))
+      Kubeclient::Client.new(
+        kubernetes_http_endpoint,
+        "v1",
+        ssl_options: {
+          cert_store: cert_store,
+          verify_ssl: OpenSSL::SSL::VERIFY_PEER,
+        },
+        auth_options: {
+          bearer_token: Base64.decode64(client_token),
+        },
+      )
+    end
+
+    describe "configmap" do
+      describe "kube-dns" do
+        let(:kubedns_configmap) { client.get_config_map("kube-dns", "kube-system") }
+
+        it "is created by Terraform" do
+          expect(kubedns_configmap.metadata.labels.maintained_by).to eq "terraform"
+        end
+
+        it "reflects the stub_domains configuration" do
+          expect(JSON.parse(kubedns_configmap.data.stubDomains)).to eq({
+            "example.com" => [
+              "10.254.154.11",
+              "10.254.154.12",
+            ],
+            "example.net" => [
+              "10.254.154.11",
+              "10.254.154.12",
+            ],
+          })
+        end
+
+        it "reflects the upstream_nameservers configuration" do
+          expect(JSON.parse(kubedns_configmap.data.upstreamNameservers)).to eq(["8.8.8.8", "8.8.4.4"])
+        end
+      end
+
+      describe "ipmasq" do
+        let(:ipmasq_configmap) { client.get_config_map("ip-masq-agent", "kube-system") }
+
+        it "is created by Terraform" do
+          expect(ipmasq_configmap.metadata.labels.maintained_by).to eq "terraform"
+        end
+
+        it "is configured properly" do
+          expect(YAML.load(ipmasq_configmap.data.config)).to eq({
+            "nonMasqueradeCIDRs" => [
+              "10.0.0.0/8",
+              "172.16.0.0/12",
+              "192.168.0.0/16",
+            ],
+            "resyncInterval" => "60s",
+            "masqLinkLocal" => false,
+          })
+        end
+      end
+    end
+  end
+end

--- a/test/integration/stub_domains_upstream_nameservers/inspec.yml
+++ b/test/integration/stub_domains_upstream_nameservers/inspec.yml
@@ -1,0 +1,20 @@
+name: stub_domains_upstream_nameservers
+attributes:
+  - name: project_id
+    required: true
+    type: string
+  - name: location
+    required: true
+    type: string
+  - name: cluster_name
+    required: true
+    type: string
+  - name: kubernetes_endpoint
+    required: true
+    type: string
+  - name: client_token
+    required: true
+    type: string
+  - name: ca_certificate
+    required: true
+    type: string

--- a/test/integration/upstream_nameservers/controls/gcloud.rb
+++ b/test/integration/upstream_nameservers/controls/gcloud.rb
@@ -1,0 +1,50 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id = attribute('project_id')
+location = attribute('location')
+cluster_name = attribute('cluster_name')
+
+control "gcloud" do
+  title "Google Compute Engine GKE configuration"
+  describe command("gcloud --project=#{project_id} container clusters --zone=#{location} describe #{cluster_name} --format=json") do
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq '' }
+
+    let!(:data) do
+      if subject.exit_status == 0
+        JSON.parse(subject.stdout)
+      else
+        {}
+      end
+    end
+
+    describe "cluster" do
+      it "is running" do
+        expect(data['status']).to eq 'RUNNING'
+      end
+
+      it "has the expected addon settings" do
+        expect(data['addonsConfig']).to eq({
+          "horizontalPodAutoscaling" => {},
+          "httpLoadBalancing" => {},
+          "kubernetesDashboard" => {
+            "disabled" => true,
+          },
+          "networkPolicyConfig" => {},
+        })
+      end
+    end
+  end
+end

--- a/test/integration/upstream_nameservers/controls/kubectl.rb
+++ b/test/integration/upstream_nameservers/controls/kubectl.rb
@@ -1,0 +1,79 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'kubeclient'
+require 'rest-client'
+
+require 'base64'
+
+kubernetes_endpoint = attribute('kubernetes_endpoint')
+client_token = attribute('client_token')
+ca_certificate = attribute('ca_certificate')
+
+control "kubectl" do
+  title "Kubernetes configuration"
+
+  describe "kubernetes" do
+    let(:kubernetes_http_endpoint) { "https://#{kubernetes_endpoint}/api" }
+    let(:client) do
+      cert_store = OpenSSL::X509::Store.new
+      cert_store.add_cert(OpenSSL::X509::Certificate.new(Base64.decode64(ca_certificate)))
+      Kubeclient::Client.new(
+        kubernetes_http_endpoint,
+        "v1",
+        ssl_options: {
+          cert_store: cert_store,
+          verify_ssl: OpenSSL::SSL::VERIFY_PEER,
+        },
+        auth_options: {
+          bearer_token: Base64.decode64(client_token),
+        },
+      )
+    end
+
+    describe "configmap" do
+      describe "kube-dns" do
+        let(:kubedns_configmap) { client.get_config_map("kube-dns", "kube-system") }
+
+        it "is created by Terraform" do
+          expect(kubedns_configmap.metadata.labels.maintained_by).to eq "terraform"
+        end
+
+        it "reflects the upstream_nameservers configuration" do
+          expect(JSON.parse(kubedns_configmap.data.upstreamNameservers)).to eq(["8.8.8.8", "8.8.4.4"])
+        end
+      end
+
+      describe "ipmasq" do
+        let(:ipmasq_configmap) { client.get_config_map("ip-masq-agent", "kube-system") }
+
+        it "is created by Terraform" do
+          expect(ipmasq_configmap.metadata.labels.maintained_by).to eq "terraform"
+        end
+
+        it "is configured properly" do
+          expect(YAML.load(ipmasq_configmap.data.config)).to eq({
+            "nonMasqueradeCIDRs" => [
+              "10.0.0.0/8",
+              "172.16.0.0/12",
+              "192.168.0.0/16",
+            ],
+            "resyncInterval" => "60s",
+            "masqLinkLocal" => false,
+          })
+        end
+      end
+    end
+  end
+end

--- a/test/integration/upstream_nameservers/inspec.yml
+++ b/test/integration/upstream_nameservers/inspec.yml
@@ -1,0 +1,20 @@
+name: upstream_nameservers
+attributes:
+  - name: project_id
+    required: true
+    type: string
+  - name: location
+    required: true
+    type: string
+  - name: cluster_name
+    required: true
+    type: string
+  - name: kubernetes_endpoint
+    required: true
+    type: string
+  - name: client_token
+    required: true
+    type: string
+  - name: ca_certificate
+    required: true
+    type: string

--- a/variables.tf
+++ b/variables.tf
@@ -206,6 +206,12 @@ variable "stub_domains" {
   default     = {}
 }
 
+variable "upstream_nameservers" {
+  type        = "list"
+  description = "If specified, the values replace the nameservers taken by default from the node’s /etc/resolv.conf"
+  default     = []
+}
+
 variable "non_masquerade_cidrs" {
   type        = "list"
   description = "List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading."


### PR DESCRIPTION
This PR adds support for k8s upstreamNameservers in kube-dns.
This PR fixes https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/204