### PR TITLE
Add opt out for node pool autoscaling

### DIFF
--- a/autogen/cluster.tf
+++ b/autogen/cluster.tf
@@ -224,10 +224,13 @@ resource "google_container_node_pool" "pools" {
   {% endif %}
 
   node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "min_count", 1)
+
   dynamic "autoscaling" {
     for_each = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
-    min_node_count = autoscaling.value.min_count
-    max_node_count = autoscaling.value.max_count
+    content {
+      min_node_count = autoscaling.value.min_count
+     max_node_count = autoscaling.value.max_count
+    }
   }
 
   management {

--- a/autogen/cluster.tf
+++ b/autogen/cluster.tf
@@ -223,9 +223,11 @@ resource "google_container_node_pool" "pools" {
   max_pods_per_node = lookup(var.node_pools[count.index], "max_pods_per_node", null)
   {% endif %}
 
-  autoscaling {
-    min_node_count = lookup(var.node_pools[count.index], "min_count", 1)
-    max_node_count = lookup(var.node_pools[count.index], "max_count", 100)
+  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "min_count", 1)
+  dynamic "autoscaling" {
+    for_each = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
+    min_node_count = autoscaling.value.min_count
+    max_node_count = autoscaling.value.max_count
   }
 
   management {

--- a/autogen/cluster.tf
+++ b/autogen/cluster.tf
@@ -228,8 +228,8 @@ resource "google_container_node_pool" "pools" {
   dynamic "autoscaling" {
     for_each = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
     content {
-      min_node_count = autoscaling.value.min_count
-     max_node_count = autoscaling.value.max_count
+      min_node_count = lookup(autoscaling.value, "min_count", 1)
+      max_node_count = lookup(autoscaling.value, "max_count", 100)
     }
   }
 

--- a/autogen/variables.tf
+++ b/autogen/variables.tf
@@ -377,7 +377,7 @@ variable "enable_intranode_visibility" {
   default     = false
 }
 
- variable "enable_vertical_pod_autoscaling" {
+variable "enable_vertical_pod_autoscaling" {
   type        = bool
   description = "Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it"
   default     = false

--- a/cluster.tf
+++ b/cluster.tf
@@ -143,10 +143,13 @@ resource "google_container_node_pool" "pools" {
   )
 
   node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "min_count", 1)
+
   dynamic "autoscaling" {
-    for_each       = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
-    min_node_count = autoscaling.value.min_count
-    max_node_count = autoscaling.value.max_count
+    for_each = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
+    content {
+      min_node_count = autoscaling.value.min_count
+      max_node_count = autoscaling.value.max_count
+    }
   }
 
   management {

--- a/cluster.tf
+++ b/cluster.tf
@@ -142,9 +142,11 @@ resource "google_container_node_pool" "pools" {
     lookup(var.node_pools[count.index], "min_count", 1),
   )
 
-  autoscaling {
-    min_node_count = lookup(var.node_pools[count.index], "min_count", 1)
-    max_node_count = lookup(var.node_pools[count.index], "max_count", 100)
+  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "min_count", 1)
+  dynamic "autoscaling" {
+    for_each       = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
+    min_node_count = autoscaling.value.min_count
+    max_node_count = autoscaling.value.max_count
   }
 
   management {

--- a/cluster.tf
+++ b/cluster.tf
@@ -147,8 +147,8 @@ resource "google_container_node_pool" "pools" {
   dynamic "autoscaling" {
     for_each = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
     content {
-      min_node_count = autoscaling.value.min_count
-      max_node_count = autoscaling.value.max_count
+      min_node_count = lookup(autoscaling.value, "min_count", 1)
+      max_node_count = lookup(autoscaling.value, "max_count", 100)
     }
   }
 

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -207,9 +207,11 @@ resource "google_container_node_pool" "pools" {
   )
   max_pods_per_node = lookup(var.node_pools[count.index], "max_pods_per_node", null)
 
-  autoscaling {
-    min_node_count = lookup(var.node_pools[count.index], "min_count", 1)
-    max_node_count = lookup(var.node_pools[count.index], "max_count", 100)
+  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "min_count", 1)
+  dynamic "autoscaling" {
+    for_each       = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
+    min_node_count = autoscaling.value.min_count
+    max_node_count = autoscaling.value.max_count
   }
 
   management {

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -208,10 +208,13 @@ resource "google_container_node_pool" "pools" {
   max_pods_per_node = lookup(var.node_pools[count.index], "max_pods_per_node", null)
 
   node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "min_count", 1)
+
   dynamic "autoscaling" {
-    for_each       = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
-    min_node_count = autoscaling.value.min_count
-    max_node_count = autoscaling.value.max_count
+    for_each = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
+    content {
+      min_node_count = autoscaling.value.min_count
+      max_node_count = autoscaling.value.max_count
+    }
   }
 
   management {

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -212,8 +212,8 @@ resource "google_container_node_pool" "pools" {
   dynamic "autoscaling" {
     for_each = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
     content {
-      min_node_count = autoscaling.value.min_count
-      max_node_count = autoscaling.value.max_count
+      min_node_count = lookup(autoscaling.value, "min_count", 1)
+      max_node_count = lookup(autoscaling.value, "max_count", 100)
     }
   }
 

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -203,10 +203,13 @@ resource "google_container_node_pool" "pools" {
   max_pods_per_node = lookup(var.node_pools[count.index], "max_pods_per_node", null)
 
   node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "min_count", 1)
+
   dynamic "autoscaling" {
-    for_each       = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
-    min_node_count = autoscaling.value.min_count
-    max_node_count = autoscaling.value.max_count
+    for_each = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
+    content {
+      min_node_count = autoscaling.value.min_count
+      max_node_count = autoscaling.value.max_count
+    }
   }
 
   management {

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -202,9 +202,11 @@ resource "google_container_node_pool" "pools" {
   )
   max_pods_per_node = lookup(var.node_pools[count.index], "max_pods_per_node", null)
 
-  autoscaling {
-    min_node_count = lookup(var.node_pools[count.index], "min_count", 1)
-    max_node_count = lookup(var.node_pools[count.index], "max_count", 100)
+  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "min_count", 1)
+  dynamic "autoscaling" {
+    for_each       = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
+    min_node_count = autoscaling.value.min_count
+    max_node_count = autoscaling.value.max_count
   }
 
   management {

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -207,8 +207,8 @@ resource "google_container_node_pool" "pools" {
   dynamic "autoscaling" {
     for_each = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
     content {
-      min_node_count = autoscaling.value.min_count
-      max_node_count = autoscaling.value.max_count
+      min_node_count = lookup(autoscaling.value, "min_count", 1)
+      max_node_count = lookup(autoscaling.value, "max_count", 100)
     }
   }
 

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -148,10 +148,13 @@ resource "google_container_node_pool" "pools" {
   )
 
   node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "min_count", 1)
+
   dynamic "autoscaling" {
-    for_each       = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
-    min_node_count = autoscaling.value.min_count
-    max_node_count = autoscaling.value.max_count
+    for_each = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
+    content {
+      min_node_count = autoscaling.value.min_count
+      max_node_count = autoscaling.value.max_count
+    }
   }
 
   management {

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -152,8 +152,8 @@ resource "google_container_node_pool" "pools" {
   dynamic "autoscaling" {
     for_each = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
     content {
-      min_node_count = autoscaling.value.min_count
-      max_node_count = autoscaling.value.max_count
+      min_node_count = lookup(autoscaling.value, "min_count", 1)
+      max_node_count = lookup(autoscaling.value, "max_count", 100)
     }
   }
 

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -147,9 +147,11 @@ resource "google_container_node_pool" "pools" {
     lookup(var.node_pools[count.index], "min_count", 1),
   )
 
-  autoscaling {
-    min_node_count = lookup(var.node_pools[count.index], "min_count", 1)
-    max_node_count = lookup(var.node_pools[count.index], "max_count", 100)
+  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "min_count", 1)
+  dynamic "autoscaling" {
+    for_each       = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []
+    min_node_count = autoscaling.value.min_count
+    max_node_count = autoscaling.value.max_count
   }
 
   management {


### PR DESCRIPTION
#249 

Allow users to set `autoscaling = false` in the node pools map variable to toggle autoscaling on that specific node pool. By default and to keep existing behaviour the default value is true for autoscaling.

I've noticed we don't really document the possible keys in the node_pools map, do we want to start doing that and if so what's the preferred way?