### PR TITLE
Check null and length of beta feature outputs

### DIFF
--- a/autogen/main.tf
+++ b/autogen/main.tf
@@ -105,9 +105,9 @@ locals {
 {% if beta_cluster %}
   # BETA features
   cluster_output_istio_enabled                    = google_container_cluster.primary.addons_config.0.istio_config.0.disabled
-  cluster_output_pod_security_policy_enabled      = google_container_cluster.primary.pod_security_policy_config.0.enabled
+  cluster_output_pod_security_policy_enabled      = google_container_cluster.primary.pod_security_policy_config != null && length(google_container_cluster.primary.pod_security_policy_config) == 1 ? google_container_cluster.primary.pod_security_policy_config.0.enabled : false
   cluster_output_intranode_visbility_enabled      = google_container_cluster.primary.enable_intranode_visibility
-  cluster_output_vertical_pod_autoscaling_enabled = google_container_cluster.primary.vertical_pod_autoscaling.0.enabled
+  cluster_output_vertical_pod_autoscaling_enabled = google_container_cluster.primary.vertical_pod_autoscaling != null && length(google_container_cluster.primary.vertical_pod_autoscaling) == 1 ? google_container_cluster.primary.vertical_pod_autoscaling.0.enabled : false
 
   # /BETA features
   {% endif %}

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -94,9 +94,9 @@ locals {
 
   # BETA features
   cluster_output_istio_enabled                    = google_container_cluster.primary.addons_config.0.istio_config.0.disabled
-  cluster_output_pod_security_policy_enabled      = google_container_cluster.primary.pod_security_policy_config.0.enabled
+  cluster_output_pod_security_policy_enabled      = google_container_cluster.primary.pod_security_policy_config != null && length(google_container_cluster.primary.pod_security_policy_config) == 1 ? google_container_cluster.primary.pod_security_policy_config.0.enabled : false
   cluster_output_intranode_visbility_enabled      = google_container_cluster.primary.enable_intranode_visibility
-  cluster_output_vertical_pod_autoscaling_enabled = google_container_cluster.primary.vertical_pod_autoscaling.0.enabled
+  cluster_output_vertical_pod_autoscaling_enabled = google_container_cluster.primary.vertical_pod_autoscaling != null && length(google_container_cluster.primary.vertical_pod_autoscaling) == 1 ? google_container_cluster.primary.vertical_pod_autoscaling.0.enabled : false
 
   # /BETA features
 

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -94,9 +94,9 @@ locals {
 
   # BETA features
   cluster_output_istio_enabled                    = google_container_cluster.primary.addons_config.0.istio_config.0.disabled
-  cluster_output_pod_security_policy_enabled      = google_container_cluster.primary.pod_security_policy_config.0.enabled
+  cluster_output_pod_security_policy_enabled      = google_container_cluster.primary.pod_security_policy_config != null && length(google_container_cluster.primary.pod_security_policy_config) == 1 ? google_container_cluster.primary.pod_security_policy_config.0.enabled : false
   cluster_output_intranode_visbility_enabled      = google_container_cluster.primary.enable_intranode_visibility
-  cluster_output_vertical_pod_autoscaling_enabled = google_container_cluster.primary.vertical_pod_autoscaling.0.enabled
+  cluster_output_vertical_pod_autoscaling_enabled = google_container_cluster.primary.vertical_pod_autoscaling != null && length(google_container_cluster.primary.vertical_pod_autoscaling) == 1 ? google_container_cluster.primary.vertical_pod_autoscaling.0.enabled : false
 
   # /BETA features
 


### PR DESCRIPTION
Fixes this error:

```
Error: Invalid index

  on .terraform/modules/gke/modules/beta-private-cluster/main.tf line 97, in locals:
  97:   cluster_output_pod_security_policy_enabled      = google_container_cluster.primary.pod_security_policy_config.0.enabled
    |----------------
    | google_container_cluster.primary.pod_security_policy_config is empty list of object

The given key does not identify an element in this collection value.


Error: Invalid index

  on .terraform/modules/gke/modules/beta-private-cluster/main.tf line 99, in locals:
  99:   cluster_output_vertical_pod_autoscaling_enabled = google_container_cluster.primary.vertical_pod_autoscaling.0.enabled
    |----------------
    | google_container_cluster.primary.vertical_pod_autoscaling is empty list of object

The given key does not identify an element in this collection value.
```