### PR TITLE
Set cluster initial node count from var

### DIFF
--- a/autogen/cluster.tf
+++ b/autogen/cluster.tf
@@ -143,7 +143,7 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
-    ignore_changes = [node_pool]
+    ignore_changes = [node_pool, initial_node_count]
   }
 
   timeouts {
@@ -152,7 +152,6 @@ resource "google_container_cluster" "primary" {
     delete = "30m"
   }
 
-  initial_node_count = var.initial_node_count
   node_pool {
     name               = "default-pool"
     initial_node_count = var.initial_node_count

--- a/autogen/cluster.tf
+++ b/autogen/cluster.tf
@@ -152,6 +152,7 @@ resource "google_container_cluster" "primary" {
     delete = "30m"
   }
 
+  initial_node_count = var.initial_node_count
   node_pool {
     name               = "default-pool"
     initial_node_count = var.initial_node_count

--- a/cluster.tf
+++ b/cluster.tf
@@ -99,7 +99,7 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
-    ignore_changes = [node_pool]
+    ignore_changes = [node_pool, initial_node_count]
   }
 
   timeouts {
@@ -108,7 +108,6 @@ resource "google_container_cluster" "primary" {
     delete = "30m"
   }
 
-  initial_node_count = var.initial_node_count
   node_pool {
     name               = "default-pool"
     initial_node_count = var.initial_node_count

--- a/cluster.tf
+++ b/cluster.tf
@@ -108,6 +108,7 @@ resource "google_container_cluster" "primary" {
     delete = "30m"
   }
 
+  initial_node_count = var.initial_node_count
   node_pool {
     name               = "default-pool"
     initial_node_count = var.initial_node_count

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -135,7 +135,7 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
-    ignore_changes = [node_pool]
+    ignore_changes = [node_pool, initial_node_count]
   }
 
   timeouts {
@@ -144,7 +144,6 @@ resource "google_container_cluster" "primary" {
     delete = "30m"
   }
 
-  initial_node_count = var.initial_node_count
   node_pool {
     name               = "default-pool"
     initial_node_count = var.initial_node_count

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -144,6 +144,7 @@ resource "google_container_cluster" "primary" {
     delete = "30m"
   }
 
+  initial_node_count = var.initial_node_count
   node_pool {
     name               = "default-pool"
     initial_node_count = var.initial_node_count

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -135,7 +135,7 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
-    ignore_changes = [node_pool]
+    ignore_changes = [node_pool, initial_node_count]
   }
 
   timeouts {
@@ -144,7 +144,6 @@ resource "google_container_cluster" "primary" {
     delete = "30m"
   }
 
-  initial_node_count = var.initial_node_count
   node_pool {
     name               = "default-pool"
     initial_node_count = var.initial_node_count

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -144,6 +144,7 @@ resource "google_container_cluster" "primary" {
     delete = "30m"
   }
 
+  initial_node_count = var.initial_node_count
   node_pool {
     name               = "default-pool"
     initial_node_count = var.initial_node_count

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -99,7 +99,7 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
-    ignore_changes = [node_pool]
+    ignore_changes = [node_pool, initial_node_count]
   }
 
   timeouts {
@@ -108,7 +108,6 @@ resource "google_container_cluster" "primary" {
     delete = "30m"
   }
 
-  initial_node_count = var.initial_node_count
   node_pool {
     name               = "default-pool"
     initial_node_count = var.initial_node_count

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -108,6 +108,7 @@ resource "google_container_cluster" "primary" {
     delete = "30m"
   }
 
+  initial_node_count = var.initial_node_count
   node_pool {
     name               = "default-pool"
     initial_node_count = var.initial_node_count


### PR DESCRIPTION
Currently, the `var.initial_node_count` is not specified from the variable.

This forces a cluster replacement:

```
      - initial_node_count          = 1 -> null # forces replacement
```

An alternative is adding to `ignore_lifecycle`, like what we do with the `node_pool.*.initial_node_count`