### PR TITLE
[wait-for-cluster.sh] Set CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE.

### DIFF
--- a/scripts/wait-for-cluster.sh
+++ b/scripts/wait-for-cluster.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,10 @@
 # limitations under the License.
 
 set -e
+
+if [ -n "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
+    CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${GOOGLE_APPLICATION_CREDENTIALS}
+fi
 
 PROJECT=$1
 CLUSTER_NAME=$2


### PR DESCRIPTION
This is due to the fact that GCP client libraries and gcloud CLI automatically check for different environment variables - `GOOGLE_APPLICATION_CREDENTIALS` and `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` respectively.