### PR TITLE
#261: Invalid plan when re-applying terraform module

### DIFF
--- a/autogen/versions.tf
+++ b/autogen/versions.tf
@@ -16,4 +16,12 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+{% if beta_cluster %}
+    google-beta = "~> 2.18.0"
+{% else %}
+    google = "~> 2.18.0"
+{% endif %}
+  }
 }

--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 2.18.0"
   region  = var.region
 }
 

--- a/examples/disable_client_cert/main.tf
+++ b/examples/disable_client_cert/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 2.18.0"
   region  = var.region
 }
 

--- a/examples/node_pool_update_variant/main.tf
+++ b/examples/node_pool_update_variant/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 2.18.0"
   region  = var.region
 }
 

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 2.18.0"
   region  = var.region
 }
 

--- a/examples/simple_regional/main.tf
+++ b/examples/simple_regional/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 2.18.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_private/main.tf
+++ b/examples/simple_regional_private/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 2.18.0"
   region  = var.region
 }
 

--- a/examples/simple_zonal/main.tf
+++ b/examples/simple_zonal/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 2.18.0"
   region  = var.region
 }
 

--- a/examples/simple_zonal_private/main.tf
+++ b/examples/simple_zonal_private/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 2.18.0"
   region  = var.region
 }
 

--- a/examples/stub_domains/main.tf
+++ b/examples/stub_domains/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 2.18.0"
   region  = var.region
 }
 

--- a/examples/stub_domains_private/main.tf
+++ b/examples/stub_domains_private/main.tf
@@ -15,12 +15,8 @@
  */
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 2.18.0"
   region  = var.region
-}
-
-provider "random" {
-  version = "~> 2.1"
 }
 
 data "google_compute_subnetwork" "subnetwork" {

--- a/examples/stub_domains_upstream_nameservers/main.tf
+++ b/examples/stub_domains_upstream_nameservers/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 2.18.0"
   region  = var.region
 }
 

--- a/examples/upstream_nameservers/main.tf
+++ b/examples/upstream_nameservers/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 2.18.0"
   region  = var.region
 }
 

--- a/modules/beta-private-cluster-update-variant/versions.tf
+++ b/modules/beta-private-cluster-update-variant/versions.tf
@@ -16,4 +16,8 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    google-beta = "~> 2.18.0"
+  }
 }

--- a/modules/beta-private-cluster/versions.tf
+++ b/modules/beta-private-cluster/versions.tf
@@ -16,4 +16,8 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    google-beta = "~> 2.18.0"
+  }
 }

--- a/modules/beta-public-cluster/versions.tf
+++ b/modules/beta-public-cluster/versions.tf
@@ -16,4 +16,8 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    google-beta = "~> 2.18.0"
+  }
 }

--- a/modules/private-cluster-update-variant/versions.tf
+++ b/modules/private-cluster-update-variant/versions.tf
@@ -16,4 +16,8 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    google = "~> 2.18.0"
+  }
 }

--- a/modules/private-cluster/versions.tf
+++ b/modules/private-cluster/versions.tf
@@ -16,4 +16,8 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    google = "~> 2.18.0"
+  }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -16,4 +16,8 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    google = "~> 2.18.0"
+  }
 }


### PR DESCRIPTION
Fixes #261

Bumbed minimal provider version to 2.18