### PR TITLE
Tying identity namespace output to successful cluster creation.

### DIFF
--- a/autogen/outputs.tf
+++ b/autogen/outputs.tf
@@ -154,4 +154,12 @@ output "release_channel" {
   description = "The release channel of this cluster"
   value       = var.release_channel
 }
+
+output "identity_namespace" {
+  description = "Workload Identity namespace"
+  value       = var.identity_namespace
+  depends_on = [
+    "google_container_cluster.primary"
+  ]
+}
 {% endif %}

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -212,6 +212,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | endpoint | Cluster endpoint |
 | horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |
 | http\_load\_balancing\_enabled | Whether http load balancing enabled |
+| identity\_namespace | Workload Identity namespace |
 | intranode\_visibility\_enabled | Whether intra-node visibility is enabled |
 | istio\_enabled | Whether Istio is enabled |
 | kubernetes\_dashboard\_enabled | Whether kubernetes dashboard enabled |

--- a/modules/beta-private-cluster-update-variant/outputs.tf
+++ b/modules/beta-private-cluster-update-variant/outputs.tf
@@ -153,3 +153,11 @@ output "release_channel" {
   description = "The release channel of this cluster"
   value       = var.release_channel
 }
+
+output "identity_namespace" {
+  description = "Workload Identity namespace"
+  value       = var.identity_namespace
+  depends_on = [
+    "google_container_cluster.primary"
+  ]
+}

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -212,6 +212,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | endpoint | Cluster endpoint |
 | horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |
 | http\_load\_balancing\_enabled | Whether http load balancing enabled |
+| identity\_namespace | Workload Identity namespace |
 | intranode\_visibility\_enabled | Whether intra-node visibility is enabled |
 | istio\_enabled | Whether Istio is enabled |
 | kubernetes\_dashboard\_enabled | Whether kubernetes dashboard enabled |

--- a/modules/beta-private-cluster/outputs.tf
+++ b/modules/beta-private-cluster/outputs.tf
@@ -153,3 +153,11 @@ output "release_channel" {
   description = "The release channel of this cluster"
   value       = var.release_channel
 }
+
+output "identity_namespace" {
+  description = "Workload Identity namespace"
+  value       = var.identity_namespace
+  depends_on = [
+    "google_container_cluster.primary"
+  ]
+}

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -203,6 +203,7 @@ In either case, upgrading to module version `v1.0.0` will trigger a recreation o
 | endpoint | Cluster endpoint |
 | horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |
 | http\_load\_balancing\_enabled | Whether http load balancing enabled |
+| identity\_namespace | Workload Identity namespace |
 | intranode\_visibility\_enabled | Whether intra-node visibility is enabled |
 | istio\_enabled | Whether Istio is enabled |
 | kubernetes\_dashboard\_enabled | Whether kubernetes dashboard enabled |

--- a/modules/beta-public-cluster/outputs.tf
+++ b/modules/beta-public-cluster/outputs.tf
@@ -153,3 +153,11 @@ output "release_channel" {
   description = "The release channel of this cluster"
   value       = var.release_channel
 }
+
+output "identity_namespace" {
+  description = "Workload Identity namespace"
+  value       = var.identity_namespace
+  depends_on = [
+    "google_container_cluster.primary"
+  ]
+}


### PR DESCRIPTION
When configuring workload identity, there is the possibility that when creating an IAM binding, Terraform attempts to create the binding, before the workload identity is configured by GKE.  This PR creates a tighter dependency between the creation of a GKE cluster and the availability of the workload identity.

This is the first step in addressing https://github.com/forseti-security/terraform-google-forseti/issues/298.