### PR TITLE
Don't set initial_node_count when autoscaling disabled on node pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Extending the adopted spec, each change should have a link to its corresponding 
 
 * Support for Shielded Nodes beta feature via `enabled_shielded_nodes` variable. [#300]
 * Support for setting node_locations on node pools. [#303]
+* Fix for specifying  `node_count` on node pools when autoscaling is disabled. [#313]
 
 ## [v5.1.1] - 2019-10-25
 

--- a/autogen/cluster.tf
+++ b/autogen/cluster.tf
@@ -316,16 +316,18 @@ resource "google_container_node_pool" "pools" {
     "version",
     local.node_version,
   )
-  initial_node_count = lookup(
+
+  initial_node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? lookup(
     var.node_pools[count.index],
     "initial_node_count",
-    lookup(var.node_pools[count.index], "min_count", 1),
-  )
+    lookup(var.node_pools[count.index], "min_count", 1)
+  ) : null
+
   {% if beta_cluster %}
   max_pods_per_node = lookup(var.node_pools[count.index], "max_pods_per_node", null)
   {% endif %}
 
-  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "min_count", 1)
+  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "node_count", 1)
 
   dynamic "autoscaling" {
     for_each = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []

--- a/cluster.tf
+++ b/cluster.tf
@@ -137,13 +137,15 @@ resource "google_container_node_pool" "pools" {
     "version",
     local.node_version,
   )
-  initial_node_count = lookup(
+
+  initial_node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? lookup(
     var.node_pools[count.index],
     "initial_node_count",
-    lookup(var.node_pools[count.index], "min_count", 1),
-  )
+    lookup(var.node_pools[count.index], "min_count", 1)
+  ) : null
 
-  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "min_count", 1)
+
+  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "node_count", 1)
 
   dynamic "autoscaling" {
     for_each = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -60,9 +60,9 @@ module "gke" {
       service_account   = var.compute_engine_service_account
     },
     {
-      name              = "pool-03"
-      autoscaling       = false
-      node_count        = 2
+      name            = "pool-03"
+      autoscaling     = false
+      node_count      = 2
       service_account = var.compute_engine_service_account
       auto_upgrade    = true
     },

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -59,12 +59,20 @@ module "gke" {
       auto_repair       = false
       service_account   = var.compute_engine_service_account
     },
+    {
+      name              = "pool-03"
+      autoscaling       = false
+      node_count        = 2
+      service_account = var.compute_engine_service_account
+      auto_upgrade    = true
+    },
   ]
 
   node_pools_oauth_scopes = {
     all     = []
     pool-01 = []
     pool-02 = []
+    pool-03 = []
   }
 
   node_pools_metadata = {
@@ -73,6 +81,7 @@ module "gke" {
       shutdown-script = file("${path.module}/data/shutdown-script.sh")
     }
     pool-02 = {}
+    pool-03 = {}
   }
 
   node_pools_labels = {
@@ -83,6 +92,7 @@ module "gke" {
       pool-01-example = true
     }
     pool-02 = {}
+    pool-03 = {}
   }
 
   node_pools_taints = {
@@ -101,6 +111,7 @@ module "gke" {
       },
     ]
     pool-02 = []
+    pool-03 = []
   }
 
   node_pools_tags = {
@@ -111,6 +122,7 @@ module "gke" {
       "pool-01-example",
     ]
     pool-02 = []
+    pool-03 = []
   }
 }
 

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -60,7 +60,7 @@ module "gke" {
     },
     {
       name            = "pool-03"
-      node_locations  = "us-east4-b,us-east4-c"
+      node_locations  = "${var.region}-b,${var.region}-c"
       autoscaling     = false
       node_count      = 2
       machine_type    = "n1-standard-2"

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -290,14 +290,16 @@ resource "google_container_node_pool" "pools" {
     "version",
     local.node_version,
   )
-  initial_node_count = lookup(
+
+  initial_node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? lookup(
     var.node_pools[count.index],
     "initial_node_count",
-    lookup(var.node_pools[count.index], "min_count", 1),
-  )
+    lookup(var.node_pools[count.index], "min_count", 1)
+  ) : null
+
   max_pods_per_node = lookup(var.node_pools[count.index], "max_pods_per_node", null)
 
-  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "min_count", 1)
+  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "node_count", 1)
 
   dynamic "autoscaling" {
     for_each = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -218,14 +218,16 @@ resource "google_container_node_pool" "pools" {
     "version",
     local.node_version,
   )
-  initial_node_count = lookup(
+
+  initial_node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? lookup(
     var.node_pools[count.index],
     "initial_node_count",
-    lookup(var.node_pools[count.index], "min_count", 1),
-  )
+    lookup(var.node_pools[count.index], "min_count", 1)
+  ) : null
+
   max_pods_per_node = lookup(var.node_pools[count.index], "max_pods_per_node", null)
 
-  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "min_count", 1)
+  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "node_count", 1)
 
   dynamic "autoscaling" {
     for_each = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -213,14 +213,16 @@ resource "google_container_node_pool" "pools" {
     "version",
     local.node_version,
   )
-  initial_node_count = lookup(
+
+  initial_node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? lookup(
     var.node_pools[count.index],
     "initial_node_count",
-    lookup(var.node_pools[count.index], "min_count", 1),
-  )
+    lookup(var.node_pools[count.index], "min_count", 1)
+  ) : null
+
   max_pods_per_node = lookup(var.node_pools[count.index], "max_pods_per_node", null)
 
-  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "min_count", 1)
+  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "node_count", 1)
 
   dynamic "autoscaling" {
     for_each = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -214,13 +214,15 @@ resource "google_container_node_pool" "pools" {
     "version",
     local.node_version,
   )
-  initial_node_count = lookup(
+
+  initial_node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? lookup(
     var.node_pools[count.index],
     "initial_node_count",
-    lookup(var.node_pools[count.index], "min_count", 1),
-  )
+    lookup(var.node_pools[count.index], "min_count", 1)
+  ) : null
 
-  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "min_count", 1)
+
+  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "node_count", 1)
 
   dynamic "autoscaling" {
     for_each = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -142,13 +142,15 @@ resource "google_container_node_pool" "pools" {
     "version",
     local.node_version,
   )
-  initial_node_count = lookup(
+
+  initial_node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? lookup(
     var.node_pools[count.index],
     "initial_node_count",
-    lookup(var.node_pools[count.index], "min_count", 1),
-  )
+    lookup(var.node_pools[count.index], "min_count", 1)
+  ) : null
 
-  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "min_count", 1)
+
+  node_count = lookup(var.node_pools[count.index], "autoscaling", true) ? null : lookup(var.node_pools[count.index], "node_count", 1)
 
   dynamic "autoscaling" {
     for_each = lookup(var.node_pools[count.index], "autoscaling", true) ? [var.node_pools[count.index]] : []

--- a/test/fixtures/shared/variables.tf
+++ b/test/fixtures/shared/variables.tf
@@ -20,13 +20,13 @@ variable "project_id" {
 
 variable "region" {
   description = "The GCP region to create and test resources in"
-  default     = "us-east4"
+  default     = "us-central1"
 }
 
 variable "zones" {
   type        = list(string)
   description = "The GCP zones to create and test resources in, for applicable tests"
-  default     = ["us-east4-a", "us-east4-b", "us-east4-c"]
+  default     = ["us-central1-a", "us-central1-b", "us-central1-c"]
 }
 
 variable "compute_engine_service_account" {
@@ -36,4 +36,3 @@ variable "compute_engine_service_account" {
 variable "registry_project_id" {
   description = "Project to use for granting access to the GCR registry, if requested"
 }
-

--- a/test/integration/node_pool/controls/gcloud.rb
+++ b/test/integration/node_pool/controls/gcloud.rb
@@ -392,8 +392,8 @@ control "gcloud" do
         including(
           "name" => "pool-03",
           "locations" => match_array([
-            "us-east4-b",
-            "us-east4-c",
+            "us-central1-b",
+            "us-central1-c",
           ]),
         )
       )

--- a/test/integration/node_pool/controls/gcloud.rb
+++ b/test/integration/node_pool/controls/gcloud.rb
@@ -36,8 +36,8 @@ control "gcloud" do
     describe "node pools" do
       let(:node_pools) { data['nodePools'].reject { |p| p['name'] == "default-pool" } }
 
-      it "has 2" do
-        expect(node_pools.count).to eq 2
+      it "has 3" do
+        expect(node_pools.count).to eq 3
       end
 
       describe "pool-01" do
@@ -274,6 +274,99 @@ control "gcloud" do
                   "gke-#{cluster_name}",
                   "gke-#{cluster_name}-pool-02",
                 ])
+              ),
+            )
+          )
+        end
+      end
+
+      describe "pool-03" do
+        it "exists" do
+          expect(data['nodePools']).to include(
+            including(
+              "name" => "pool-03",
+            )
+          )
+        end
+
+        it "is the expected machine type" do
+          expect(data['nodePools']).to include(
+            including(
+              "name" => "pool-03",
+              "config" => including(
+                "machineType" => "n1-standard-2",
+              ),
+            )
+          )
+        end
+
+        it "has autoscaling disabled" do
+          expect(data['nodePools']).not_to include(
+            including(
+              "name" => "pool-03",
+              "autoscaling" => including(
+                "enabled" => true,
+              ),
+            )
+          )
+        end
+
+        it "has the expected node count" do
+          expect(data['nodePools']).to include(
+            including(
+              "name" => "pool-03",
+              "initialNodeCount" => 2
+            )
+          )
+        end
+
+        it "has autorepair enabled" do
+          expect(data['nodePools']).to include(
+            including(
+              "name" => "pool-03",
+              "management" => including(
+                "autoRepair" => true,
+              ),
+            )
+          )
+        end
+
+        it "has automatic upgrades enabled" do
+          expect(data['nodePools']).to include(
+            including(
+              "name" => "pool-03",
+              "management" => including(
+                "autoUpgrade" => true,
+              ),
+            )
+          )
+        end
+
+        it "has the expected labels" do
+          expect(data['nodePools']).to include(
+            including(
+              "name" => "pool-03",
+              "config" => including(
+                "labels" => {
+                  "all-pools-example" => "true",
+                  "cluster_name" => cluster_name,
+                  "node_pool" => "pool-03",
+                },
+              ),
+            )
+          )
+        end
+
+        it "has the expected network tags" do
+          expect(data['nodePools']).to include(
+            including(
+              "name" => "pool-03",
+              "config" => including(
+                "tags" => match_array([
+                  "all-node-example",
+                  "gke-#{cluster_name}",
+                  "gke-#{cluster_name}-pool-03",
+                ]),
               ),
             )
           )

--- a/test/integration/node_pool/controls/kubectl.rb
+++ b/test/integration/node_pool/controls/kubectl.rb
@@ -82,6 +82,21 @@ control "kubectl" do
           )
         end
       end
+      describe "pool-03" do
+        let(:nodes) do
+          all_nodes.select { |n| n.metadata.labels.node_pool == "pool-03" }
+        end
+
+        it "has the expected taints" do
+          expect(taints).to include(
+            {
+              effect: "PreferNoSchedule",
+              key: "all-pools-example",
+              value: "true",
+            }
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #311 

When `autoscaling` is `false` for a node pool only `node_count` should be set. `initial_node_count` should be empty. 

Also uses a new node pool var `node_count` rather than using `min_count` to match the provider vars.  #297 should be updated to include this (defaults to `1`). 

A node pool without autoscaling can be created with
```
{
    autoscaling = false
    node_count = 2 
    ...
}
```