### PR TITLE
Bugfix/kubernetes dashboard cluster ipv4

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -27,10 +27,9 @@ resource "google_container_cluster" "primary" {
   project         = var.project_id
   resource_labels = var.cluster_resource_labels
 
-  location          = local.location
-  node_locations    = local.node_locations
-  cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = data.google_compute_network.gke_network.self_link
+  location       = local.location
+  node_locations = local.node_locations
+  network        = data.google_compute_network.gke_network.self_link
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/cluster.tf
+++ b/cluster.tf
@@ -79,10 +79,6 @@ resource "google_container_cluster" "primary" {
       disabled = ! var.horizontal_pod_autoscaling
     }
 
-    kubernetes_dashboard {
-      disabled = ! var.kubernetes_dashboard
-    }
-
     network_policy_config {
       disabled = ! var.network_policy
     }

--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,6 @@ locals {
   cluster_output_network_policy_enabled             = google_container_cluster.primary.addons_config.0.network_policy_config.0.disabled
   cluster_output_http_load_balancing_enabled        = google_container_cluster.primary.addons_config.0.http_load_balancing.0.disabled
   cluster_output_horizontal_pod_autoscaling_enabled = google_container_cluster.primary.addons_config.0.horizontal_pod_autoscaling.0.disabled
-  cluster_output_kubernetes_dashboard_enabled       = google_container_cluster.primary.addons_config.0.kubernetes_dashboard.0.disabled
 
 
   cluster_output_node_pools_names    = concat(google_container_node_pool.pools.*.name, [""])
@@ -105,7 +104,6 @@ locals {
   cluster_network_policy_enabled             = ! local.cluster_output_network_policy_enabled
   cluster_http_load_balancing_enabled        = ! local.cluster_output_http_load_balancing_enabled
   cluster_horizontal_pod_autoscaling_enabled = ! local.cluster_output_horizontal_pod_autoscaling_enabled
-  cluster_kubernetes_dashboard_enabled       = ! local.cluster_output_kubernetes_dashboard_enabled
 }
 
 /******************************************

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -27,10 +27,9 @@ resource "google_container_cluster" "primary" {
   project         = var.project_id
   resource_labels = var.cluster_resource_labels
 
-  location          = local.location
-  node_locations    = local.node_locations
-  cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = data.google_compute_network.gke_network.self_link
+  location       = local.location
+  node_locations = local.node_locations
+  network        = data.google_compute_network.gke_network.self_link
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -111,10 +111,6 @@ resource "google_container_cluster" "primary" {
       disabled = ! var.horizontal_pod_autoscaling
     }
 
-    kubernetes_dashboard {
-      disabled = ! var.kubernetes_dashboard
-    }
-
     network_policy_config {
       disabled = ! var.network_policy
     }

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -93,7 +93,6 @@ locals {
   cluster_output_network_policy_enabled             = google_container_cluster.primary.addons_config.0.network_policy_config.0.disabled
   cluster_output_http_load_balancing_enabled        = google_container_cluster.primary.addons_config.0.http_load_balancing.0.disabled
   cluster_output_horizontal_pod_autoscaling_enabled = google_container_cluster.primary.addons_config.0.horizontal_pod_autoscaling.0.disabled
-  cluster_output_kubernetes_dashboard_enabled       = google_container_cluster.primary.addons_config.0.kubernetes_dashboard.0.disabled
 
   # BETA features
   cluster_output_istio_disabled                   = google_container_cluster.primary.addons_config.0.istio_config != null && length(google_container_cluster.primary.addons_config.0.istio_config) == 1 ? google_container_cluster.primary.addons_config.0.istio_config.0.disabled : false
@@ -125,7 +124,6 @@ locals {
   cluster_network_policy_enabled             = ! local.cluster_output_network_policy_enabled
   cluster_http_load_balancing_enabled        = ! local.cluster_output_http_load_balancing_enabled
   cluster_horizontal_pod_autoscaling_enabled = ! local.cluster_output_horizontal_pod_autoscaling_enabled
-  cluster_kubernetes_dashboard_enabled       = ! local.cluster_output_kubernetes_dashboard_enabled
   # BETA features
   cluster_istio_enabled                    = ! local.cluster_output_istio_disabled
   cluster_cloudrun_enabled                 = var.cloudrun

--- a/modules/beta-private-cluster-update-variant/outputs.tf
+++ b/modules/beta-private-cluster-update-variant/outputs.tf
@@ -103,11 +103,6 @@ output "horizontal_pod_autoscaling_enabled" {
   value       = local.cluster_horizontal_pod_autoscaling_enabled
 }
 
-output "kubernetes_dashboard_enabled" {
-  description = "Whether kubernetes dashboard enabled"
-  value       = local.cluster_kubernetes_dashboard_enabled
-}
-
 output "node_pools_names" {
   description = "List of node pools names"
   value       = local.cluster_node_pools_names

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -292,11 +292,6 @@ variable "issue_client_certificate" {
   default     = false
 }
 
-variable "cluster_ipv4_cidr" {
-  default     = ""
-  description = "The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR."
-}
-
 variable "cluster_resource_labels" {
   type        = map(string)
   description = "The GCE resource labels (a map of key/value pairs) to be applied to the cluster"

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -96,12 +96,6 @@ variable "http_load_balancing" {
   default     = true
 }
 
-variable "kubernetes_dashboard" {
-  type        = bool
-  description = "Enable kubernetes dashboard addon"
-  default     = false
-}
-
 variable "network_policy" {
   type        = bool
   description = "Enable network policy addon"

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -27,10 +27,9 @@ resource "google_container_cluster" "primary" {
   project         = var.project_id
   resource_labels = var.cluster_resource_labels
 
-  location          = local.location
-  node_locations    = local.node_locations
-  cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = data.google_compute_network.gke_network.self_link
+  location       = local.location
+  node_locations = local.node_locations
+  network        = data.google_compute_network.gke_network.self_link
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -111,10 +111,6 @@ resource "google_container_cluster" "primary" {
       disabled = ! var.horizontal_pod_autoscaling
     }
 
-    kubernetes_dashboard {
-      disabled = ! var.kubernetes_dashboard
-    }
-
     network_policy_config {
       disabled = ! var.network_policy
     }

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -93,7 +93,6 @@ locals {
   cluster_output_network_policy_enabled             = google_container_cluster.primary.addons_config.0.network_policy_config.0.disabled
   cluster_output_http_load_balancing_enabled        = google_container_cluster.primary.addons_config.0.http_load_balancing.0.disabled
   cluster_output_horizontal_pod_autoscaling_enabled = google_container_cluster.primary.addons_config.0.horizontal_pod_autoscaling.0.disabled
-  cluster_output_kubernetes_dashboard_enabled       = google_container_cluster.primary.addons_config.0.kubernetes_dashboard.0.disabled
 
   # BETA features
   cluster_output_istio_disabled                   = google_container_cluster.primary.addons_config.0.istio_config != null && length(google_container_cluster.primary.addons_config.0.istio_config) == 1 ? google_container_cluster.primary.addons_config.0.istio_config.0.disabled : false
@@ -125,7 +124,6 @@ locals {
   cluster_network_policy_enabled             = ! local.cluster_output_network_policy_enabled
   cluster_http_load_balancing_enabled        = ! local.cluster_output_http_load_balancing_enabled
   cluster_horizontal_pod_autoscaling_enabled = ! local.cluster_output_horizontal_pod_autoscaling_enabled
-  cluster_kubernetes_dashboard_enabled       = ! local.cluster_output_kubernetes_dashboard_enabled
   # BETA features
   cluster_istio_enabled                    = ! local.cluster_output_istio_disabled
   cluster_cloudrun_enabled                 = var.cloudrun

--- a/modules/beta-private-cluster/outputs.tf
+++ b/modules/beta-private-cluster/outputs.tf
@@ -103,11 +103,6 @@ output "horizontal_pod_autoscaling_enabled" {
   value       = local.cluster_horizontal_pod_autoscaling_enabled
 }
 
-output "kubernetes_dashboard_enabled" {
-  description = "Whether kubernetes dashboard enabled"
-  value       = local.cluster_kubernetes_dashboard_enabled
-}
-
 output "node_pools_names" {
   description = "List of node pools names"
   value       = local.cluster_node_pools_names

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -292,11 +292,6 @@ variable "issue_client_certificate" {
   default     = false
 }
 
-variable "cluster_ipv4_cidr" {
-  default     = ""
-  description = "The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR."
-}
-
 variable "cluster_resource_labels" {
   type        = map(string)
   description = "The GCE resource labels (a map of key/value pairs) to be applied to the cluster"

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -96,12 +96,6 @@ variable "http_load_balancing" {
   default     = true
 }
 
-variable "kubernetes_dashboard" {
-  type        = bool
-  description = "Enable kubernetes dashboard addon"
-  default     = false
-}
-
 variable "network_policy" {
   type        = bool
   description = "Enable network policy addon"

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -27,10 +27,9 @@ resource "google_container_cluster" "primary" {
   project         = var.project_id
   resource_labels = var.cluster_resource_labels
 
-  location          = local.location
-  node_locations    = local.node_locations
-  cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = data.google_compute_network.gke_network.self_link
+  location       = local.location
+  node_locations = local.node_locations
+  network        = data.google_compute_network.gke_network.self_link
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -111,10 +111,6 @@ resource "google_container_cluster" "primary" {
       disabled = ! var.horizontal_pod_autoscaling
     }
 
-    kubernetes_dashboard {
-      disabled = ! var.kubernetes_dashboard
-    }
-
     network_policy_config {
       disabled = ! var.network_policy
     }

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -93,7 +93,6 @@ locals {
   cluster_output_network_policy_enabled             = google_container_cluster.primary.addons_config.0.network_policy_config.0.disabled
   cluster_output_http_load_balancing_enabled        = google_container_cluster.primary.addons_config.0.http_load_balancing.0.disabled
   cluster_output_horizontal_pod_autoscaling_enabled = google_container_cluster.primary.addons_config.0.horizontal_pod_autoscaling.0.disabled
-  cluster_output_kubernetes_dashboard_enabled       = google_container_cluster.primary.addons_config.0.kubernetes_dashboard.0.disabled
 
   # BETA features
   cluster_output_istio_disabled                   = google_container_cluster.primary.addons_config.0.istio_config != null && length(google_container_cluster.primary.addons_config.0.istio_config) == 1 ? google_container_cluster.primary.addons_config.0.istio_config.0.disabled : false
@@ -125,7 +124,6 @@ locals {
   cluster_network_policy_enabled             = ! local.cluster_output_network_policy_enabled
   cluster_http_load_balancing_enabled        = ! local.cluster_output_http_load_balancing_enabled
   cluster_horizontal_pod_autoscaling_enabled = ! local.cluster_output_horizontal_pod_autoscaling_enabled
-  cluster_kubernetes_dashboard_enabled       = ! local.cluster_output_kubernetes_dashboard_enabled
   # BETA features
   cluster_istio_enabled                    = ! local.cluster_output_istio_disabled
   cluster_cloudrun_enabled                 = var.cloudrun

--- a/modules/beta-public-cluster/outputs.tf
+++ b/modules/beta-public-cluster/outputs.tf
@@ -103,11 +103,6 @@ output "horizontal_pod_autoscaling_enabled" {
   value       = local.cluster_horizontal_pod_autoscaling_enabled
 }
 
-output "kubernetes_dashboard_enabled" {
-  description = "Whether kubernetes dashboard enabled"
-  value       = local.cluster_kubernetes_dashboard_enabled
-}
-
 output "node_pools_names" {
   description = "List of node pools names"
   value       = local.cluster_node_pools_names

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -292,11 +292,6 @@ variable "issue_client_certificate" {
   default     = false
 }
 
-variable "cluster_ipv4_cidr" {
-  default     = ""
-  description = "The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR."
-}
-
 variable "cluster_resource_labels" {
   type        = map(string)
   description = "The GCE resource labels (a map of key/value pairs) to be applied to the cluster"

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -96,12 +96,6 @@ variable "http_load_balancing" {
   default     = true
 }
 
-variable "kubernetes_dashboard" {
-  type        = bool
-  description = "Enable kubernetes dashboard addon"
-  default     = false
-}
-
 variable "network_policy" {
   type        = bool
   description = "Enable network policy addon"

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -27,10 +27,9 @@ resource "google_container_cluster" "primary" {
   project         = var.project_id
   resource_labels = var.cluster_resource_labels
 
-  location          = local.location
-  node_locations    = local.node_locations
-  cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = data.google_compute_network.gke_network.self_link
+  location       = local.location
+  node_locations = local.node_locations
+  network        = data.google_compute_network.gke_network.self_link
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -79,10 +79,6 @@ resource "google_container_cluster" "primary" {
       disabled = ! var.horizontal_pod_autoscaling
     }
 
-    kubernetes_dashboard {
-      disabled = ! var.kubernetes_dashboard
-    }
-
     network_policy_config {
       disabled = ! var.network_policy
     }

--- a/modules/private-cluster-update-variant/main.tf
+++ b/modules/private-cluster-update-variant/main.tf
@@ -80,7 +80,6 @@ locals {
   cluster_output_network_policy_enabled             = google_container_cluster.primary.addons_config.0.network_policy_config.0.disabled
   cluster_output_http_load_balancing_enabled        = google_container_cluster.primary.addons_config.0.http_load_balancing.0.disabled
   cluster_output_horizontal_pod_autoscaling_enabled = google_container_cluster.primary.addons_config.0.horizontal_pod_autoscaling.0.disabled
-  cluster_output_kubernetes_dashboard_enabled       = google_container_cluster.primary.addons_config.0.kubernetes_dashboard.0.disabled
 
 
   cluster_output_node_pools_names    = concat(google_container_node_pool.pools.*.name, [""])
@@ -105,7 +104,6 @@ locals {
   cluster_network_policy_enabled             = ! local.cluster_output_network_policy_enabled
   cluster_http_load_balancing_enabled        = ! local.cluster_output_http_load_balancing_enabled
   cluster_horizontal_pod_autoscaling_enabled = ! local.cluster_output_horizontal_pod_autoscaling_enabled
-  cluster_kubernetes_dashboard_enabled       = ! local.cluster_output_kubernetes_dashboard_enabled
 }
 
 /******************************************

--- a/modules/private-cluster-update-variant/outputs.tf
+++ b/modules/private-cluster-update-variant/outputs.tf
@@ -103,11 +103,6 @@ output "horizontal_pod_autoscaling_enabled" {
   value       = local.cluster_horizontal_pod_autoscaling_enabled
 }
 
-output "kubernetes_dashboard_enabled" {
-  description = "Whether kubernetes dashboard enabled"
-  value       = local.cluster_kubernetes_dashboard_enabled
-}
-
 output "node_pools_names" {
   description = "List of node pools names"
   value       = local.cluster_node_pools_names
@@ -122,4 +117,3 @@ output "service_account" {
   description = "The service account to default running nodes as if not overridden in `node_pools`."
   value       = local.service_account
 }
-

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -282,11 +282,6 @@ variable "issue_client_certificate" {
   default     = false
 }
 
-variable "cluster_ipv4_cidr" {
-  default     = ""
-  description = "The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR."
-}
-
 variable "cluster_resource_labels" {
   type        = map(string)
   description = "The GCE resource labels (a map of key/value pairs) to be applied to the cluster"

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -96,12 +96,6 @@ variable "http_load_balancing" {
   default     = true
 }
 
-variable "kubernetes_dashboard" {
-  type        = bool
-  description = "Enable kubernetes dashboard addon"
-  default     = false
-}
-
 variable "network_policy" {
   type        = bool
   description = "Enable network policy addon"

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -27,10 +27,9 @@ resource "google_container_cluster" "primary" {
   project         = var.project_id
   resource_labels = var.cluster_resource_labels
 
-  location          = local.location
-  node_locations    = local.node_locations
-  cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = data.google_compute_network.gke_network.self_link
+  location       = local.location
+  node_locations = local.node_locations
+  network        = data.google_compute_network.gke_network.self_link
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -79,10 +79,6 @@ resource "google_container_cluster" "primary" {
       disabled = ! var.horizontal_pod_autoscaling
     }
 
-    kubernetes_dashboard {
-      disabled = ! var.kubernetes_dashboard
-    }
-
     network_policy_config {
       disabled = ! var.network_policy
     }

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -80,7 +80,6 @@ locals {
   cluster_output_network_policy_enabled             = google_container_cluster.primary.addons_config.0.network_policy_config.0.disabled
   cluster_output_http_load_balancing_enabled        = google_container_cluster.primary.addons_config.0.http_load_balancing.0.disabled
   cluster_output_horizontal_pod_autoscaling_enabled = google_container_cluster.primary.addons_config.0.horizontal_pod_autoscaling.0.disabled
-  cluster_output_kubernetes_dashboard_enabled       = google_container_cluster.primary.addons_config.0.kubernetes_dashboard.0.disabled
 
 
   cluster_output_node_pools_names    = concat(google_container_node_pool.pools.*.name, [""])
@@ -105,7 +104,6 @@ locals {
   cluster_network_policy_enabled             = ! local.cluster_output_network_policy_enabled
   cluster_http_load_balancing_enabled        = ! local.cluster_output_http_load_balancing_enabled
   cluster_horizontal_pod_autoscaling_enabled = ! local.cluster_output_horizontal_pod_autoscaling_enabled
-  cluster_kubernetes_dashboard_enabled       = ! local.cluster_output_kubernetes_dashboard_enabled
 }
 
 /******************************************

--- a/modules/private-cluster/outputs.tf
+++ b/modules/private-cluster/outputs.tf
@@ -103,11 +103,6 @@ output "horizontal_pod_autoscaling_enabled" {
   value       = local.cluster_horizontal_pod_autoscaling_enabled
 }
 
-output "kubernetes_dashboard_enabled" {
-  description = "Whether kubernetes dashboard enabled"
-  value       = local.cluster_kubernetes_dashboard_enabled
-}
-
 output "node_pools_names" {
   description = "List of node pools names"
   value       = local.cluster_node_pools_names
@@ -122,4 +117,3 @@ output "service_account" {
   description = "The service account to default running nodes as if not overridden in `node_pools`."
   value       = local.service_account
 }
-

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -282,11 +282,6 @@ variable "issue_client_certificate" {
   default     = false
 }
 
-variable "cluster_ipv4_cidr" {
-  default     = ""
-  description = "The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR."
-}
-
 variable "cluster_resource_labels" {
   type        = map(string)
   description = "The GCE resource labels (a map of key/value pairs) to be applied to the cluster"

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -96,12 +96,6 @@ variable "http_load_balancing" {
   default     = true
 }
 
-variable "kubernetes_dashboard" {
-  type        = bool
-  description = "Enable kubernetes dashboard addon"
-  default     = false
-}
-
 variable "network_policy" {
   type        = bool
   description = "Enable network policy addon"

--- a/outputs.tf
+++ b/outputs.tf
@@ -103,11 +103,6 @@ output "horizontal_pod_autoscaling_enabled" {
   value       = local.cluster_horizontal_pod_autoscaling_enabled
 }
 
-output "kubernetes_dashboard_enabled" {
-  description = "Whether kubernetes dashboard enabled"
-  value       = local.cluster_kubernetes_dashboard_enabled
-}
-
 output "node_pools_names" {
   description = "List of node pools names"
   value       = local.cluster_node_pools_names
@@ -122,4 +117,3 @@ output "service_account" {
   description = "The service account to default running nodes as if not overridden in `node_pools`."
   value       = local.service_account
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -282,11 +282,6 @@ variable "issue_client_certificate" {
   default     = false
 }
 
-variable "cluster_ipv4_cidr" {
-  default     = ""
-  description = "The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR."
-}
-
 variable "cluster_resource_labels" {
   type        = map(string)
   description = "The GCE resource labels (a map of key/value pairs) to be applied to the cluster"

--- a/variables.tf
+++ b/variables.tf
@@ -96,12 +96,6 @@ variable "http_load_balancing" {
   default     = true
 }
 
-variable "kubernetes_dashboard" {
-  type        = bool
-  description = "Enable kubernetes dashboard addon"
-  default     = false
-}
-
 variable "network_policy" {
   type        = bool
   description = "Enable network policy addon"


### PR DESCRIPTION
Kubernetes Dashboard
```
Error: Invalid index

  on .terraform/modules/gke/terraform-google-modules-terraform-google-kubernetes-engine-ab02f24/modules/private-cluster/main.tf line 82, in locals:
  82:   cluster_output_kubernetes_dashboard_enabled       = google_container_cluster.primary.addons_config.0.kubernetes_dashboard.0.disabled
    |----------------
    | google_container_cluster.primary.addons_config[0].kubernetes_dashboard is empty list of object

The given key does not identify an element in this collection value.
```


cluster_ipv4_cidr
```

```




