### PR TITLE
Cluster wait for resource

### DIFF
--- a/autogen/outputs.tf.tmpl
+++ b/autogen/outputs.tf.tmpl
@@ -54,6 +54,7 @@ output "endpoint" {
     */
     google_container_cluster.primary,
     google_container_node_pool.pools,
+    null_resource.wait_for_cluster.id,
   ]
 }
 

--- a/modules/beta-private-cluster-update-variant/outputs.tf
+++ b/modules/beta-private-cluster-update-variant/outputs.tf
@@ -54,6 +54,7 @@ output "endpoint" {
     */
     google_container_cluster.primary,
     google_container_node_pool.pools,
+    null_resource.wait_for_cluster.id,
   ]
 }
 

--- a/modules/beta-private-cluster/outputs.tf
+++ b/modules/beta-private-cluster/outputs.tf
@@ -54,6 +54,7 @@ output "endpoint" {
     */
     google_container_cluster.primary,
     google_container_node_pool.pools,
+    null_resource.wait_for_cluster.id,
   ]
 }
 

--- a/modules/beta-public-cluster/outputs.tf
+++ b/modules/beta-public-cluster/outputs.tf
@@ -54,6 +54,7 @@ output "endpoint" {
     */
     google_container_cluster.primary,
     google_container_node_pool.pools,
+    null_resource.wait_for_cluster.id,
   ]
 }
 

--- a/modules/private-cluster-update-variant/outputs.tf
+++ b/modules/private-cluster-update-variant/outputs.tf
@@ -54,6 +54,7 @@ output "endpoint" {
     */
     google_container_cluster.primary,
     google_container_node_pool.pools,
+    null_resource.wait_for_cluster.id,
   ]
 }
 

--- a/modules/private-cluster/outputs.tf
+++ b/modules/private-cluster/outputs.tf
@@ -54,6 +54,7 @@ output "endpoint" {
     */
     google_container_cluster.primary,
     google_container_node_pool.pools,
+    null_resource.wait_for_cluster.id,
   ]
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -54,6 +54,7 @@ output "endpoint" {
     */
     google_container_cluster.primary,
     google_container_node_pool.pools,
+    null_resource.wait_for_cluster.id,
   ]
 }
 


### PR DESCRIPTION
Wait for resource, before endpoint is released, so other dependent components (like helm) are not going to use or access the cluster before it is ready.