### PR TITLE
Change upstream_nameserver variable type  

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -206,7 +206,7 @@ variable "stub_domains" {
 }
 
 variable "upstream_nameservers" {
-  type        = "list"
+  type        = list(string)
   description = "If specified, the values replace the nameservers taken by default from the node’s /etc/resolv.conf"
   default     = []
 }


### PR DESCRIPTION
A small change on variables.tf, list type constraints are deprecated on Terraform 0.12
Set explicitly type to "list(string)" as the list elements are strings.