### PR TITLE
Add variable to allow a pre-generated SSH key to be passed to the ACM module

### DIFF
--- a/modules/acm/README.md
+++ b/modules/acm/README.md
@@ -53,6 +53,7 @@ By default, this module will attempt to download the ACM operator from Google di
 | operator\_path | Path to the operator yaml config. If unset, will download from GCS releases. | string | `"null"` | no |
 | policy\_dir | Subfolder containing configs in ACM Git repo | string | n/a | yes |
 | project\_id | The project in which the resource belongs. | string | n/a | yes |
+| ssh\_auth\_key | Key for Git authentication. Overrides 'create_ssh_key' variable. Can be set using 'file(path/to/file)'-function. | string | `"null"` | no |
 | sync\_branch | ACM repo Git branch | string | `"master"` | no |
 | sync\_repo | ACM Git repo address | string | n/a | yes |
 

--- a/modules/acm/main.tf
+++ b/modules/acm/main.tf
@@ -18,7 +18,7 @@ locals {
   cluster_endpoint       = "https://${var.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token
   cluster_ca_certificate = data.google_container_cluster.primary.master_auth.0.cluster_ca_certificate
-  private_key            = var.create_ssh_key ? tls_private_key.git_creds[0].private_key_pem : ""
+  private_key            = var.create_ssh_key && var.ssh_auth_key == null ? tls_private_key.git_creds[0].private_key_pem : var.ssh_auth_key
   download_operator      = var.operator_path == null ? true : false
   operator_path          = local.download_operator ? "${path.module}/config-management-operator.yaml" : var.operator_path
 }

--- a/modules/acm/variables.tf
+++ b/modules/acm/variables.tf
@@ -62,6 +62,12 @@ variable "create_ssh_key" {
   default     = true
 }
 
+variable "ssh_auth_key" {
+  description = "Key for Git authentication. Overrides 'create_ssh_key' variable. Can be set using 'file(path/to/file)'-function."
+  type        = string
+  default     = null
+}
+
 variable "enable_policy_controller" {
   description = "Whether to enable the ACM Policy Controller on the cluster"
   type        = bool


### PR DESCRIPTION
 * Fix #329