### PR TITLE
[WIP] Upgrade to provider version 3.0.0

### DIFF
--- a/autogen/cluster.tf.tmpl
+++ b/autogen/cluster.tf.tmpl
@@ -30,11 +30,9 @@ resource "google_container_cluster" "primary" {
   description     = var.description
   project         = var.project_id
   resource_labels = var.cluster_resource_labels
-
-  location          = local.location
-  node_locations    = local.node_locations
-  cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = data.google_compute_network.gke_network.self_link
+  location        = local.location
+  node_locations  = local.node_locations
+  network         = data.google_compute_network.gke_network.self_link
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/autogen/versions.tf.tmpl
+++ b/autogen/versions.tf.tmpl
@@ -19,9 +19,9 @@ terraform {
 
   required_providers {
 {% if beta_cluster %}
-    google-beta = "~> 2.18.0"
+    google-beta = "~> 3.0.0-beta.1"
 {% else %}
-    google = "~> 2.18.0"
+    google = "~> 3.0.0-beta.1"
 {% endif %}
   }
 }

--- a/cluster.tf
+++ b/cluster.tf
@@ -26,11 +26,9 @@ resource "google_container_cluster" "primary" {
   description     = var.description
   project         = var.project_id
   resource_labels = var.cluster_resource_labels
-
-  location          = local.location
-  node_locations    = local.node_locations
-  cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = data.google_compute_network.gke_network.self_link
+  location        = local.location
+  node_locations  = local.node_locations
+  network         = data.google_compute_network.gke_network.self_link
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.18.0"
+  version = "~> 3.0.0-beta.1"
   region  = var.region
 }
 

--- a/examples/disable_client_cert/main.tf
+++ b/examples/disable_client_cert/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.18.0"
+  version = "~> 3.0.0-beta.1"
   region  = var.region
 }
 

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 2.18.0"
+  version = "~> 3.0.0-beta.1"
   region  = var.region
 }
 

--- a/examples/node_pool_update_variant/main.tf
+++ b/examples/node_pool_update_variant/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.18.0"
+  version = "~> 3.0.0-beta.1"
   region  = var.region
 }
 

--- a/examples/node_pool_update_variant_beta/main.tf
+++ b/examples/node_pool_update_variant_beta/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version     = "~> 2.18.0"
+  version     = "~> 3.0.0-beta.1"
   credentials = file(var.credentials_path)
   region      = var.region
 }

--- a/examples/private_zonal_with_networking/main.tf
+++ b/examples/private_zonal_with_networking/main.tf
@@ -14,9 +14,14 @@
  * limitations under the License.
  */
 
+provider "google-beta" {
+  version = "~> 3.0.0-beta.1"
+  region  = var.region
+}
+
+
 module "gcp-network" {
-  source       = "terraform-google-modules/network/google"
-  version      = "~> 1.4.0"
+  source       = "git::https://github.com/terraform-google-modules/terraform-google-network?ref=release/2.0"
   project_id   = var.project_id
   network_name = var.network
 

--- a/examples/regional_private_node_pool_oauth_scopes/provider.tf
+++ b/examples/regional_private_node_pool_oauth_scopes/provider.tf
@@ -15,9 +15,9 @@
  */
 
 provider "google" {
-  version = "2.18.0"
+  version = "~> 3.0.0-beta.1"
 }
 
 provider "google-beta" {
-  version = "2.18.0"
+  version = "~> 3.0.0-beta.1"
 }

--- a/examples/safer_cluster/main.tf
+++ b/examples/safer_cluster/main.tf
@@ -30,11 +30,11 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.18.0"
+  version = "~> 3.0.0-beta.1"
 }
 
 provider "google-beta" {
-  version = "~> 2.18.0"
+  version = "~> 3.0.0-beta.1"
 }
 
 module "gke" {

--- a/examples/safer_cluster/network.tf
+++ b/examples/safer_cluster/network.tf
@@ -15,8 +15,7 @@
  */
 
 module "gcp-network" {
-  source       = "terraform-google-modules/network/google"
-  version      = "~> 1.4.0"
+  source       = "git::https://github.com/terraform-google-modules/terraform-google-network?ref=release/2.0"
   project_id   = var.project_id
   network_name = local.network_name
 

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.18.0"
+  version = "~> 3.0.0-beta.1"
   region  = var.region
 }
 

--- a/examples/simple_regional/main.tf
+++ b/examples/simple_regional/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.18.0"
+  version = "~> 3.0.0-beta.1"
   region  = var.region
 }
 

--- a/examples/simple_regional_beta/main.tf
+++ b/examples/simple_regional_beta/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 2.18.0"
+  version = "~> 3.0.0-beta.1"
   region  = var.region
 }
 

--- a/examples/simple_regional_private/main.tf
+++ b/examples/simple_regional_private/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.18.0"
+  version = "~> 3.0.0-beta.1"
   region  = var.region
 }
 

--- a/examples/simple_regional_private_beta/main.tf
+++ b/examples/simple_regional_private_beta/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 2.18.0"
+  version = "~> 3.0.0-beta.1"
   region  = var.region
 }
 

--- a/examples/simple_regional_with_networking/main.tf
+++ b/examples/simple_regional_with_networking/main.tf
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
+provider "google" {
+  version = "~> 3.0.0-beta.1"
+  region  = var.region
+}
+
 module "gcp-network" {
-  source       = "terraform-google-modules/network/google"
-  version      = "~> 1.4.0"
+  source       = "git::https://github.com/terraform-google-modules/terraform-google-network?ref=release/2.0"
   project_id   = var.project_id
   network_name = var.network
 

--- a/examples/simple_zonal_private/main.tf
+++ b/examples/simple_zonal_private/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.18.0"
+  version = "~> 3.0.0-beta.1"
   region  = var.region
 }
 

--- a/examples/simple_zonal_with_acm/main.tf
+++ b/examples/simple_zonal_with_acm/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.18.0"
+  version = "~> 3.0.0-beta.1"
   region  = var.region
 }
 

--- a/examples/stub_domains/main.tf
+++ b/examples/stub_domains/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.18.0"
+  version = "~> 3.0.0-beta.1"
   region  = var.region
 }
 

--- a/examples/stub_domains_private/main.tf
+++ b/examples/stub_domains_private/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.18.0"
+  version = "~> 3.0.0-beta.1"
   region  = var.region
 }
 

--- a/examples/stub_domains_upstream_nameservers/main.tf
+++ b/examples/stub_domains_upstream_nameservers/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.18.0"
+  version = "~> 3.0.0-beta.1"
   region  = var.region
 }
 

--- a/examples/upstream_nameservers/main.tf
+++ b/examples/upstream_nameservers/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 2.18.0"
+  version = "~> 3.0.0-beta.1"
   region  = var.region
 }
 

--- a/examples/workload_metadata_config/main.tf
+++ b/examples/workload_metadata_config/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 2.18.0"
+  version = "~> 3.0.0-beta.1"
   region  = var.region
 }
 

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -26,11 +26,9 @@ resource "google_container_cluster" "primary" {
   description     = var.description
   project         = var.project_id
   resource_labels = var.cluster_resource_labels
-
-  location          = local.location
-  node_locations    = local.node_locations
-  cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = data.google_compute_network.gke_network.self_link
+  location        = local.location
+  node_locations  = local.node_locations
+  network         = data.google_compute_network.gke_network.self_link
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/modules/beta-private-cluster-update-variant/versions.tf
+++ b/modules/beta-private-cluster-update-variant/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    google-beta = "~> 2.18.0"
+    google-beta = "~> 3.0.0-beta.1"
   }
 }

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -26,11 +26,9 @@ resource "google_container_cluster" "primary" {
   description     = var.description
   project         = var.project_id
   resource_labels = var.cluster_resource_labels
-
-  location          = local.location
-  node_locations    = local.node_locations
-  cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = data.google_compute_network.gke_network.self_link
+  location        = local.location
+  node_locations  = local.node_locations
+  network         = data.google_compute_network.gke_network.self_link
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/modules/beta-private-cluster/versions.tf
+++ b/modules/beta-private-cluster/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    google-beta = "~> 2.18.0"
+    google-beta = "~> 3.0.0-beta.1"
   }
 }

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -26,11 +26,9 @@ resource "google_container_cluster" "primary" {
   description     = var.description
   project         = var.project_id
   resource_labels = var.cluster_resource_labels
-
-  location          = local.location
-  node_locations    = local.node_locations
-  cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = data.google_compute_network.gke_network.self_link
+  location        = local.location
+  node_locations  = local.node_locations
+  network         = data.google_compute_network.gke_network.self_link
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/modules/beta-public-cluster/versions.tf
+++ b/modules/beta-public-cluster/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    google-beta = "~> 2.18.0"
+    google-beta = "~> 3.0.0-beta.1"
   }
 }

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -26,11 +26,9 @@ resource "google_container_cluster" "primary" {
   description     = var.description
   project         = var.project_id
   resource_labels = var.cluster_resource_labels
-
-  location          = local.location
-  node_locations    = local.node_locations
-  cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = data.google_compute_network.gke_network.self_link
+  location        = local.location
+  node_locations  = local.node_locations
+  network         = data.google_compute_network.gke_network.self_link
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/modules/private-cluster-update-variant/versions.tf
+++ b/modules/private-cluster-update-variant/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    google = "~> 2.18.0"
+    google = "~> 3.0.0-beta.1"
   }
 }

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -26,11 +26,9 @@ resource "google_container_cluster" "primary" {
   description     = var.description
   project         = var.project_id
   resource_labels = var.cluster_resource_labels
-
-  location          = local.location
-  node_locations    = local.node_locations
-  cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = data.google_compute_network.gke_network.self_link
+  location        = local.location
+  node_locations  = local.node_locations
+  network         = data.google_compute_network.gke_network.self_link
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/modules/private-cluster/versions.tf
+++ b/modules/private-cluster/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    google = "~> 2.18.0"
+    google = "~> 3.0.0-beta.1"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    google = "~> 2.18.0"
+    google = "~> 3.0.0-beta.1"
   }
 }


### PR DESCRIPTION
fixes #338 
fixes #349 

Remove cluster_ipv4_cidr and use ip_allocation_policy.cluster_ipv4_cidr_block/cluster_secondary_range_name

Blocked by:

- Network 2.0 

- 3.0.0 GA