### PR TITLE
Fix "Quoted references are deprecated" warning for identity_namespace output

### DIFF
--- a/autogen/outputs.tf.tmpl
+++ b/autogen/outputs.tf.tmpl
@@ -155,7 +155,7 @@ output "identity_namespace" {
   description = "Workload Identity namespace"
   value       = var.identity_namespace
   depends_on = [
-    "google_container_cluster.primary"
+    google_container_cluster.primary
   ]
 }
 {% endif %}


### PR DESCRIPTION
```
Warning: Quoted references are deprecated

  on .terraform/modules/gke/terraform-google-modules-terraform-google-kubernetes-engine-2283032/modules/beta-private-cluster/outputs.tf line 157, in output "identity_namespace":
 157:     "google_container_cluster.primary"

In this context, references are expected literally rather than in quotes.
Terraform 0.11 and earlier required quotes, but quoted references are now
deprecated and will be removed in a future version of Terraform. Remove the
quotes surrounding this reference to silence this warning
```