### PR TITLE
[DOC] Absolute path to examples directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This module is meant for use with Terraform 0.12. If you haven't
 intended for Terraform 0.11.x is [3.0.0].
 
 ## Usage
-There are multiple examples included in the [examples](./examples/) folder but simple usage is as follows:
+There are multiple examples included in the [examples] folder but simple usage is as follows:
 
 ```hcl
 module "gke" {
@@ -264,3 +264,4 @@ The project has the following folders and files:
 [terraform-provider-google]: https://github.com/terraform-providers/terraform-provider-google
 [3.0.0]: https://registry.terraform.io/modules/terraform-google-modules/kubernetes-engine/google/3.0.0
 [terraform-0.12-upgrade]: https://www.terraform.io/upgrade-guides/0-12.html
+[examples]: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/tree/master/examples


### PR DESCRIPTION
Hi !

I propose to switch to a absolute path to examples directory, because the link doesn't work on registry.terraform.io

The link makes a reference to master, I don't know if this is acceptable .

thanks !