### PR TITLE
Removing dependency on jq from wait-for-cluster.sh script

### DIFF
--- a/autogen/main/scripts/wait-for-cluster.sh
+++ b/autogen/main/scripts/wait-for-cluster.sh
@@ -22,17 +22,15 @@ fi
 
 PROJECT=$1
 CLUSTER_NAME=$2
-gcloud_command="gcloud container clusters list --project=$PROJECT --format=json"
-jq_query=".[] | select(.name==\"$CLUSTER_NAME\") | .status"
 
-echo "Waiting for cluster $2 in project $1 to reconcile..."
+echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$($gcloud_command | jq -r "$jq_query")
+current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
 
-while [[ "${current_status}" == "RECONCILING" ]]; do
+while [[ "$current_status" == "RECONCILING" ]]; do
     printf "."
     sleep 5
-    current_status=$($gcloud_command | jq -r "$jq_query")
+    current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
 done
 
 echo "Cluster is ready!"

--- a/autogen/main/scripts/wait-for-cluster.sh
+++ b/autogen/main/scripts/wait-for-cluster.sh
@@ -25,12 +25,12 @@ CLUSTER_NAME=$2
 
 echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
+current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
 
 while [[ "$current_status" == "RECONCILING" ]]; do
     printf "."
     sleep 5
-    current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
 done
 
 echo "Cluster is ready!"

--- a/modules/beta-private-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/beta-private-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -22,17 +22,15 @@ fi
 
 PROJECT=$1
 CLUSTER_NAME=$2
-gcloud_command="gcloud container clusters list --project=$PROJECT --format=json"
-jq_query=".[] | select(.name==\"$CLUSTER_NAME\") | .status"
 
-echo "Waiting for cluster $2 in project $1 to reconcile..."
+echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$($gcloud_command | jq -r "$jq_query")
+current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
 
-while [[ "${current_status}" == "RECONCILING" ]]; do
+while [[ "$current_status" == "RECONCILING" ]]; do
     printf "."
     sleep 5
-    current_status=$($gcloud_command | jq -r "$jq_query")
+    current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
 done
 
 echo "Cluster is ready!"

--- a/modules/beta-private-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/beta-private-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -25,12 +25,12 @@ CLUSTER_NAME=$2
 
 echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
+current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
 
 while [[ "$current_status" == "RECONCILING" ]]; do
     printf "."
     sleep 5
-    current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
 done
 
 echo "Cluster is ready!"

--- a/modules/beta-private-cluster/scripts/wait-for-cluster.sh
+++ b/modules/beta-private-cluster/scripts/wait-for-cluster.sh
@@ -22,17 +22,15 @@ fi
 
 PROJECT=$1
 CLUSTER_NAME=$2
-gcloud_command="gcloud container clusters list --project=$PROJECT --format=json"
-jq_query=".[] | select(.name==\"$CLUSTER_NAME\") | .status"
 
-echo "Waiting for cluster $2 in project $1 to reconcile..."
+echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$($gcloud_command | jq -r "$jq_query")
+current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
 
-while [[ "${current_status}" == "RECONCILING" ]]; do
+while [[ "$current_status" == "RECONCILING" ]]; do
     printf "."
     sleep 5
-    current_status=$($gcloud_command | jq -r "$jq_query")
+    current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
 done
 
 echo "Cluster is ready!"

--- a/modules/beta-private-cluster/scripts/wait-for-cluster.sh
+++ b/modules/beta-private-cluster/scripts/wait-for-cluster.sh
@@ -25,12 +25,12 @@ CLUSTER_NAME=$2
 
 echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
+current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
 
 while [[ "$current_status" == "RECONCILING" ]]; do
     printf "."
     sleep 5
-    current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
 done
 
 echo "Cluster is ready!"

--- a/modules/beta-public-cluster/scripts/wait-for-cluster.sh
+++ b/modules/beta-public-cluster/scripts/wait-for-cluster.sh
@@ -22,17 +22,15 @@ fi
 
 PROJECT=$1
 CLUSTER_NAME=$2
-gcloud_command="gcloud container clusters list --project=$PROJECT --format=json"
-jq_query=".[] | select(.name==\"$CLUSTER_NAME\") | .status"
 
-echo "Waiting for cluster $2 in project $1 to reconcile..."
+echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$($gcloud_command | jq -r "$jq_query")
+current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
 
-while [[ "${current_status}" == "RECONCILING" ]]; do
+while [[ "$current_status" == "RECONCILING" ]]; do
     printf "."
     sleep 5
-    current_status=$($gcloud_command | jq -r "$jq_query")
+    current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
 done
 
 echo "Cluster is ready!"

--- a/modules/beta-public-cluster/scripts/wait-for-cluster.sh
+++ b/modules/beta-public-cluster/scripts/wait-for-cluster.sh
@@ -25,12 +25,12 @@ CLUSTER_NAME=$2
 
 echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
+current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
 
 while [[ "$current_status" == "RECONCILING" ]]; do
     printf "."
     sleep 5
-    current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
 done
 
 echo "Cluster is ready!"

--- a/modules/private-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/private-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -22,17 +22,15 @@ fi
 
 PROJECT=$1
 CLUSTER_NAME=$2
-gcloud_command="gcloud container clusters list --project=$PROJECT --format=json"
-jq_query=".[] | select(.name==\"$CLUSTER_NAME\") | .status"
 
-echo "Waiting for cluster $2 in project $1 to reconcile..."
+echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$($gcloud_command | jq -r "$jq_query")
+current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
 
-while [[ "${current_status}" == "RECONCILING" ]]; do
+while [[ "$current_status" == "RECONCILING" ]]; do
     printf "."
     sleep 5
-    current_status=$($gcloud_command | jq -r "$jq_query")
+    current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
 done
 
 echo "Cluster is ready!"

--- a/modules/private-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/private-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -25,12 +25,12 @@ CLUSTER_NAME=$2
 
 echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
+current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
 
 while [[ "$current_status" == "RECONCILING" ]]; do
     printf "."
     sleep 5
-    current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
 done
 
 echo "Cluster is ready!"

--- a/modules/private-cluster/scripts/wait-for-cluster.sh
+++ b/modules/private-cluster/scripts/wait-for-cluster.sh
@@ -22,17 +22,15 @@ fi
 
 PROJECT=$1
 CLUSTER_NAME=$2
-gcloud_command="gcloud container clusters list --project=$PROJECT --format=json"
-jq_query=".[] | select(.name==\"$CLUSTER_NAME\") | .status"
 
-echo "Waiting for cluster $2 in project $1 to reconcile..."
+echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$($gcloud_command | jq -r "$jq_query")
+current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
 
-while [[ "${current_status}" == "RECONCILING" ]]; do
+while [[ "$current_status" == "RECONCILING" ]]; do
     printf "."
     sleep 5
-    current_status=$($gcloud_command | jq -r "$jq_query")
+    current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
 done
 
 echo "Cluster is ready!"

--- a/modules/private-cluster/scripts/wait-for-cluster.sh
+++ b/modules/private-cluster/scripts/wait-for-cluster.sh
@@ -25,12 +25,12 @@ CLUSTER_NAME=$2
 
 echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
+current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
 
 while [[ "$current_status" == "RECONCILING" ]]; do
     printf "."
     sleep 5
-    current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
 done
 
 echo "Cluster is ready!"

--- a/scripts/wait-for-cluster.sh
+++ b/scripts/wait-for-cluster.sh
@@ -22,17 +22,15 @@ fi
 
 PROJECT=$1
 CLUSTER_NAME=$2
-gcloud_command="gcloud container clusters list --project=$PROJECT --format=json"
-jq_query=".[] | select(.name==\"$CLUSTER_NAME\") | .status"
 
-echo "Waiting for cluster $2 in project $1 to reconcile..."
+echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$($gcloud_command | jq -r "$jq_query")
+current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
 
-while [[ "${current_status}" == "RECONCILING" ]]; do
+while [[ "$current_status" == "RECONCILING" ]]; do
     printf "."
     sleep 5
-    current_status=$($gcloud_command | jq -r "$jq_query")
+    current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
 done
 
 echo "Cluster is ready!"

--- a/scripts/wait-for-cluster.sh
+++ b/scripts/wait-for-cluster.sh
@@ -25,12 +25,12 @@ CLUSTER_NAME=$2
 
 echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
+current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
 
 while [[ "$current_status" == "RECONCILING" ]]; do
     printf "."
     sleep 5
-    current_status=$(gcloud container clusters list --project=$PROJECT --filter=name:$CLUSTER_NAME --format="value(status)")
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
 done
 
 echo "Cluster is ready!"


### PR DESCRIPTION
The gcloud --format command can be used instead of jq to extract the cluster status for this script.

I will submit a change for the delete-default-resource.sh script in another PR.