### PR TITLE
refactor: use gcloud module for scripts, closes #401

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ Then perform the following commands on the root folder:
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | bool | `"true"` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
-| gcloud\_sdk\_version | The gcloud sdk version to download | string | `"296.0.0"` | no |
 | gcloud\_skip\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
 | gcloud\_upgrade | Whether to upgrade gcloud at runtime | bool | `"false"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ Then perform the following commands on the root folder:
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | bool | `"true"` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
+| gcloud\_sdk\_version | The gcloud sdk version to download | string | `"296.0.0"` | no |
+| gcloud\_skip\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
+| gcloud\_upgrade | Whether to upgrade gcloud at runtime | bool | `"false"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | bool | `"true"` | no |
 | http\_load\_balancing | Enable httpload balancer addon | bool | `"true"` | no |

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -534,6 +534,10 @@ module "gcloud_wait_for_cluster" {
   version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
+  upgrade            = var.gcloud_upgrade
+  gcloud_sdk_version = var.gcloud_sdk_version
+  skip_download      = var.gcloud_skip_download
+
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -541,6 +541,5 @@ module "gcloud_wait_for_cluster" {
 
   module_depends_on = [
     google_container_cluster.primary.master_version,
-    join("-", google_container_node_pool.pools[*].name),
   ]
 }

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -531,7 +531,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.4"
+  version = "~> 0.5"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -540,7 +540,7 @@ module "gcloud_wait_for_cluster" {
   destroy_cmd_body       = "${var.project_id} ${var.name}"
 
   module_depends_on = [
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
+    google_container_cluster.primary.master_version,
+    join("-", google_container_node_pool.pools[*].name),
   ]
 }

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -531,7 +531,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.5"
+  version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
@@ -539,8 +539,8 @@ module "gcloud_wait_for_cluster" {
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
   destroy_cmd_body       = "${var.project_id} ${var.name}"
 
-  module_depends_on = [
-    google_container_cluster.primary.master_version,
-    google_container_node_pool.pools[*].name
-  ]
+  module_depends_on = concat(
+    [google_container_cluster.primary.master_version],
+    [for pool in google_container_node_pool.pools : pool.name]
+  )
 }

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -529,25 +529,13 @@ resource "google_container_node_pool" "pools" {
   }
 }
 
-resource "null_resource" "wait_for_cluster" {
-  count = var.skip_provisioners ? 0 : 1
+module "gcloud_wait_for_cluster" {
+  source  = "terraform-google-modules/gcloud/google"
+  version = "~> 0.3"
+  enabled = var.skip_provisioners
 
-  triggers = {
-    project_id = var.project_id
-    name       = var.name
-  }
-
-  provisioner "local-exec" {
-    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
-  }
-
-  provisioner "local-exec" {
-    when    = destroy
-    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
-  }
-
-  depends_on = [
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
-  ]
+  create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
+  create_cmd_body        = "${var.project_id} ${var.name}"
+  destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
+  destroy_cmd_body       = "${var.project_id} ${var.name}"
 }

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -541,5 +541,6 @@ module "gcloud_wait_for_cluster" {
 
   module_depends_on = [
     google_container_cluster.primary.master_version,
+    google_container_node_pool.pools[*].name
   ]
 }

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -534,9 +534,8 @@ module "gcloud_wait_for_cluster" {
   version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
-  upgrade            = var.gcloud_upgrade
-  gcloud_sdk_version = var.gcloud_sdk_version
-  skip_download      = var.gcloud_skip_download
+  upgrade       = var.gcloud_upgrade
+  skip_download = var.gcloud_skip_download
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -531,11 +531,16 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.3"
+  version = "~> 0.4"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
   destroy_cmd_body       = "${var.project_id} ${var.name}"
+
+  module_depends_on = [
+    google_container_cluster.primary,
+    google_container_node_pool.pools,
+  ]
 }

--- a/autogen/main/dns.tf.tmpl
+++ b/autogen/main/dns.tf.tmpl
@@ -25,9 +25,8 @@ module "gcloud_delete_default_kube_dns_configmap" {
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
-  upgrade            = var.gcloud_upgrade
-  gcloud_sdk_version = var.gcloud_sdk_version
-  skip_download      = var.gcloud_skip_download
+  upgrade       = var.gcloud_upgrade
+  skip_download = var.gcloud_skip_download
 
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"

--- a/autogen/main/dns.tf.tmpl
+++ b/autogen/main/dns.tf.tmpl
@@ -25,6 +25,10 @@ module "gcloud_delete_default_kube_dns_configmap" {
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
+  upgrade            = var.gcloud_upgrade
+  gcloud_sdk_version = var.gcloud_sdk_version
+  skip_download      = var.gcloud_skip_download
+
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
 

--- a/autogen/main/dns.tf.tmpl
+++ b/autogen/main/dns.tf.tmpl
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.3"
+  version               = "~> 0.4"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
@@ -51,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -78,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -108,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/autogen/main/dns.tf.tmpl
+++ b/autogen/main/dns.tf.tmpl
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.5"
+  version               = "~> 1.0.1"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/autogen/main/dns.tf.tmpl
+++ b/autogen/main/dns.tf.tmpl
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.4"
+  version               = "~> 0.5"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/autogen/main/dns.tf.tmpl
+++ b/autogen/main/dns.tf.tmpl
@@ -51,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -78,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -108,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/autogen/main/dns.tf.tmpl
+++ b/autogen/main/dns.tf.tmpl
@@ -27,6 +27,12 @@ module "gcloud_delete_default_kube_dns_configmap" {
 
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
+
+  module_depends_on = concat(
+    [data.google_client_config.default.access_token],
+    [google_container_cluster.primary.master_version],
+    [for pool in google_container_node_pool.pools : pool.name]
+  )
 }
 
 /******************************************

--- a/autogen/main/dns.tf.tmpl
+++ b/autogen/main/dns.tf.tmpl
@@ -19,18 +19,14 @@
 /******************************************
   Delete default kube-dns configmap
  *****************************************/
-resource "null_resource" "delete_default_kube_dns_configmap" {
-  count = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners ? 1 : 0
+module "gcloud_delete_default_kube_dns_configmap" {
+  source                = "terraform-google-modules/gcloud/google"
+  version               = "~> 0.3"
+  enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
+  additional_components = ["kubectl"]
 
-  provisioner "local-exec" {
-    command = "${path.module}/scripts/kubectl_wrapper.sh https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
-  }
-
-  depends_on = [
-    data.google_client_config.default,
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
-  ]
+  create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
+  create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
 }
 
 /******************************************
@@ -55,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -82,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -112,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/autogen/main/scripts/delete-default-resource.sh
+++ b/autogen/main/scripts/delete-default-resource.sh
@@ -29,7 +29,7 @@ RESOURCE_LIST=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" || exi
 
 # Delete requested resource
 if [[ $RESOURCE_LIST = *"${RESOURCE_NAME}"* ]]; then
-    RESOURCE_MAINTAINED_LABEL=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" -o json "${RESOURCE_NAME}" | jq -r '.metadata.labels."maintained_by"')
+    RESOURCE_MAINTAINED_LABEL=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" "${RESOURCE_NAME}" -o=jsonpath='{.metadata.labels.maintained_by}')
     if [[ $RESOURCE_MAINTAINED_LABEL = "terraform" ]]; then
         echo "Terraform maintained ${RESOURCE_NAME} ${RESOURCE_TYPE} appears to have already been created in ${RESOURCE_NAMESPACE} namespace"
     else

--- a/autogen/main/scripts/wait-for-cluster.sh
+++ b/autogen/main/scripts/wait-for-cluster.sh
@@ -25,12 +25,9 @@ CLUSTER_NAME=$2
 
 echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-
-while [[ "$current_status" == "RECONCILING" ]]; do
-    printf "."
-    sleep 5
-    current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-done
+while
+  current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
+  [[ "${current_status}" == "RECONCILING" ]]
+do printf ".";sleep 5; done
 
 echo "Cluster is ready!"

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -531,3 +531,21 @@ variable "firewall_inbound_ports" {
   description = "List of TCP ports for admission/webhook controllers"
   default     = ["8443", "9443", "15017"]
 }
+
+variable "gcloud_upgrade" {
+  type        = bool
+  description = "Whether to upgrade gcloud at runtime"
+  default     = false
+}
+
+variable "gcloud_sdk_version" {
+  type        = string
+  description = "The gcloud sdk version to download"
+  default     = "296.0.0"
+}
+
+variable "gcloud_skip_download" {
+  type        = bool
+  description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"
+  default     = true
+}

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -538,12 +538,6 @@ variable "gcloud_upgrade" {
   default     = false
 }
 
-variable "gcloud_sdk_version" {
-  type        = string
-  description = "The gcloud sdk version to download"
-  default     = "296.0.0"
-}
-
 variable "gcloud_skip_download" {
   type        = bool
   description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"

--- a/cluster.tf
+++ b/cluster.tf
@@ -249,25 +249,13 @@ resource "google_container_node_pool" "pools" {
   }
 }
 
-resource "null_resource" "wait_for_cluster" {
-  count = var.skip_provisioners ? 0 : 1
+module "gcloud_wait_for_cluster" {
+  source  = "terraform-google-modules/gcloud/google"
+  version = "~> 0.3"
+  enabled = var.skip_provisioners
 
-  triggers = {
-    project_id = var.project_id
-    name       = var.name
-  }
-
-  provisioner "local-exec" {
-    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
-  }
-
-  provisioner "local-exec" {
-    when    = destroy
-    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
-  }
-
-  depends_on = [
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
-  ]
+  create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
+  create_cmd_body        = "${var.project_id} ${var.name}"
+  destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
+  destroy_cmd_body       = "${var.project_id} ${var.name}"
 }

--- a/cluster.tf
+++ b/cluster.tf
@@ -251,11 +251,16 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.3"
+  version = "~> 0.4"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
   destroy_cmd_body       = "${var.project_id} ${var.name}"
+
+  module_depends_on = [
+    google_container_cluster.primary,
+    google_container_node_pool.pools,
+  ]
 }

--- a/cluster.tf
+++ b/cluster.tf
@@ -261,6 +261,5 @@ module "gcloud_wait_for_cluster" {
 
   module_depends_on = [
     google_container_cluster.primary.master_version,
-    join("-", google_container_node_pool.pools[*].name),
   ]
 }

--- a/cluster.tf
+++ b/cluster.tf
@@ -260,7 +260,7 @@ module "gcloud_wait_for_cluster" {
   destroy_cmd_body       = "${var.project_id} ${var.name}"
 
   module_depends_on = [
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
+    google_container_cluster.primary.master_version,
+    join("-", google_container_node_pool.pools[*].name),
   ]
 }

--- a/cluster.tf
+++ b/cluster.tf
@@ -261,5 +261,6 @@ module "gcloud_wait_for_cluster" {
 
   module_depends_on = [
     google_container_cluster.primary.master_version,
+    google_container_node_pool.pools[*].name
   ]
 }

--- a/cluster.tf
+++ b/cluster.tf
@@ -251,7 +251,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.4"
+  version = "~> 0.5"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"

--- a/cluster.tf
+++ b/cluster.tf
@@ -254,9 +254,8 @@ module "gcloud_wait_for_cluster" {
   version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
-  upgrade            = var.gcloud_upgrade
-  gcloud_sdk_version = var.gcloud_sdk_version
-  skip_download      = var.gcloud_skip_download
+  upgrade       = var.gcloud_upgrade
+  skip_download = var.gcloud_skip_download
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"

--- a/cluster.tf
+++ b/cluster.tf
@@ -251,7 +251,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.5"
+  version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
@@ -259,8 +259,8 @@ module "gcloud_wait_for_cluster" {
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
   destroy_cmd_body       = "${var.project_id} ${var.name}"
 
-  module_depends_on = [
-    google_container_cluster.primary.master_version,
-    google_container_node_pool.pools[*].name
-  ]
+  module_depends_on = concat(
+    [google_container_cluster.primary.master_version],
+    [for pool in google_container_node_pool.pools : pool.name]
+  )
 }

--- a/cluster.tf
+++ b/cluster.tf
@@ -254,6 +254,10 @@ module "gcloud_wait_for_cluster" {
   version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
+  upgrade            = var.gcloud_upgrade
+  gcloud_sdk_version = var.gcloud_sdk_version
+  skip_download      = var.gcloud_skip_download
+
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"

--- a/dns.tf
+++ b/dns.tf
@@ -25,9 +25,8 @@ module "gcloud_delete_default_kube_dns_configmap" {
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
-  upgrade            = var.gcloud_upgrade
-  gcloud_sdk_version = var.gcloud_sdk_version
-  skip_download      = var.gcloud_skip_download
+  upgrade       = var.gcloud_upgrade
+  skip_download = var.gcloud_skip_download
 
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"

--- a/dns.tf
+++ b/dns.tf
@@ -25,6 +25,10 @@ module "gcloud_delete_default_kube_dns_configmap" {
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
+  upgrade            = var.gcloud_upgrade
+  gcloud_sdk_version = var.gcloud_sdk_version
+  skip_download      = var.gcloud_skip_download
+
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
 

--- a/dns.tf
+++ b/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.3"
+  version               = "~> 0.4"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
@@ -51,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -78,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -108,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/dns.tf
+++ b/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.5"
+  version               = "~> 1.0.1"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/dns.tf
+++ b/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.4"
+  version               = "~> 0.5"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/dns.tf
+++ b/dns.tf
@@ -51,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -78,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -108,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/dns.tf
+++ b/dns.tf
@@ -27,6 +27,12 @@ module "gcloud_delete_default_kube_dns_configmap" {
 
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
+
+  module_depends_on = concat(
+    [data.google_client_config.default.access_token],
+    [google_container_cluster.primary.master_version],
+    [for pool in google_container_node_pool.pools : pool.name]
+  )
 }
 
 /******************************************

--- a/dns.tf
+++ b/dns.tf
@@ -19,18 +19,14 @@
 /******************************************
   Delete default kube-dns configmap
  *****************************************/
-resource "null_resource" "delete_default_kube_dns_configmap" {
-  count = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners ? 1 : 0
+module "gcloud_delete_default_kube_dns_configmap" {
+  source                = "terraform-google-modules/gcloud/google"
+  version               = "~> 0.3"
+  enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
+  additional_components = ["kubectl"]
 
-  provisioner "local-exec" {
-    command = "${path.module}/scripts/kubectl_wrapper.sh https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
-  }
-
-  depends_on = [
-    data.google_client_config.default,
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
-  ]
+  create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
+  create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
 }
 
 /******************************************
@@ -55,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -82,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -112,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -173,7 +173,6 @@ Then perform the following commands on the root folder:
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | bool | `"false"` | no |
-| gcloud\_sdk\_version | The gcloud sdk version to download | string | `"296.0.0"` | no |
 | gcloud\_skip\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
 | gcloud\_upgrade | Whether to upgrade gcloud at runtime | bool | `"false"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -173,6 +173,9 @@ Then perform the following commands on the root folder:
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | bool | `"false"` | no |
+| gcloud\_sdk\_version | The gcloud sdk version to download | string | `"296.0.0"` | no |
+| gcloud\_skip\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
+| gcloud\_upgrade | Whether to upgrade gcloud at runtime | bool | `"false"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | bool | `"true"` | no |
 | http\_load\_balancing | Enable httpload balancer addon | bool | `"true"` | no |

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -492,7 +492,7 @@ module "gcloud_wait_for_cluster" {
   destroy_cmd_body       = "${var.project_id} ${var.name}"
 
   module_depends_on = [
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
+    google_container_cluster.primary.master_version,
+    join("-", google_container_node_pool.pools[*].name),
   ]
 }

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -483,7 +483,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.4"
+  version = "~> 0.5"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -483,11 +483,16 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.3"
+  version = "~> 0.4"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
   destroy_cmd_body       = "${var.project_id} ${var.name}"
+
+  module_depends_on = [
+    google_container_cluster.primary,
+    google_container_node_pool.pools,
+  ]
 }

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -486,6 +486,10 @@ module "gcloud_wait_for_cluster" {
   version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
+  upgrade            = var.gcloud_upgrade
+  gcloud_sdk_version = var.gcloud_sdk_version
+  skip_download      = var.gcloud_skip_download
+
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -486,9 +486,8 @@ module "gcloud_wait_for_cluster" {
   version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
-  upgrade            = var.gcloud_upgrade
-  gcloud_sdk_version = var.gcloud_sdk_version
-  skip_download      = var.gcloud_skip_download
+  upgrade       = var.gcloud_upgrade
+  skip_download = var.gcloud_skip_download
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -483,7 +483,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.5"
+  version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
@@ -491,8 +491,8 @@ module "gcloud_wait_for_cluster" {
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
   destroy_cmd_body       = "${var.project_id} ${var.name}"
 
-  module_depends_on = [
-    google_container_cluster.primary.master_version,
-    google_container_node_pool.pools[*].name
-  ]
+  module_depends_on = concat(
+    [google_container_cluster.primary.master_version],
+    [for pool in google_container_node_pool.pools : pool.name]
+  )
 }

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -493,5 +493,6 @@ module "gcloud_wait_for_cluster" {
 
   module_depends_on = [
     google_container_cluster.primary.master_version,
+    google_container_node_pool.pools[*].name
   ]
 }

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -481,25 +481,13 @@ resource "google_container_node_pool" "pools" {
   }
 }
 
-resource "null_resource" "wait_for_cluster" {
-  count = var.skip_provisioners ? 0 : 1
+module "gcloud_wait_for_cluster" {
+  source  = "terraform-google-modules/gcloud/google"
+  version = "~> 0.3"
+  enabled = var.skip_provisioners
 
-  triggers = {
-    project_id = var.project_id
-    name       = var.name
-  }
-
-  provisioner "local-exec" {
-    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
-  }
-
-  provisioner "local-exec" {
-    when    = destroy
-    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
-  }
-
-  depends_on = [
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
-  ]
+  create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
+  create_cmd_body        = "${var.project_id} ${var.name}"
+  destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
+  destroy_cmd_body       = "${var.project_id} ${var.name}"
 }

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -493,6 +493,5 @@ module "gcloud_wait_for_cluster" {
 
   module_depends_on = [
     google_container_cluster.primary.master_version,
-    join("-", google_container_node_pool.pools[*].name),
   ]
 }

--- a/modules/beta-private-cluster-update-variant/dns.tf
+++ b/modules/beta-private-cluster-update-variant/dns.tf
@@ -25,9 +25,8 @@ module "gcloud_delete_default_kube_dns_configmap" {
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
-  upgrade            = var.gcloud_upgrade
-  gcloud_sdk_version = var.gcloud_sdk_version
-  skip_download      = var.gcloud_skip_download
+  upgrade       = var.gcloud_upgrade
+  skip_download = var.gcloud_skip_download
 
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"

--- a/modules/beta-private-cluster-update-variant/dns.tf
+++ b/modules/beta-private-cluster-update-variant/dns.tf
@@ -25,6 +25,10 @@ module "gcloud_delete_default_kube_dns_configmap" {
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
+  upgrade            = var.gcloud_upgrade
+  gcloud_sdk_version = var.gcloud_sdk_version
+  skip_download      = var.gcloud_skip_download
+
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
 

--- a/modules/beta-private-cluster-update-variant/dns.tf
+++ b/modules/beta-private-cluster-update-variant/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.3"
+  version               = "~> 0.4"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
@@ -51,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -78,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -108,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/modules/beta-private-cluster-update-variant/dns.tf
+++ b/modules/beta-private-cluster-update-variant/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.5"
+  version               = "~> 1.0.1"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/modules/beta-private-cluster-update-variant/dns.tf
+++ b/modules/beta-private-cluster-update-variant/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.4"
+  version               = "~> 0.5"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/modules/beta-private-cluster-update-variant/dns.tf
+++ b/modules/beta-private-cluster-update-variant/dns.tf
@@ -51,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -78,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -108,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/modules/beta-private-cluster-update-variant/dns.tf
+++ b/modules/beta-private-cluster-update-variant/dns.tf
@@ -27,6 +27,12 @@ module "gcloud_delete_default_kube_dns_configmap" {
 
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
+
+  module_depends_on = concat(
+    [data.google_client_config.default.access_token],
+    [google_container_cluster.primary.master_version],
+    [for pool in google_container_node_pool.pools : pool.name]
+  )
 }
 
 /******************************************

--- a/modules/beta-private-cluster-update-variant/dns.tf
+++ b/modules/beta-private-cluster-update-variant/dns.tf
@@ -19,18 +19,14 @@
 /******************************************
   Delete default kube-dns configmap
  *****************************************/
-resource "null_resource" "delete_default_kube_dns_configmap" {
-  count = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners ? 1 : 0
+module "gcloud_delete_default_kube_dns_configmap" {
+  source                = "terraform-google-modules/gcloud/google"
+  version               = "~> 0.3"
+  enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
+  additional_components = ["kubectl"]
 
-  provisioner "local-exec" {
-    command = "${path.module}/scripts/kubectl_wrapper.sh https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
-  }
-
-  depends_on = [
-    data.google_client_config.default,
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
-  ]
+  create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
+  create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
 }
 
 /******************************************
@@ -55,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -82,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -112,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/modules/beta-private-cluster-update-variant/scripts/delete-default-resource.sh
+++ b/modules/beta-private-cluster-update-variant/scripts/delete-default-resource.sh
@@ -29,7 +29,7 @@ RESOURCE_LIST=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" || exi
 
 # Delete requested resource
 if [[ $RESOURCE_LIST = *"${RESOURCE_NAME}"* ]]; then
-    RESOURCE_MAINTAINED_LABEL=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" -o json "${RESOURCE_NAME}" | jq -r '.metadata.labels."maintained_by"')
+    RESOURCE_MAINTAINED_LABEL=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" "${RESOURCE_NAME}" -o=jsonpath='{.metadata.labels.maintained_by}')
     if [[ $RESOURCE_MAINTAINED_LABEL = "terraform" ]]; then
         echo "Terraform maintained ${RESOURCE_NAME} ${RESOURCE_TYPE} appears to have already been created in ${RESOURCE_NAMESPACE} namespace"
     else

--- a/modules/beta-private-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/beta-private-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -25,12 +25,9 @@ CLUSTER_NAME=$2
 
 echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-
-while [[ "$current_status" == "RECONCILING" ]]; do
-    printf "."
-    sleep 5
-    current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-done
+while
+  current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
+  [[ "${current_status}" == "RECONCILING" ]]
+do printf ".";sleep 5; done
 
 echo "Cluster is ready!"

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -530,12 +530,6 @@ variable "gcloud_upgrade" {
   default     = false
 }
 
-variable "gcloud_sdk_version" {
-  type        = string
-  description = "The gcloud sdk version to download"
-  default     = "296.0.0"
-}
-
 variable "gcloud_skip_download" {
   type        = bool
   description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -523,3 +523,21 @@ variable "firewall_inbound_ports" {
   description = "List of TCP ports for admission/webhook controllers"
   default     = ["8443", "9443", "15017"]
 }
+
+variable "gcloud_upgrade" {
+  type        = bool
+  description = "Whether to upgrade gcloud at runtime"
+  default     = false
+}
+
+variable "gcloud_sdk_version" {
+  type        = string
+  description = "The gcloud sdk version to download"
+  default     = "296.0.0"
+}
+
+variable "gcloud_skip_download" {
+  type        = bool
+  description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"
+  default     = true
+}

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -151,6 +151,9 @@ Then perform the following commands on the root folder:
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | bool | `"false"` | no |
+| gcloud\_sdk\_version | The gcloud sdk version to download | string | `"296.0.0"` | no |
+| gcloud\_skip\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
+| gcloud\_upgrade | Whether to upgrade gcloud at runtime | bool | `"false"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | bool | `"true"` | no |
 | http\_load\_balancing | Enable httpload balancer addon | bool | `"true"` | no |

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -151,7 +151,6 @@ Then perform the following commands on the root folder:
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | bool | `"false"` | no |
-| gcloud\_sdk\_version | The gcloud sdk version to download | string | `"296.0.0"` | no |
 | gcloud\_skip\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
 | gcloud\_upgrade | Whether to upgrade gcloud at runtime | bool | `"false"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -413,9 +413,8 @@ module "gcloud_wait_for_cluster" {
   version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
-  upgrade            = var.gcloud_upgrade
-  gcloud_sdk_version = var.gcloud_sdk_version
-  skip_download      = var.gcloud_skip_download
+  upgrade       = var.gcloud_upgrade
+  skip_download = var.gcloud_skip_download
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -410,7 +410,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.4"
+  version = "~> 0.5"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -413,6 +413,10 @@ module "gcloud_wait_for_cluster" {
   version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
+  upgrade            = var.gcloud_upgrade
+  gcloud_sdk_version = var.gcloud_sdk_version
+  skip_download      = var.gcloud_skip_download
+
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -410,7 +410,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.5"
+  version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
@@ -418,8 +418,8 @@ module "gcloud_wait_for_cluster" {
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
   destroy_cmd_body       = "${var.project_id} ${var.name}"
 
-  module_depends_on = [
-    google_container_cluster.primary.master_version,
-    google_container_node_pool.pools[*].name
-  ]
+  module_depends_on = concat(
+    [google_container_cluster.primary.master_version],
+    [for pool in google_container_node_pool.pools : pool.name]
+  )
 }

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -408,25 +408,13 @@ resource "google_container_node_pool" "pools" {
   }
 }
 
-resource "null_resource" "wait_for_cluster" {
-  count = var.skip_provisioners ? 0 : 1
+module "gcloud_wait_for_cluster" {
+  source  = "terraform-google-modules/gcloud/google"
+  version = "~> 0.3"
+  enabled = var.skip_provisioners
 
-  triggers = {
-    project_id = var.project_id
-    name       = var.name
-  }
-
-  provisioner "local-exec" {
-    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
-  }
-
-  provisioner "local-exec" {
-    when    = destroy
-    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
-  }
-
-  depends_on = [
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
-  ]
+  create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
+  create_cmd_body        = "${var.project_id} ${var.name}"
+  destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
+  destroy_cmd_body       = "${var.project_id} ${var.name}"
 }

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -419,7 +419,7 @@ module "gcloud_wait_for_cluster" {
   destroy_cmd_body       = "${var.project_id} ${var.name}"
 
   module_depends_on = [
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
+    google_container_cluster.primary.master_version,
+    join("-", google_container_node_pool.pools[*].name),
   ]
 }

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -410,11 +410,16 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.3"
+  version = "~> 0.4"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
   destroy_cmd_body       = "${var.project_id} ${var.name}"
+
+  module_depends_on = [
+    google_container_cluster.primary,
+    google_container_node_pool.pools,
+  ]
 }

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -420,6 +420,5 @@ module "gcloud_wait_for_cluster" {
 
   module_depends_on = [
     google_container_cluster.primary.master_version,
-    join("-", google_container_node_pool.pools[*].name),
   ]
 }

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -420,5 +420,6 @@ module "gcloud_wait_for_cluster" {
 
   module_depends_on = [
     google_container_cluster.primary.master_version,
+    google_container_node_pool.pools[*].name
   ]
 }

--- a/modules/beta-private-cluster/dns.tf
+++ b/modules/beta-private-cluster/dns.tf
@@ -25,9 +25,8 @@ module "gcloud_delete_default_kube_dns_configmap" {
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
-  upgrade            = var.gcloud_upgrade
-  gcloud_sdk_version = var.gcloud_sdk_version
-  skip_download      = var.gcloud_skip_download
+  upgrade       = var.gcloud_upgrade
+  skip_download = var.gcloud_skip_download
 
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"

--- a/modules/beta-private-cluster/dns.tf
+++ b/modules/beta-private-cluster/dns.tf
@@ -25,6 +25,10 @@ module "gcloud_delete_default_kube_dns_configmap" {
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
+  upgrade            = var.gcloud_upgrade
+  gcloud_sdk_version = var.gcloud_sdk_version
+  skip_download      = var.gcloud_skip_download
+
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
 

--- a/modules/beta-private-cluster/dns.tf
+++ b/modules/beta-private-cluster/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.3"
+  version               = "~> 0.4"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
@@ -51,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -78,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -108,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/modules/beta-private-cluster/dns.tf
+++ b/modules/beta-private-cluster/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.5"
+  version               = "~> 1.0.1"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/modules/beta-private-cluster/dns.tf
+++ b/modules/beta-private-cluster/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.4"
+  version               = "~> 0.5"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/modules/beta-private-cluster/dns.tf
+++ b/modules/beta-private-cluster/dns.tf
@@ -51,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -78,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -108,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/modules/beta-private-cluster/dns.tf
+++ b/modules/beta-private-cluster/dns.tf
@@ -27,6 +27,12 @@ module "gcloud_delete_default_kube_dns_configmap" {
 
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
+
+  module_depends_on = concat(
+    [data.google_client_config.default.access_token],
+    [google_container_cluster.primary.master_version],
+    [for pool in google_container_node_pool.pools : pool.name]
+  )
 }
 
 /******************************************

--- a/modules/beta-private-cluster/dns.tf
+++ b/modules/beta-private-cluster/dns.tf
@@ -19,18 +19,14 @@
 /******************************************
   Delete default kube-dns configmap
  *****************************************/
-resource "null_resource" "delete_default_kube_dns_configmap" {
-  count = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners ? 1 : 0
+module "gcloud_delete_default_kube_dns_configmap" {
+  source                = "terraform-google-modules/gcloud/google"
+  version               = "~> 0.3"
+  enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
+  additional_components = ["kubectl"]
 
-  provisioner "local-exec" {
-    command = "${path.module}/scripts/kubectl_wrapper.sh https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
-  }
-
-  depends_on = [
-    data.google_client_config.default,
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
-  ]
+  create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
+  create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
 }
 
 /******************************************
@@ -55,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -82,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -112,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/modules/beta-private-cluster/scripts/delete-default-resource.sh
+++ b/modules/beta-private-cluster/scripts/delete-default-resource.sh
@@ -29,7 +29,7 @@ RESOURCE_LIST=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" || exi
 
 # Delete requested resource
 if [[ $RESOURCE_LIST = *"${RESOURCE_NAME}"* ]]; then
-    RESOURCE_MAINTAINED_LABEL=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" -o json "${RESOURCE_NAME}" | jq -r '.metadata.labels."maintained_by"')
+    RESOURCE_MAINTAINED_LABEL=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" "${RESOURCE_NAME}" -o=jsonpath='{.metadata.labels.maintained_by}')
     if [[ $RESOURCE_MAINTAINED_LABEL = "terraform" ]]; then
         echo "Terraform maintained ${RESOURCE_NAME} ${RESOURCE_TYPE} appears to have already been created in ${RESOURCE_NAMESPACE} namespace"
     else

--- a/modules/beta-private-cluster/scripts/wait-for-cluster.sh
+++ b/modules/beta-private-cluster/scripts/wait-for-cluster.sh
@@ -25,12 +25,9 @@ CLUSTER_NAME=$2
 
 echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-
-while [[ "$current_status" == "RECONCILING" ]]; do
-    printf "."
-    sleep 5
-    current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-done
+while
+  current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
+  [[ "${current_status}" == "RECONCILING" ]]
+do printf ".";sleep 5; done
 
 echo "Cluster is ready!"

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -530,12 +530,6 @@ variable "gcloud_upgrade" {
   default     = false
 }
 
-variable "gcloud_sdk_version" {
-  type        = string
-  description = "The gcloud sdk version to download"
-  default     = "296.0.0"
-}
-
 variable "gcloud_skip_download" {
   type        = bool
   description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -523,3 +523,21 @@ variable "firewall_inbound_ports" {
   description = "List of TCP ports for admission/webhook controllers"
   default     = ["8443", "9443", "15017"]
 }
+
+variable "gcloud_upgrade" {
+  type        = bool
+  description = "Whether to upgrade gcloud at runtime"
+  default     = false
+}
+
+variable "gcloud_sdk_version" {
+  type        = string
+  description = "The gcloud sdk version to download"
+  default     = "296.0.0"
+}
+
+variable "gcloud_skip_download" {
+  type        = bool
+  description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"
+  default     = true
+}

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -164,6 +164,9 @@ Then perform the following commands on the root folder:
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | bool | `"false"` | no |
+| gcloud\_sdk\_version | The gcloud sdk version to download | string | `"296.0.0"` | no |
+| gcloud\_skip\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
+| gcloud\_upgrade | Whether to upgrade gcloud at runtime | bool | `"false"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | bool | `"true"` | no |
 | http\_load\_balancing | Enable httpload balancer addon | bool | `"true"` | no |

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -164,7 +164,6 @@ Then perform the following commands on the root folder:
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | bool | `"false"` | no |
-| gcloud\_sdk\_version | The gcloud sdk version to download | string | `"296.0.0"` | no |
 | gcloud\_skip\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
 | gcloud\_upgrade | Whether to upgrade gcloud at runtime | bool | `"false"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -473,6 +473,10 @@ module "gcloud_wait_for_cluster" {
   version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
+  upgrade            = var.gcloud_upgrade
+  gcloud_sdk_version = var.gcloud_sdk_version
+  skip_download      = var.gcloud_skip_download
+
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -473,9 +473,8 @@ module "gcloud_wait_for_cluster" {
   version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
-  upgrade            = var.gcloud_upgrade
-  gcloud_sdk_version = var.gcloud_sdk_version
-  skip_download      = var.gcloud_skip_download
+  upgrade       = var.gcloud_upgrade
+  skip_download = var.gcloud_skip_download
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -468,25 +468,18 @@ resource "google_container_node_pool" "pools" {
   }
 }
 
-resource "null_resource" "wait_for_cluster" {
-  count = var.skip_provisioners ? 0 : 1
+module "gcloud_wait_for_cluster" {
+  source  = "terraform-google-modules/gcloud/google"
+  version = "~> 1.0.1"
+  enabled = var.skip_provisioners
 
-  triggers = {
-    project_id = var.project_id
-    name       = var.name
-  }
+  create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
+  create_cmd_body        = "${var.project_id} ${var.name}"
+  destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
+  destroy_cmd_body       = "${var.project_id} ${var.name}"
 
-  provisioner "local-exec" {
-    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
-  }
-
-  provisioner "local-exec" {
-    when    = destroy
-    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
-  }
-
-  depends_on = [
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
-  ]
+  module_depends_on = concat(
+    [google_container_cluster.primary.master_version],
+    [for pool in google_container_node_pool.pools : pool.name]
+  )
 }

--- a/modules/beta-public-cluster-update-variant/dns.tf
+++ b/modules/beta-public-cluster-update-variant/dns.tf
@@ -25,9 +25,8 @@ module "gcloud_delete_default_kube_dns_configmap" {
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
-  upgrade            = var.gcloud_upgrade
-  gcloud_sdk_version = var.gcloud_sdk_version
-  skip_download      = var.gcloud_skip_download
+  upgrade       = var.gcloud_upgrade
+  skip_download = var.gcloud_skip_download
 
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"

--- a/modules/beta-public-cluster-update-variant/dns.tf
+++ b/modules/beta-public-cluster-update-variant/dns.tf
@@ -25,6 +25,10 @@ module "gcloud_delete_default_kube_dns_configmap" {
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
+  upgrade            = var.gcloud_upgrade
+  gcloud_sdk_version = var.gcloud_sdk_version
+  skip_download      = var.gcloud_skip_download
+
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
 

--- a/modules/beta-public-cluster-update-variant/scripts/delete-default-resource.sh
+++ b/modules/beta-public-cluster-update-variant/scripts/delete-default-resource.sh
@@ -29,7 +29,7 @@ RESOURCE_LIST=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" || exi
 
 # Delete requested resource
 if [[ $RESOURCE_LIST = *"${RESOURCE_NAME}"* ]]; then
-    RESOURCE_MAINTAINED_LABEL=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" -o json "${RESOURCE_NAME}" | jq -r '.metadata.labels."maintained_by"')
+    RESOURCE_MAINTAINED_LABEL=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" "${RESOURCE_NAME}" -o=jsonpath='{.metadata.labels.maintained_by}')
     if [[ $RESOURCE_MAINTAINED_LABEL = "terraform" ]]; then
         echo "Terraform maintained ${RESOURCE_NAME} ${RESOURCE_TYPE} appears to have already been created in ${RESOURCE_NAMESPACE} namespace"
     else

--- a/modules/beta-public-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/beta-public-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -25,12 +25,9 @@ CLUSTER_NAME=$2
 
 echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-
-while [[ "$current_status" == "RECONCILING" ]]; do
-    printf "."
-    sleep 5
-    current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-done
+while
+  current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
+  [[ "${current_status}" == "RECONCILING" ]]
+do printf ".";sleep 5; done
 
 echo "Cluster is ready!"

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -506,12 +506,6 @@ variable "gcloud_upgrade" {
   default     = false
 }
 
-variable "gcloud_sdk_version" {
-  type        = string
-  description = "The gcloud sdk version to download"
-  default     = "296.0.0"
-}
-
 variable "gcloud_skip_download" {
   type        = bool
   description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -499,3 +499,21 @@ variable "firewall_inbound_ports" {
   description = "List of TCP ports for admission/webhook controllers"
   default     = ["8443", "9443", "15017"]
 }
+
+variable "gcloud_upgrade" {
+  type        = bool
+  description = "Whether to upgrade gcloud at runtime"
+  default     = false
+}
+
+variable "gcloud_sdk_version" {
+  type        = string
+  description = "The gcloud sdk version to download"
+  default     = "296.0.0"
+}
+
+variable "gcloud_skip_download" {
+  type        = bool
+  description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"
+  default     = true
+}

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -142,6 +142,9 @@ Then perform the following commands on the root folder:
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | bool | `"false"` | no |
+| gcloud\_sdk\_version | The gcloud sdk version to download | string | `"296.0.0"` | no |
+| gcloud\_skip\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
+| gcloud\_upgrade | Whether to upgrade gcloud at runtime | bool | `"false"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | bool | `"true"` | no |
 | http\_load\_balancing | Enable httpload balancer addon | bool | `"true"` | no |

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -142,7 +142,6 @@ Then perform the following commands on the root folder:
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | bool | `"false"` | no |
-| gcloud\_sdk\_version | The gcloud sdk version to download | string | `"296.0.0"` | no |
 | gcloud\_skip\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
 | gcloud\_upgrade | Whether to upgrade gcloud at runtime | bool | `"false"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -400,9 +400,8 @@ module "gcloud_wait_for_cluster" {
   version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
-  upgrade            = var.gcloud_upgrade
-  gcloud_sdk_version = var.gcloud_sdk_version
-  skip_download      = var.gcloud_skip_download
+  upgrade       = var.gcloud_upgrade
+  skip_download = var.gcloud_skip_download
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -400,6 +400,10 @@ module "gcloud_wait_for_cluster" {
   version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
+  upgrade            = var.gcloud_upgrade
+  gcloud_sdk_version = var.gcloud_sdk_version
+  skip_download      = var.gcloud_skip_download
+
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -395,25 +395,13 @@ resource "google_container_node_pool" "pools" {
   }
 }
 
-resource "null_resource" "wait_for_cluster" {
-  count = var.skip_provisioners ? 0 : 1
+module "gcloud_wait_for_cluster" {
+  source  = "terraform-google-modules/gcloud/google"
+  version = "~> 0.3"
+  enabled = var.skip_provisioners
 
-  triggers = {
-    project_id = var.project_id
-    name       = var.name
-  }
-
-  provisioner "local-exec" {
-    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
-  }
-
-  provisioner "local-exec" {
-    when    = destroy
-    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
-  }
-
-  depends_on = [
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
-  ]
+  create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
+  create_cmd_body        = "${var.project_id} ${var.name}"
+  destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
+  destroy_cmd_body       = "${var.project_id} ${var.name}"
 }

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -397,7 +397,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.5"
+  version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
@@ -405,8 +405,8 @@ module "gcloud_wait_for_cluster" {
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
   destroy_cmd_body       = "${var.project_id} ${var.name}"
 
-  module_depends_on = [
-    google_container_cluster.primary.master_version,
-    google_container_node_pool.pools[*].name
-  ]
+  module_depends_on = concat(
+    [google_container_cluster.primary.master_version],
+    [for pool in google_container_node_pool.pools : pool.name]
+  )
 }

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -407,6 +407,5 @@ module "gcloud_wait_for_cluster" {
 
   module_depends_on = [
     google_container_cluster.primary.master_version,
-    join("-", google_container_node_pool.pools[*].name),
   ]
 }

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -397,11 +397,16 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.3"
+  version = "~> 0.4"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
   destroy_cmd_body       = "${var.project_id} ${var.name}"
+
+  module_depends_on = [
+    google_container_cluster.primary,
+    google_container_node_pool.pools,
+  ]
 }

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -397,7 +397,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.4"
+  version = "~> 0.5"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -407,5 +407,6 @@ module "gcloud_wait_for_cluster" {
 
   module_depends_on = [
     google_container_cluster.primary.master_version,
+    google_container_node_pool.pools[*].name
   ]
 }

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -406,7 +406,7 @@ module "gcloud_wait_for_cluster" {
   destroy_cmd_body       = "${var.project_id} ${var.name}"
 
   module_depends_on = [
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
+    google_container_cluster.primary.master_version,
+    join("-", google_container_node_pool.pools[*].name),
   ]
 }

--- a/modules/beta-public-cluster/dns.tf
+++ b/modules/beta-public-cluster/dns.tf
@@ -25,9 +25,8 @@ module "gcloud_delete_default_kube_dns_configmap" {
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
-  upgrade            = var.gcloud_upgrade
-  gcloud_sdk_version = var.gcloud_sdk_version
-  skip_download      = var.gcloud_skip_download
+  upgrade       = var.gcloud_upgrade
+  skip_download = var.gcloud_skip_download
 
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"

--- a/modules/beta-public-cluster/dns.tf
+++ b/modules/beta-public-cluster/dns.tf
@@ -25,6 +25,10 @@ module "gcloud_delete_default_kube_dns_configmap" {
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
+  upgrade            = var.gcloud_upgrade
+  gcloud_sdk_version = var.gcloud_sdk_version
+  skip_download      = var.gcloud_skip_download
+
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
 

--- a/modules/beta-public-cluster/dns.tf
+++ b/modules/beta-public-cluster/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.3"
+  version               = "~> 0.4"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
@@ -51,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -78,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -108,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/modules/beta-public-cluster/dns.tf
+++ b/modules/beta-public-cluster/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.5"
+  version               = "~> 1.0.1"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/modules/beta-public-cluster/dns.tf
+++ b/modules/beta-public-cluster/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.4"
+  version               = "~> 0.5"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/modules/beta-public-cluster/dns.tf
+++ b/modules/beta-public-cluster/dns.tf
@@ -51,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -78,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -108,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/modules/beta-public-cluster/dns.tf
+++ b/modules/beta-public-cluster/dns.tf
@@ -27,6 +27,12 @@ module "gcloud_delete_default_kube_dns_configmap" {
 
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
+
+  module_depends_on = concat(
+    [data.google_client_config.default.access_token],
+    [google_container_cluster.primary.master_version],
+    [for pool in google_container_node_pool.pools : pool.name]
+  )
 }
 
 /******************************************

--- a/modules/beta-public-cluster/dns.tf
+++ b/modules/beta-public-cluster/dns.tf
@@ -19,18 +19,14 @@
 /******************************************
   Delete default kube-dns configmap
  *****************************************/
-resource "null_resource" "delete_default_kube_dns_configmap" {
-  count = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners ? 1 : 0
+module "gcloud_delete_default_kube_dns_configmap" {
+  source                = "terraform-google-modules/gcloud/google"
+  version               = "~> 0.3"
+  enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
+  additional_components = ["kubectl"]
 
-  provisioner "local-exec" {
-    command = "${path.module}/scripts/kubectl_wrapper.sh https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
-  }
-
-  depends_on = [
-    data.google_client_config.default,
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
-  ]
+  create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
+  create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
 }
 
 /******************************************
@@ -55,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -82,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -112,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/modules/beta-public-cluster/scripts/delete-default-resource.sh
+++ b/modules/beta-public-cluster/scripts/delete-default-resource.sh
@@ -29,7 +29,7 @@ RESOURCE_LIST=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" || exi
 
 # Delete requested resource
 if [[ $RESOURCE_LIST = *"${RESOURCE_NAME}"* ]]; then
-    RESOURCE_MAINTAINED_LABEL=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" -o json "${RESOURCE_NAME}" | jq -r '.metadata.labels."maintained_by"')
+    RESOURCE_MAINTAINED_LABEL=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" "${RESOURCE_NAME}" -o=jsonpath='{.metadata.labels.maintained_by}')
     if [[ $RESOURCE_MAINTAINED_LABEL = "terraform" ]]; then
         echo "Terraform maintained ${RESOURCE_NAME} ${RESOURCE_TYPE} appears to have already been created in ${RESOURCE_NAMESPACE} namespace"
     else

--- a/modules/beta-public-cluster/scripts/wait-for-cluster.sh
+++ b/modules/beta-public-cluster/scripts/wait-for-cluster.sh
@@ -25,12 +25,9 @@ CLUSTER_NAME=$2
 
 echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-
-while [[ "$current_status" == "RECONCILING" ]]; do
-    printf "."
-    sleep 5
-    current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-done
+while
+  current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
+  [[ "${current_status}" == "RECONCILING" ]]
+do printf ".";sleep 5; done
 
 echo "Cluster is ready!"

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -506,12 +506,6 @@ variable "gcloud_upgrade" {
   default     = false
 }
 
-variable "gcloud_sdk_version" {
-  type        = string
-  description = "The gcloud sdk version to download"
-  default     = "296.0.0"
-}
-
 variable "gcloud_skip_download" {
   type        = bool
   description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -499,3 +499,21 @@ variable "firewall_inbound_ports" {
   description = "List of TCP ports for admission/webhook controllers"
   default     = ["8443", "9443", "15017"]
 }
+
+variable "gcloud_upgrade" {
+  type        = bool
+  description = "Whether to upgrade gcloud at runtime"
+  default     = false
+}
+
+variable "gcloud_sdk_version" {
+  type        = string
+  description = "The gcloud sdk version to download"
+  default     = "296.0.0"
+}
+
+variable "gcloud_skip_download" {
+  type        = bool
+  description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"
+  default     = true
+}

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -145,6 +145,9 @@ Then perform the following commands on the root folder:
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | bool | `"true"` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
+| gcloud\_sdk\_version | The gcloud sdk version to download | string | `"296.0.0"` | no |
+| gcloud\_skip\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
+| gcloud\_upgrade | Whether to upgrade gcloud at runtime | bool | `"false"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | bool | `"true"` | no |
 | http\_load\_balancing | Enable httpload balancer addon | bool | `"true"` | no |

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -145,7 +145,6 @@ Then perform the following commands on the root folder:
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | bool | `"true"` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
-| gcloud\_sdk\_version | The gcloud sdk version to download | string | `"296.0.0"` | no |
 | gcloud\_skip\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
 | gcloud\_upgrade | Whether to upgrade gcloud at runtime | bool | `"false"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -340,6 +340,10 @@ module "gcloud_wait_for_cluster" {
   version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
+  upgrade            = var.gcloud_upgrade
+  gcloud_sdk_version = var.gcloud_sdk_version
+  skip_download      = var.gcloud_skip_download
+
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -335,25 +335,13 @@ resource "google_container_node_pool" "pools" {
   }
 }
 
-resource "null_resource" "wait_for_cluster" {
-  count = var.skip_provisioners ? 0 : 1
+module "gcloud_wait_for_cluster" {
+  source  = "terraform-google-modules/gcloud/google"
+  version = "~> 0.3"
+  enabled = var.skip_provisioners
 
-  triggers = {
-    project_id = var.project_id
-    name       = var.name
-  }
-
-  provisioner "local-exec" {
-    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
-  }
-
-  provisioner "local-exec" {
-    when    = destroy
-    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
-  }
-
-  depends_on = [
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
-  ]
+  create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
+  create_cmd_body        = "${var.project_id} ${var.name}"
+  destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
+  destroy_cmd_body       = "${var.project_id} ${var.name}"
 }

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -340,9 +340,8 @@ module "gcloud_wait_for_cluster" {
   version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
-  upgrade            = var.gcloud_upgrade
-  gcloud_sdk_version = var.gcloud_sdk_version
-  skip_download      = var.gcloud_skip_download
+  upgrade       = var.gcloud_upgrade
+  skip_download = var.gcloud_skip_download
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -347,5 +347,6 @@ module "gcloud_wait_for_cluster" {
 
   module_depends_on = [
     google_container_cluster.primary.master_version,
+    google_container_node_pool.pools[*].name
   ]
 }

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -337,11 +337,16 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.3"
+  version = "~> 0.4"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
   destroy_cmd_body       = "${var.project_id} ${var.name}"
+
+  module_depends_on = [
+    google_container_cluster.primary,
+    google_container_node_pool.pools,
+  ]
 }

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -337,7 +337,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.4"
+  version = "~> 0.5"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -337,7 +337,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.5"
+  version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
@@ -345,8 +345,8 @@ module "gcloud_wait_for_cluster" {
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
   destroy_cmd_body       = "${var.project_id} ${var.name}"
 
-  module_depends_on = [
-    google_container_cluster.primary.master_version,
-    google_container_node_pool.pools[*].name
-  ]
+  module_depends_on = concat(
+    [google_container_cluster.primary.master_version],
+    [for pool in google_container_node_pool.pools : pool.name]
+  )
 }

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -346,7 +346,7 @@ module "gcloud_wait_for_cluster" {
   destroy_cmd_body       = "${var.project_id} ${var.name}"
 
   module_depends_on = [
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
+    google_container_cluster.primary.master_version,
+    join("-", google_container_node_pool.pools[*].name),
   ]
 }

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -347,6 +347,5 @@ module "gcloud_wait_for_cluster" {
 
   module_depends_on = [
     google_container_cluster.primary.master_version,
-    join("-", google_container_node_pool.pools[*].name),
   ]
 }

--- a/modules/private-cluster-update-variant/dns.tf
+++ b/modules/private-cluster-update-variant/dns.tf
@@ -25,9 +25,8 @@ module "gcloud_delete_default_kube_dns_configmap" {
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
-  upgrade            = var.gcloud_upgrade
-  gcloud_sdk_version = var.gcloud_sdk_version
-  skip_download      = var.gcloud_skip_download
+  upgrade       = var.gcloud_upgrade
+  skip_download = var.gcloud_skip_download
 
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"

--- a/modules/private-cluster-update-variant/dns.tf
+++ b/modules/private-cluster-update-variant/dns.tf
@@ -25,6 +25,10 @@ module "gcloud_delete_default_kube_dns_configmap" {
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
+  upgrade            = var.gcloud_upgrade
+  gcloud_sdk_version = var.gcloud_sdk_version
+  skip_download      = var.gcloud_skip_download
+
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
 

--- a/modules/private-cluster-update-variant/dns.tf
+++ b/modules/private-cluster-update-variant/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.3"
+  version               = "~> 0.4"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
@@ -51,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -78,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -108,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/modules/private-cluster-update-variant/dns.tf
+++ b/modules/private-cluster-update-variant/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.5"
+  version               = "~> 1.0.1"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/modules/private-cluster-update-variant/dns.tf
+++ b/modules/private-cluster-update-variant/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.4"
+  version               = "~> 0.5"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/modules/private-cluster-update-variant/dns.tf
+++ b/modules/private-cluster-update-variant/dns.tf
@@ -51,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -78,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -108,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/modules/private-cluster-update-variant/dns.tf
+++ b/modules/private-cluster-update-variant/dns.tf
@@ -27,6 +27,12 @@ module "gcloud_delete_default_kube_dns_configmap" {
 
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
+
+  module_depends_on = concat(
+    [data.google_client_config.default.access_token],
+    [google_container_cluster.primary.master_version],
+    [for pool in google_container_node_pool.pools : pool.name]
+  )
 }
 
 /******************************************

--- a/modules/private-cluster-update-variant/dns.tf
+++ b/modules/private-cluster-update-variant/dns.tf
@@ -19,18 +19,14 @@
 /******************************************
   Delete default kube-dns configmap
  *****************************************/
-resource "null_resource" "delete_default_kube_dns_configmap" {
-  count = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners ? 1 : 0
+module "gcloud_delete_default_kube_dns_configmap" {
+  source                = "terraform-google-modules/gcloud/google"
+  version               = "~> 0.3"
+  enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
+  additional_components = ["kubectl"]
 
-  provisioner "local-exec" {
-    command = "${path.module}/scripts/kubectl_wrapper.sh https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
-  }
-
-  depends_on = [
-    data.google_client_config.default,
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
-  ]
+  create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
+  create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
 }
 
 /******************************************
@@ -55,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -82,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -112,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/modules/private-cluster-update-variant/scripts/delete-default-resource.sh
+++ b/modules/private-cluster-update-variant/scripts/delete-default-resource.sh
@@ -29,7 +29,7 @@ RESOURCE_LIST=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" || exi
 
 # Delete requested resource
 if [[ $RESOURCE_LIST = *"${RESOURCE_NAME}"* ]]; then
-    RESOURCE_MAINTAINED_LABEL=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" -o json "${RESOURCE_NAME}" | jq -r '.metadata.labels."maintained_by"')
+    RESOURCE_MAINTAINED_LABEL=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" "${RESOURCE_NAME}" -o=jsonpath='{.metadata.labels.maintained_by}')
     if [[ $RESOURCE_MAINTAINED_LABEL = "terraform" ]]; then
         echo "Terraform maintained ${RESOURCE_NAME} ${RESOURCE_TYPE} appears to have already been created in ${RESOURCE_NAMESPACE} namespace"
     else

--- a/modules/private-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/private-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -25,12 +25,9 @@ CLUSTER_NAME=$2
 
 echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-
-while [[ "$current_status" == "RECONCILING" ]]; do
-    printf "."
-    sleep 5
-    current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-done
+while
+  current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
+  [[ "${current_status}" == "RECONCILING" ]]
+do printf ".";sleep 5; done
 
 echo "Cluster is ready!"

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -362,3 +362,21 @@ variable "firewall_inbound_ports" {
   description = "List of TCP ports for admission/webhook controllers"
   default     = ["8443", "9443", "15017"]
 }
+
+variable "gcloud_upgrade" {
+  type        = bool
+  description = "Whether to upgrade gcloud at runtime"
+  default     = false
+}
+
+variable "gcloud_sdk_version" {
+  type        = string
+  description = "The gcloud sdk version to download"
+  default     = "296.0.0"
+}
+
+variable "gcloud_skip_download" {
+  type        = bool
+  description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"
+  default     = true
+}

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -369,12 +369,6 @@ variable "gcloud_upgrade" {
   default     = false
 }
 
-variable "gcloud_sdk_version" {
-  type        = string
-  description = "The gcloud sdk version to download"
-  default     = "296.0.0"
-}
-
 variable "gcloud_skip_download" {
   type        = bool
   description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -123,7 +123,6 @@ Then perform the following commands on the root folder:
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | bool | `"true"` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
-| gcloud\_sdk\_version | The gcloud sdk version to download | string | `"296.0.0"` | no |
 | gcloud\_skip\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
 | gcloud\_upgrade | Whether to upgrade gcloud at runtime | bool | `"false"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -123,6 +123,9 @@ Then perform the following commands on the root folder:
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | bool | `"true"` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
+| gcloud\_sdk\_version | The gcloud sdk version to download | string | `"296.0.0"` | no |
+| gcloud\_skip\_download | Whether to skip downloading gcloud (assumes gcloud is already available outside the module) | bool | `"true"` | no |
+| gcloud\_upgrade | Whether to upgrade gcloud at runtime | bool | `"false"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | bool | `"true"` | no |
 | http\_load\_balancing | Enable httpload balancer addon | bool | `"true"` | no |

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -273,7 +273,7 @@ module "gcloud_wait_for_cluster" {
   destroy_cmd_body       = "${var.project_id} ${var.name}"
 
   module_depends_on = [
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
+    google_container_cluster.primary.master_version,
+    join("-", google_container_node_pool.pools[*].name),
   ]
 }

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -274,5 +274,6 @@ module "gcloud_wait_for_cluster" {
 
   module_depends_on = [
     google_container_cluster.primary.master_version,
+    google_container_node_pool.pools[*].name
   ]
 }

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -267,6 +267,10 @@ module "gcloud_wait_for_cluster" {
   version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
+  upgrade            = var.gcloud_upgrade
+  gcloud_sdk_version = var.gcloud_sdk_version
+  skip_download      = var.gcloud_skip_download
+
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -267,9 +267,8 @@ module "gcloud_wait_for_cluster" {
   version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
-  upgrade            = var.gcloud_upgrade
-  gcloud_sdk_version = var.gcloud_sdk_version
-  skip_download      = var.gcloud_skip_download
+  upgrade       = var.gcloud_upgrade
+  skip_download = var.gcloud_skip_download
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -274,6 +274,5 @@ module "gcloud_wait_for_cluster" {
 
   module_depends_on = [
     google_container_cluster.primary.master_version,
-    join("-", google_container_node_pool.pools[*].name),
   ]
 }

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -264,7 +264,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.4"
+  version = "~> 0.5"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -264,11 +264,16 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.3"
+  version = "~> 0.4"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
   create_cmd_body        = "${var.project_id} ${var.name}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
   destroy_cmd_body       = "${var.project_id} ${var.name}"
+
+  module_depends_on = [
+    google_container_cluster.primary,
+    google_container_node_pool.pools,
+  ]
 }

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -264,7 +264,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 0.5"
+  version = "~> 1.0.1"
   enabled = var.skip_provisioners
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
@@ -272,8 +272,8 @@ module "gcloud_wait_for_cluster" {
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
   destroy_cmd_body       = "${var.project_id} ${var.name}"
 
-  module_depends_on = [
-    google_container_cluster.primary.master_version,
-    google_container_node_pool.pools[*].name
-  ]
+  module_depends_on = concat(
+    [google_container_cluster.primary.master_version],
+    [for pool in google_container_node_pool.pools : pool.name]
+  )
 }

--- a/modules/private-cluster/dns.tf
+++ b/modules/private-cluster/dns.tf
@@ -25,9 +25,8 @@ module "gcloud_delete_default_kube_dns_configmap" {
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
-  upgrade            = var.gcloud_upgrade
-  gcloud_sdk_version = var.gcloud_sdk_version
-  skip_download      = var.gcloud_skip_download
+  upgrade       = var.gcloud_upgrade
+  skip_download = var.gcloud_skip_download
 
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"

--- a/modules/private-cluster/dns.tf
+++ b/modules/private-cluster/dns.tf
@@ -25,6 +25,10 @@ module "gcloud_delete_default_kube_dns_configmap" {
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
+  upgrade            = var.gcloud_upgrade
+  gcloud_sdk_version = var.gcloud_sdk_version
+  skip_download      = var.gcloud_skip_download
+
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
 

--- a/modules/private-cluster/dns.tf
+++ b/modules/private-cluster/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.3"
+  version               = "~> 0.4"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 
@@ -51,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -78,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -108,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
+    module.gcloud_delete_default_kube_dns_configmap.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/modules/private-cluster/dns.tf
+++ b/modules/private-cluster/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.5"
+  version               = "~> 1.0.1"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/modules/private-cluster/dns.tf
+++ b/modules/private-cluster/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 0.4"
+  version               = "~> 0.5"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/modules/private-cluster/dns.tf
+++ b/modules/private-cluster/dns.tf
@@ -51,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -78,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -108,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap.outputs.wait,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/modules/private-cluster/dns.tf
+++ b/modules/private-cluster/dns.tf
@@ -27,6 +27,12 @@ module "gcloud_delete_default_kube_dns_configmap" {
 
   create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
   create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
+
+  module_depends_on = concat(
+    [data.google_client_config.default.access_token],
+    [google_container_cluster.primary.master_version],
+    [for pool in google_container_node_pool.pools : pool.name]
+  )
 }
 
 /******************************************

--- a/modules/private-cluster/dns.tf
+++ b/modules/private-cluster/dns.tf
@@ -19,18 +19,14 @@
 /******************************************
   Delete default kube-dns configmap
  *****************************************/
-resource "null_resource" "delete_default_kube_dns_configmap" {
-  count = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners ? 1 : 0
+module "gcloud_delete_default_kube_dns_configmap" {
+  source                = "terraform-google-modules/gcloud/google"
+  version               = "~> 0.3"
+  enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
+  additional_components = ["kubectl"]
 
-  provisioner "local-exec" {
-    command = "${path.module}/scripts/kubectl_wrapper.sh https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
-  }
-
-  depends_on = [
-    data.google_client_config.default,
-    google_container_cluster.primary,
-    google_container_node_pool.pools,
-  ]
+  create_cmd_entrypoint = "${path.module}/scripts/kubectl_wrapper.sh"
+  create_cmd_body       = "https://${local.cluster_endpoint} ${data.google_client_config.default.access_token} ${local.cluster_ca_certificate} ${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
 }
 
 /******************************************
@@ -55,7 +51,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -82,7 +78,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,
@@ -112,7 +108,7 @@ EOF
   }
 
   depends_on = [
-    null_resource.delete_default_kube_dns_configmap,
+    module.gcloud_delete_default_kube_dns_configmap,
     data.google_client_config.default,
     google_container_cluster.primary,
     google_container_node_pool.pools,

--- a/modules/private-cluster/scripts/delete-default-resource.sh
+++ b/modules/private-cluster/scripts/delete-default-resource.sh
@@ -29,7 +29,7 @@ RESOURCE_LIST=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" || exi
 
 # Delete requested resource
 if [[ $RESOURCE_LIST = *"${RESOURCE_NAME}"* ]]; then
-    RESOURCE_MAINTAINED_LABEL=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" -o json "${RESOURCE_NAME}" | jq -r '.metadata.labels."maintained_by"')
+    RESOURCE_MAINTAINED_LABEL=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" "${RESOURCE_NAME}" -o=jsonpath='{.metadata.labels.maintained_by}')
     if [[ $RESOURCE_MAINTAINED_LABEL = "terraform" ]]; then
         echo "Terraform maintained ${RESOURCE_NAME} ${RESOURCE_TYPE} appears to have already been created in ${RESOURCE_NAMESPACE} namespace"
     else

--- a/modules/private-cluster/scripts/wait-for-cluster.sh
+++ b/modules/private-cluster/scripts/wait-for-cluster.sh
@@ -25,12 +25,9 @@ CLUSTER_NAME=$2
 
 echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-
-while [[ "$current_status" == "RECONCILING" ]]; do
-    printf "."
-    sleep 5
-    current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-done
+while
+  current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
+  [[ "${current_status}" == "RECONCILING" ]]
+do printf ".";sleep 5; done
 
 echo "Cluster is ready!"

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -362,3 +362,21 @@ variable "firewall_inbound_ports" {
   description = "List of TCP ports for admission/webhook controllers"
   default     = ["8443", "9443", "15017"]
 }
+
+variable "gcloud_upgrade" {
+  type        = bool
+  description = "Whether to upgrade gcloud at runtime"
+  default     = false
+}
+
+variable "gcloud_sdk_version" {
+  type        = string
+  description = "The gcloud sdk version to download"
+  default     = "296.0.0"
+}
+
+variable "gcloud_skip_download" {
+  type        = bool
+  description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"
+  default     = true
+}

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -369,12 +369,6 @@ variable "gcloud_upgrade" {
   default     = false
 }
 
-variable "gcloud_sdk_version" {
-  type        = string
-  description = "The gcloud sdk version to download"
-  default     = "296.0.0"
-}
-
 variable "gcloud_skip_download" {
   type        = bool
   description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"

--- a/scripts/delete-default-resource.sh
+++ b/scripts/delete-default-resource.sh
@@ -29,7 +29,7 @@ RESOURCE_LIST=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" || exi
 
 # Delete requested resource
 if [[ $RESOURCE_LIST = *"${RESOURCE_NAME}"* ]]; then
-    RESOURCE_MAINTAINED_LABEL=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" -o json "${RESOURCE_NAME}" | jq -r '.metadata.labels."maintained_by"')
+    RESOURCE_MAINTAINED_LABEL=$(kubectl -n "${RESOURCE_NAMESPACE}" get "${RESOURCE_TYPE}" "${RESOURCE_NAME}" -o=jsonpath='{.metadata.labels.maintained_by}')
     if [[ $RESOURCE_MAINTAINED_LABEL = "terraform" ]]; then
         echo "Terraform maintained ${RESOURCE_NAME} ${RESOURCE_TYPE} appears to have already been created in ${RESOURCE_NAMESPACE} namespace"
     else

--- a/scripts/wait-for-cluster.sh
+++ b/scripts/wait-for-cluster.sh
@@ -25,12 +25,9 @@ CLUSTER_NAME=$2
 
 echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
-current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-
-while [[ "$current_status" == "RECONCILING" ]]; do
-    printf "."
-    sleep 5
-    current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-done
+while
+  current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
+  [[ "${current_status}" == "RECONCILING" ]]
+do printf ".";sleep 5; done
 
 echo "Cluster is ready!"

--- a/variables.tf
+++ b/variables.tf
@@ -338,3 +338,21 @@ variable "firewall_inbound_ports" {
   description = "List of TCP ports for admission/webhook controllers"
   default     = ["8443", "9443", "15017"]
 }
+
+variable "gcloud_upgrade" {
+  type        = bool
+  description = "Whether to upgrade gcloud at runtime"
+  default     = false
+}
+
+variable "gcloud_sdk_version" {
+  type        = string
+  description = "The gcloud sdk version to download"
+  default     = "296.0.0"
+}
+
+variable "gcloud_skip_download" {
+  type        = bool
+  description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -345,12 +345,6 @@ variable "gcloud_upgrade" {
   default     = false
 }
 
-variable "gcloud_sdk_version" {
-  type        = string
-  description = "The gcloud sdk version to download"
-  default     = "296.0.0"
-}
-
 variable "gcloud_skip_download" {
   type        = bool
   description = "Whether to skip downloading gcloud (assumes gcloud is already available outside the module)"


### PR DESCRIPTION
Uses gcloud module for wait-for-cluster and delete-default-resource scripts.

Fixes #401

In other words: Removes dependency on locally installed `glcloud`, `kubectl`, and `jq` binaries.