### PR TITLE
Fix the warning about deprecated external references from destroy provisioners

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -495,13 +495,18 @@ resource "google_container_node_pool" "pools" {
 resource "null_resource" "wait_for_cluster" {
   count = var.skip_provisioners ? 0 : 1
 
+  triggers = {
+    project_id = var.project_id
+    name       = var.name
+  }
+
   provisioner "local-exec" {
-    command = "${path.module}/scripts/wait-for-cluster.sh ${var.project_id} ${var.name}"
+    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
   }
 
   provisioner "local-exec" {
     when    = destroy
-    command = "${path.module}/scripts/wait-for-cluster.sh ${var.project_id} ${var.name}"
+    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
   }
 
   depends_on = [

--- a/cluster.tf
+++ b/cluster.tf
@@ -227,13 +227,18 @@ resource "google_container_node_pool" "pools" {
 resource "null_resource" "wait_for_cluster" {
   count = var.skip_provisioners ? 0 : 1
 
+  triggers = {
+    project_id = var.project_id
+    name       = var.name
+  }
+
   provisioner "local-exec" {
-    command = "${path.module}/scripts/wait-for-cluster.sh ${var.project_id} ${var.name}"
+    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
   }
 
   provisioner "local-exec" {
     when    = destroy
-    command = "${path.module}/scripts/wait-for-cluster.sh ${var.project_id} ${var.name}"
+    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
   }
 
   depends_on = [

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -447,13 +447,18 @@ resource "google_container_node_pool" "pools" {
 resource "null_resource" "wait_for_cluster" {
   count = var.skip_provisioners ? 0 : 1
 
+  triggers = {
+    project_id = var.project_id
+    name       = var.name
+  }
+
   provisioner "local-exec" {
-    command = "${path.module}/scripts/wait-for-cluster.sh ${var.project_id} ${var.name}"
+    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
   }
 
   provisioner "local-exec" {
     when    = destroy
-    command = "${path.module}/scripts/wait-for-cluster.sh ${var.project_id} ${var.name}"
+    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
   }
 
   depends_on = [

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -374,13 +374,18 @@ resource "google_container_node_pool" "pools" {
 resource "null_resource" "wait_for_cluster" {
   count = var.skip_provisioners ? 0 : 1
 
+  triggers = {
+    project_id = var.project_id
+    name       = var.name
+  }
+
   provisioner "local-exec" {
-    command = "${path.module}/scripts/wait-for-cluster.sh ${var.project_id} ${var.name}"
+    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
   }
 
   provisioner "local-exec" {
     when    = destroy
-    command = "${path.module}/scripts/wait-for-cluster.sh ${var.project_id} ${var.name}"
+    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
   }
 
   depends_on = [

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -361,13 +361,18 @@ resource "google_container_node_pool" "pools" {
 resource "null_resource" "wait_for_cluster" {
   count = var.skip_provisioners ? 0 : 1
 
+  triggers = {
+    project_id = var.project_id
+    name       = var.name
+  }
+
   provisioner "local-exec" {
-    command = "${path.module}/scripts/wait-for-cluster.sh ${var.project_id} ${var.name}"
+    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
   }
 
   provisioner "local-exec" {
     when    = destroy
-    command = "${path.module}/scripts/wait-for-cluster.sh ${var.project_id} ${var.name}"
+    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
   }
 
   depends_on = [

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -313,13 +313,18 @@ resource "google_container_node_pool" "pools" {
 resource "null_resource" "wait_for_cluster" {
   count = var.skip_provisioners ? 0 : 1
 
+  triggers = {
+    project_id = var.project_id
+    name       = var.name
+  }
+
   provisioner "local-exec" {
-    command = "${path.module}/scripts/wait-for-cluster.sh ${var.project_id} ${var.name}"
+    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
   }
 
   provisioner "local-exec" {
     when    = destroy
-    command = "${path.module}/scripts/wait-for-cluster.sh ${var.project_id} ${var.name}"
+    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
   }
 
   depends_on = [

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -240,13 +240,18 @@ resource "google_container_node_pool" "pools" {
 resource "null_resource" "wait_for_cluster" {
   count = var.skip_provisioners ? 0 : 1
 
+  triggers = {
+    project_id = var.project_id
+    name       = var.name
+  }
+
   provisioner "local-exec" {
-    command = "${path.module}/scripts/wait-for-cluster.sh ${var.project_id} ${var.name}"
+    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
   }
 
   provisioner "local-exec" {
     when    = destroy
-    command = "${path.module}/scripts/wait-for-cluster.sh ${var.project_id} ${var.name}"
+    command = "${path.module}/scripts/wait-for-cluster.sh ${self.triggers.project_id} ${self.triggers.name}"
   }
 
   depends_on = [


### PR DESCRIPTION
Fixes https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/405

I've used the solution proposed by @apparentlymart in 
https://discuss.hashicorp.com/t/how-to-rewrite-null-resource-with-local-exec-provisioner-when-destroy-to-prepare-for-deprecation-after-0-12-8/4580