### PR TITLE
Make workload identity k8s SA configurable

### DIFF
--- a/modules/workload-identity/output.tf
+++ b/modules/workload-identity/output.tf
@@ -26,7 +26,7 @@ output "k8s_service_account_namespace" {
 
 output "gcp_service_account_email" {
   description = "Email address of GCP service account."
-  value       = google_service_account.cluster_service_account.email
+  value       = local.gcp_sa_email
 }
 
 output "gcp_service_account_fqn" {

--- a/modules/workload-identity/variables.tf
+++ b/modules/workload-identity/variables.tf
@@ -19,6 +19,12 @@ variable "name" {
   type        = string
 }
 
+variable "k8s_sa_name" {
+  description = "Name for the existing Kubernetes service account"
+  type        = string
+  default     = null
+}
+
 variable "namespace" {
   description = "Namespace for k8s service account"
   default     = "default"


### PR DESCRIPTION
In some cases, we want to attach workload identity to an existing Kubernetes Service Account. This updates the module to handle that case.