### PR TITLE
Remove unused variable `service_account` in safer-cluster to avoid confusion

### DIFF
--- a/autogen/safer-cluster/variables.tf.tmpl
+++ b/autogen/safer-cluster/variables.tf.tmpl
@@ -214,12 +214,6 @@ variable "registry_project_id" {
   default     = ""
 }
 
-variable "service_account" {
-  type        = string
-  description = "The service account to run nodes as if not overridden in `node_pools`. The create_service_account variable default value (true) will cause a cluster-specific service account to be created."
-  default     = ""
-}
-
 variable "cluster_resource_labels" {
   type        = map(string)
   description = "The GCE resource labels (a map of key/value pairs) to be applied to the cluster"

--- a/modules/safer-cluster-update-variant/README.md
+++ b/modules/safer-cluster-update-variant/README.md
@@ -241,7 +241,6 @@ For simplicity, we suggest using `roles/container.admin` and
 | registry\_project\_id | Project holding the Google Container Registry. If empty, we use the cluster project. If grant_registry_access is true, storage.objectViewer role is assigned on this project. | string | `""` | no |
 | resource\_usage\_export\_dataset\_id | The dataset id for which network egress metering for this cluster will be enabled. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | string | `""` | no |
 | sandbox\_enabled | (Beta) Enable GKE Sandbox (Do not forget to set `image_type` = `COS_CONTAINERD` and `node_version` = `1.12.7-gke.17` or later to use it). | bool | `"false"` | no |
-| service\_account | The service account to run nodes as if not overridden in `node_pools`. The create_service_account variable default value (true) will cause a cluster-specific service account to be created. | string | `""` | no |
 | skip\_provisioners | Flag to skip all local-exec provisioners. It breaks `stub_domains` and `upstream_nameservers` variables functionality. | bool | `"false"` | no |
 | stub\_domains | Map of stub domains and their resolvers to forward DNS queries for a certain domain to an external DNS server | map(list(string)) | `<map>` | no |
 | subnetwork | The subnetwork to host the cluster in | string | n/a | yes |

--- a/modules/safer-cluster-update-variant/variables.tf
+++ b/modules/safer-cluster-update-variant/variables.tf
@@ -214,12 +214,6 @@ variable "registry_project_id" {
   default     = ""
 }
 
-variable "service_account" {
-  type        = string
-  description = "The service account to run nodes as if not overridden in `node_pools`. The create_service_account variable default value (true) will cause a cluster-specific service account to be created."
-  default     = ""
-}
-
 variable "cluster_resource_labels" {
   type        = map(string)
   description = "The GCE resource labels (a map of key/value pairs) to be applied to the cluster"

--- a/modules/safer-cluster/README.md
+++ b/modules/safer-cluster/README.md
@@ -241,7 +241,6 @@ For simplicity, we suggest using `roles/container.admin` and
 | registry\_project\_id | Project holding the Google Container Registry. If empty, we use the cluster project. If grant_registry_access is true, storage.objectViewer role is assigned on this project. | string | `""` | no |
 | resource\_usage\_export\_dataset\_id | The dataset id for which network egress metering for this cluster will be enabled. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | string | `""` | no |
 | sandbox\_enabled | (Beta) Enable GKE Sandbox (Do not forget to set `image_type` = `COS_CONTAINERD` and `node_version` = `1.12.7-gke.17` or later to use it). | bool | `"false"` | no |
-| service\_account | The service account to run nodes as if not overridden in `node_pools`. The create_service_account variable default value (true) will cause a cluster-specific service account to be created. | string | `""` | no |
 | skip\_provisioners | Flag to skip all local-exec provisioners. It breaks `stub_domains` and `upstream_nameservers` variables functionality. | bool | `"false"` | no |
 | stub\_domains | Map of stub domains and their resolvers to forward DNS queries for a certain domain to an external DNS server | map(list(string)) | `<map>` | no |
 | subnetwork | The subnetwork to host the cluster in | string | n/a | yes |

--- a/modules/safer-cluster/variables.tf
+++ b/modules/safer-cluster/variables.tf
@@ -214,12 +214,6 @@ variable "registry_project_id" {
   default     = ""
 }
 
-variable "service_account" {
-  type        = string
-  description = "The service account to run nodes as if not overridden in `node_pools`. The create_service_account variable default value (true) will cause a cluster-specific service account to be created."
-  default     = ""
-}
-
 variable "cluster_resource_labels" {
   type        = map(string)
   description = "The GCE resource labels (a map of key/value pairs) to be applied to the cluster"


### PR DESCRIPTION
**TL;DR: Remove unused variable `service_account` in module `safer-cluster` to avoid confusion**

I found the document of `safer-cluster` a little bit confusing because there are two similar variables about worker nodes' service account:

1. `compute_engine_service_account`
2. `service_account`

After digging into the source code, I found the var `service_account` is unused but is the **same word** used in `main` module.

I think the former one is better understood so I remove the unused one to avoid confusion, even it's the same as the one used in `main`.