### PR TITLE
update and pin kubernetes provider to >= 1.11.1

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = ">= 1.11.1"
+  version                = "~> 1.10.0, ~> 1.11.1"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/auth.tf
+++ b/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10.0"
+  version                = ">= 1.11.1"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/auth.tf
+++ b/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10.0, ~> 1.11.1"
+  version                = "!= 1.11.0, < 2.0.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/auth.tf
+++ b/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "!= 1.11.0, < 2.0.0"
+  version                = "~> 1.10, != 1.11.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/autogen/main/auth.tf.tmpl
+++ b/autogen/main/auth.tf.tmpl
@@ -31,7 +31,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10.0"
+  version                = ">= 1.11.1"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/autogen/main/auth.tf.tmpl
+++ b/autogen/main/auth.tf.tmpl
@@ -31,7 +31,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "!= 1.11.0, < 2.0.0"
+  version                = "~> 1.10, != 1.11.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/autogen/main/auth.tf.tmpl
+++ b/autogen/main/auth.tf.tmpl
@@ -31,7 +31,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = ">= 1.11.1"
+  version                = "~> 1.10.0, ~> 1.11.1"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/autogen/main/auth.tf.tmpl
+++ b/autogen/main/auth.tf.tmpl
@@ -31,7 +31,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10.0, ~> 1.11.1"
+  version                = "!= 1.11.0, < 2.0.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/examples/workload_identity/main.tf
+++ b/examples/workload_identity/main.tf
@@ -24,7 +24,7 @@ provider "google" {
 }
 
 provider "kubernetes" {
-  version                = "~> 1.10"
+  version                = "~> 1.10, != 1.11.0"
   host                   = module.gke.endpoint
   token                  = data.google_client_config.default.access_token
   cluster_ca_certificate = base64decode(module.gke.ca_certificate)

--- a/modules/beta-private-cluster-update-variant/auth.tf
+++ b/modules/beta-private-cluster-update-variant/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = ">= 1.11.1"
+  version                = "~> 1.10.0, ~> 1.11.1"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/beta-private-cluster-update-variant/auth.tf
+++ b/modules/beta-private-cluster-update-variant/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10.0"
+  version                = ">= 1.11.1"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/beta-private-cluster-update-variant/auth.tf
+++ b/modules/beta-private-cluster-update-variant/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10.0, ~> 1.11.1"
+  version                = "!= 1.11.0, < 2.0.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/beta-private-cluster-update-variant/auth.tf
+++ b/modules/beta-private-cluster-update-variant/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "!= 1.11.0, < 2.0.0"
+  version                = "~> 1.10, != 1.11.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/beta-private-cluster/auth.tf
+++ b/modules/beta-private-cluster/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = ">= 1.11.1"
+  version                = "~> 1.10.0, ~> 1.11.1"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/beta-private-cluster/auth.tf
+++ b/modules/beta-private-cluster/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10.0"
+  version                = ">= 1.11.1"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/beta-private-cluster/auth.tf
+++ b/modules/beta-private-cluster/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10.0, ~> 1.11.1"
+  version                = "!= 1.11.0, < 2.0.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/beta-private-cluster/auth.tf
+++ b/modules/beta-private-cluster/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "!= 1.11.0, < 2.0.0"
+  version                = "~> 1.10, != 1.11.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/beta-public-cluster/auth.tf
+++ b/modules/beta-public-cluster/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = ">= 1.11.1"
+  version                = "~> 1.10.0, ~> 1.11.1"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/beta-public-cluster/auth.tf
+++ b/modules/beta-public-cluster/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10.0"
+  version                = ">= 1.11.1"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/beta-public-cluster/auth.tf
+++ b/modules/beta-public-cluster/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10.0, ~> 1.11.1"
+  version                = "!= 1.11.0, < 2.0.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/beta-public-cluster/auth.tf
+++ b/modules/beta-public-cluster/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "!= 1.11.0, < 2.0.0"
+  version                = "~> 1.10, != 1.11.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/private-cluster-update-variant/auth.tf
+++ b/modules/private-cluster-update-variant/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = ">= 1.11.1"
+  version                = "~> 1.10.0, ~> 1.11.1"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/private-cluster-update-variant/auth.tf
+++ b/modules/private-cluster-update-variant/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10.0"
+  version                = ">= 1.11.1"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/private-cluster-update-variant/auth.tf
+++ b/modules/private-cluster-update-variant/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10.0, ~> 1.11.1"
+  version                = "!= 1.11.0, < 2.0.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/private-cluster-update-variant/auth.tf
+++ b/modules/private-cluster-update-variant/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "!= 1.11.0, < 2.0.0"
+  version                = "~> 1.10, != 1.11.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/private-cluster/auth.tf
+++ b/modules/private-cluster/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = ">= 1.11.1"
+  version                = "~> 1.10.0, ~> 1.11.1"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/private-cluster/auth.tf
+++ b/modules/private-cluster/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10.0"
+  version                = ">= 1.11.1"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/private-cluster/auth.tf
+++ b/modules/private-cluster/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10.0, ~> 1.11.1"
+  version                = "!= 1.11.0, < 2.0.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/private-cluster/auth.tf
+++ b/modules/private-cluster/auth.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "!= 1.11.0, < 2.0.0"
+  version                = "~> 1.10, != 1.11.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token


### PR DESCRIPTION
Re-visting #429, the upstream issue has been resolved with 1.11.1 (terraform-providers/terraform-provider-kubernetes#759). This update sets the kubernetes provider version at or greater than the problematic version 1.11.0

Advancing to 1.11.1 also addresses terraform-providers/terraform-provider-kubernetes/issues/787 which was broken in kubernetes 1.10 and 1.11 and prevented running Terraform in a pod, ie Atlantis.


