### PR TITLE
Remove `node_pools_taints` from module example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,18 +77,6 @@ module "gke" {
     }
   }
 
-  node_pools_taints = {
-    all = []
-
-    default-node-pool = [
-      {
-        key    = "default-node-pool"
-        value  = true
-        effect = "PREFER_NO_SCHEDULE"
-      },
-    ]
-  }
-
   node_pools_tags = {
     all = []
 


### PR DESCRIPTION
The `node_pools_taints` variable is no longer supported in this module. This pull request simply removes it from the README's example usage.