### PR TITLE
Firewall support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| add\_cluster\_firewall\_rules | Create additional firewall rules | bool | `"true"` | no |
+| add\_cluster\_firewall\_rules | Create additional firewall rules | bool | `"false"` | no |
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |
 | cluster\_ipv4\_cidr | The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR. | string | `"null"` | no |

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| add\_cluster\_firewall\_rules | Create additional firewall rules | bool | `"true"` | no |
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |
 | cluster\_ipv4\_cidr | The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR. | string | `"null"` | no |
@@ -109,7 +110,6 @@ Then perform the following commands on the root folder:
 | default\_max\_pods\_per\_node | The maximum number of pods to schedule per node | string | `"110"` | no |
 | description | The description of the cluster | string | `""` | no |
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | bool | `"true"` | no |
-| firewall\_enabled | Create additional firewall rules | bool | `"true"` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
@@ -223,7 +223,7 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 In order to execute this module you must have a Service Account with the
 following project roles:
 - roles/compute.viewer
-- roles/compute.securityAdmin
+- roles/compute.securityAdmin (only required if `add_cluster_firewall_rules` is set to `true`)
 - roles/container.clusterAdmin
 - roles/container.developer
 - roles/iam.serviceAccountAdmin

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Then perform the following commands on the root folder:
 | default\_max\_pods\_per\_node | The maximum number of pods to schedule per node | string | `"110"` | no |
 | description | The description of the cluster | string | `""` | no |
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | bool | `"true"` | no |
+| firewall\_enabled | Create additional firewall rules | bool | `"true"` | no |
+| firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
+| firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | bool | `"true"` | no |
 | http\_load\_balancing | Enable httpload balancer addon | bool | `"true"` | no |
@@ -220,6 +223,7 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 In order to execute this module you must have a Service Account with the
 following project roles:
 - roles/compute.viewer
+- roles/compute.securityAdmin
 - roles/container.clusterAdmin
 - roles/container.developer
 - roles/iam.serviceAccountAdmin

--- a/autogen/main/README.md
+++ b/autogen/main/README.md
@@ -240,7 +240,7 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 In order to execute this module you must have a Service Account with the
 following project roles:
 - roles/compute.viewer
-- roles/compute.securityAdmin
+- roles/compute.securityAdmin (only required if `add_cluster_firewall_rules` is set to `true`)
 - roles/container.clusterAdmin
 - roles/container.developer
 - roles/iam.serviceAccountAdmin

--- a/autogen/main/README.md
+++ b/autogen/main/README.md
@@ -240,6 +240,7 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 In order to execute this module you must have a Service Account with the
 following project roles:
 - roles/compute.viewer
+- roles/compute.securityAdmin
 - roles/container.clusterAdmin
 - roles/container.developer
 - roles/iam.serviceAccountAdmin

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -82,6 +82,7 @@ resource "google_container_cluster" "primary" {
 {% endif %}
 
   default_max_pods_per_node = var.default_max_pods_per_node
+
 {% if beta_cluster %}
   enable_binary_authorization = var.enable_binary_authorization
   enable_intranode_visibility = var.enable_intranode_visibility
@@ -159,7 +160,7 @@ resource "google_container_cluster" "primary" {
     }
 
     dns_cache_config {
-      enabled   = var.dns_cache
+      enabled = var.dns_cache
     }
     {% endif %}
   }
@@ -171,16 +172,16 @@ resource "google_container_cluster" "primary" {
 
   maintenance_policy {
   {% if beta_cluster %}
-    dynamic "recurring_window"{
+    dynamic "recurring_window" {
       for_each = local.cluster_maintenance_window_is_recurring
       content {
         start_time = var.maintenance_start_time
-        end_time = var.maintenance_end_time
+        end_time   = var.maintenance_end_time
         recurrence = var.maintenance_recurrence
       }
     }
 
-    dynamic "daily_maintenance_window"{
+    dynamic "daily_maintenance_window" {
       for_each = local.cluster_maintenance_window_is_daily
       content {
         start_time = var.maintenance_start_time
@@ -352,7 +353,7 @@ resource "google_container_node_pool" "pools" {
   {% endif %}
   for_each = local.node_pools
   {% if update_variant %}
-  name     = {for k, v in random_id.name : k => v.hex}[each.key]
+  name     = { for k, v in random_id.name : k => v.hex }[each.key]
   {% else %}
   name     = each.key
   {% endif %}
@@ -396,7 +397,7 @@ resource "google_container_node_pool" "pools" {
 
   {% if beta_cluster %}
   upgrade_settings {
-    max_surge = lookup(each.value, "max_surge", 1)
+    max_surge       = lookup(each.value, "max_surge", 1)
     max_unavailable = lookup(each.value, "max_unavailable", 0)
   }
   {% endif %}
@@ -433,8 +434,8 @@ resource "google_container_node_pool" "pools" {
     }
     {% endif %}
     tags = concat(
-      lookup(local.node_pools_tags, "default_values", [true, true])[0] ? ["gke-${var.name}"] : [],
-      lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["gke-${var.name}-${each.value["name"]}"] : [],
+      lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
+      lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-${each.value["name"]}"] : [],
       local.node_pools_tags["all"],
       local.node_pools_tags[each.value["name"]],
     )

--- a/autogen/main/firewall.tf.tmpl
+++ b/autogen/main/firewall.tf.tmpl
@@ -25,7 +25,7 @@
   a default-deny egress rule
  *****************************************/
 resource "google_compute_firewall" "intra_egress" {
-  count       = var.firewall_enabled ? 1 : 0
+  count       = var.add_cluster_firewall_rules ? 1 : 0
   name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
@@ -61,7 +61,7 @@ resource "google_compute_firewall" "intra_egress" {
   https://github.com/kubernetes/kubernetes/issues/79739
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
-  count       = var.firewall_enabled ? 1 : 0
+  count       = var.add_cluster_firewall_rules ? 1 : 0
   name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id

--- a/autogen/main/firewall.tf.tmpl
+++ b/autogen/main/firewall.tf.tmpl
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{{ autogeneration_note }}
+
+
+/******************************************
+  Match the gke-<CLUSTER>-<ID>-all INGRESS
+  firewall rule created by GKE but for EGRESS
+
+  Required for clusters when VPCs enforce
+  a default-deny egress rule
+ *****************************************/
+resource "google_compute_firewall" "intra_egress" {
+  count       = var.firewall_enabled ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
+  description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "EGRESS"
+
+  target_tags = [local.cluster_network_tag]
+  destination_ranges = [
+    local.cluster_endpoint_for_nodes,
+    local.cluster_subnet_cidr,
+    local.cluster_alias_ranges_cidr[var.ip_range_pods],
+  ]
+
+  # Allow all possible protocols
+  allow { protocol = "tcp" }
+  allow { protocol = "udp" }
+  allow { protocol = "icmp" }
+  allow { protocol = "sctp" }
+  allow { protocol = "esp" }
+  allow { protocol = "ah" }
+
+  depends_on = [
+    google_container_cluster.primary,
+  ]
+}
+
+
+/******************************************
+  Allow GKE master to hit non 443 ports for
+  Webhooks/Admission Controllers
+
+  https://github.com/kubernetes/kubernetes/issues/79739
+ *****************************************/
+resource "google_compute_firewall" "master_webhooks" {
+  count       = var.firewall_enabled ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
+  description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "INGRESS"
+
+  source_ranges = [local.cluster_endpoint_for_nodes]
+  target_tags   = [local.cluster_network_tag]
+
+  allow {
+    protocol = "tcp"
+    ports    = var.firewall_inbound_ports
+  }
+
+  depends_on = [
+    google_container_cluster.primary,
+  ]
+
+}

--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -77,8 +77,8 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
-  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.ip_cidr_range
-  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.*.ip_cidr_range
+  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.*.secondary_ip_range) : range.range_name => range.ip_cidr_range }
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -54,17 +54,17 @@ locals {
   node_pools      = zipmap(local.node_pool_names, tolist(toset(var.node_pools)))
 
 {% if beta_cluster %}
-  release_channel         = var.release_channel != null ? [{ channel : var.release_channel }] : []
+  release_channel = var.release_channel != null ? [{ channel : var.release_channel }] : []
 
   autoscalling_resource_limits = var.cluster_autoscaling.enabled ? [{
-      resource_type = "cpu"
-      minimum       = var.cluster_autoscaling.min_cpu_cores
-      maximum       = var.cluster_autoscaling.max_cpu_cores
+    resource_type = "cpu"
+    minimum       = var.cluster_autoscaling.min_cpu_cores
+    maximum       = var.cluster_autoscaling.max_cpu_cores
     }, {
-      resource_type = "memory"
-      minimum       = var.cluster_autoscaling.min_memory_gb
-      maximum       = var.cluster_autoscaling.max_memory_gb
-    }] : []
+    resource_type = "memory"
+    minimum       = var.cluster_autoscaling.min_memory_gb
+    maximum       = var.cluster_autoscaling.max_memory_gb
+  }] : []
 
 {% endif %}
 
@@ -76,6 +76,9 @@ locals {
   cluster_type                = var.regional ? "regional" : "zonal"
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
+
+  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.ip_cidr_range
+  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.secondary_ip_range) : range.range_name => range.ip_cidr_range }
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true
@@ -106,10 +109,12 @@ locals {
   cluster_output_zones          = local.cluster_output_regional_zones
 
 {% if private_cluster %}
-  cluster_endpoint     = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
-  cluster_peering_name = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? google_container_cluster.primary.private_cluster_config.0.peering_name : null
+  cluster_endpoint           = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
+  cluster_peering_name       = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? google_container_cluster.primary.private_cluster_config.0.peering_name : null
+  cluster_endpoint_for_nodes = var.master_ipv4_cidr_block
 {% else %}
-  cluster_endpoint = google_container_cluster.primary.endpoint
+  cluster_endpoint           = google_container_cluster.primary.endpoint
+  cluster_endpoint_for_nodes = "${google_container_cluster.primary.endpoint}/32"
 {% endif %}
 
   cluster_output_master_auth                        = concat(google_container_cluster.primary.*.master_auth, [])
@@ -147,6 +152,7 @@ locals {
   cluster_zones    = sort(local.cluster_output_zones)
 
   cluster_name                               = local.cluster_output_name
+  cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version
   cluster_min_master_version                 = local.cluster_output_min_master_version
@@ -167,14 +173,14 @@ locals {
   cluster_vertical_pod_autoscaling_enabled = local.cluster_output_vertical_pod_autoscaling_enabled
 
   cluster_workload_identity_config = var.identity_namespace == null ? [] : var.identity_namespace == "enabled" ? [{
-  identity_namespace = "${var.project_id}.svc.id.goog"}] : [{identity_namespace = var.identity_namespace
+    identity_namespace = "${var.project_id}.svc.id.goog" }] : [{ identity_namespace = var.identity_namespace
   }]
   # /BETA features
 {% endif %}
 
 {% if beta_cluster %}
   cluster_maintenance_window_is_recurring = var.maintenance_recurrence != "" && var.maintenance_end_time != "" ? [1] : []
-  cluster_maintenance_window_is_daily = length(local.cluster_maintenance_window_is_recurring) > 0 ? [] : [1]
+  cluster_maintenance_window_is_daily     = length(local.cluster_maintenance_window_is_recurring) > 0 ? [] : [1]
 {% endif %}
 }
 

--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -77,8 +77,8 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
-  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.*.ip_cidr_range
-  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.*.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+  cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
+  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/autogen/main/networks.tf
+++ b/autogen/main/networks.tf
@@ -16,16 +16,10 @@
 
 {{ autogeneration_note }}
 
-data "google_compute_network" "gke_network" {
-  provider = google
-
-  name    = var.network
-  project = local.network_project_id
-}
-
 data "google_compute_subnetwork" "gke_subnetwork" {
   provider = google
 
+  count   = var.add_cluster_firewall_rules ? 1 : 0
   name    = var.subnetwork
   region  = local.region
   project = local.network_project_id

--- a/autogen/main/networks.tf
+++ b/autogen/main/networks.tf
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{{ autogeneration_note }}
+
+data "google_compute_network" "gke_network" {
+  provider = google
+
+  name    = var.network
+  project = local.network_project_id
+}
+
+data "google_compute_subnetwork" "gke_subnetwork" {
+  provider = google
+
+  name    = var.subnetwork
+  region  = local.region
+  project = local.network_project_id
+}

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -426,7 +426,7 @@ variable "enable_binary_authorization" {
 }
 
 variable "pod_security_policy_config" {
-  type = list(object({ enabled = bool }))
+  type        = list(object({ enabled = bool }))
   description = "enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created."
 
   default = [{
@@ -488,3 +488,22 @@ variable "enable_shielded_nodes" {
   default     = true
 }
 {% endif %}
+
+
+variable "firewall_enabled" {
+  type        = bool
+  description = "Create additional firewall rules"
+  default     = true
+}
+
+variable "firewall_priority" {
+  type        = number
+  description = "Priority rule for firewall rules"
+  default     = 1000
+}
+
+variable "firewall_inbound_ports" {
+  type        = list(string)
+  description = "List of TCP ports for admission/webhook controllers"
+  default     = ["8443", "9443", "15017"]
+}

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -493,7 +493,7 @@ variable "enable_shielded_nodes" {
 variable "add_cluster_firewall_rules" {
   type        = bool
   description = "Create additional firewall rules"
-  default     = true
+  default     = false
 }
 
 variable "firewall_priority" {

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -490,7 +490,7 @@ variable "enable_shielded_nodes" {
 {% endif %}
 
 
-variable "firewall_enabled" {
+variable "add_cluster_firewall_rules" {
   type        = bool
   description = "Create additional firewall rules"
   default     = true

--- a/autogen/safer-cluster/variables.tf.tmpl
+++ b/autogen/safer-cluster/variables.tf.tmpl
@@ -317,7 +317,7 @@ variable "skip_provisioners" {
 }
 
 variable "pod_security_policy_config" {
-  type = list(object({ enabled = bool }))
+  type        = list(object({ enabled = bool }))
   description = "enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created."
 
   default = [{

--- a/cluster.tf
+++ b/cluster.tf
@@ -51,6 +51,7 @@ resource "google_container_cluster" "primary" {
 
 
   default_max_pods_per_node = var.default_max_pods_per_node
+
   dynamic "master_authorized_networks_config" {
     for_each = local.master_authorized_networks_config
     content {
@@ -182,8 +183,8 @@ resource "google_container_node_pool" "pools" {
       },
     )
     tags = concat(
-      lookup(local.node_pools_tags, "default_values", [true, true])[0] ? ["gke-${var.name}"] : [],
-      lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["gke-${var.name}-${each.value["name"]}"] : [],
+      lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
+      lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-${each.value["name"]}"] : [],
       local.node_pools_tags["all"],
       local.node_pools_tags[each.value["name"]],
     )

--- a/examples/private_zonal_with_networking/main.tf
+++ b/examples/private_zonal_with_networking/main.tf
@@ -58,7 +58,7 @@ module "gke" {
   region     = var.region
   zones      = slice(var.zones, 0, 1)
 
-  network                 = module.gcp-network.network_named
+  network                 = module.gcp-network.network_name
   subnetwork              = module.gcp-network.subnets_names[0]
   ip_range_pods           = var.ip_range_pods_name
   ip_range_services       = var.ip_range_services_name

--- a/examples/private_zonal_with_networking/main.tf
+++ b/examples/private_zonal_with_networking/main.tf
@@ -58,12 +58,8 @@ module "gke" {
   region     = var.region
   zones      = slice(var.zones, 0, 1)
 
-  // This craziness gets a plain network name from the reference link which is the
-  // only way to force cluster creation to wait on network creation without a
-  // depends_on link.  Tests use terraform 0.12.6, which does not have regex or regexall
-  network = reverse(split("/", data.google_compute_subnetwork.subnetwork.network))[0]
-
-  subnetwork              = data.google_compute_subnetwork.subnetwork.name
+  network                 = module.gcp-network.network_named
+  subnetwork              = module.gcp-network.subnets_names[0]
   ip_range_pods           = var.ip_range_pods_name
   ip_range_services       = var.ip_range_services_name
   create_service_account  = true

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -24,17 +24,19 @@ provider "google" {
 }
 
 module "gke" {
-  source                 = "../../"
-  project_id             = var.project_id
-  name                   = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
-  region                 = var.region
-  network                = var.network
-  network_project_id     = var.network_project_id
-  subnetwork             = var.subnetwork
-  ip_range_pods          = var.ip_range_pods
-  ip_range_services      = var.ip_range_services
-  create_service_account = false
-  service_account        = var.compute_engine_service_account
+  source                     = "../../"
+  project_id                 = var.project_id
+  name                       = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
+  region                     = var.region
+  network                    = var.network
+  network_project_id         = var.network_project_id
+  subnetwork                 = var.subnetwork
+  ip_range_pods              = var.ip_range_pods
+  ip_range_services          = var.ip_range_services
+  create_service_account     = false
+  service_account            = var.compute_engine_service_account
+  add_cluster_firewall_rules = true
+  firewall_inbound_ports     = ["9443", "15017"]
 }
 
 data "google_client_config" "default" {

--- a/firewall.tf
+++ b/firewall.tf
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was automatically generated from a template in ./autogen/main
+
+
+/******************************************
+  Match the gke-<CLUSTER>-<ID>-all INGRESS
+  firewall rule created by GKE but for EGRESS
+
+  Required for clusters when VPCs enforce
+  a default-deny egress rule
+ *****************************************/
+resource "google_compute_firewall" "intra_egress" {
+  count       = var.firewall_enabled ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
+  description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "EGRESS"
+
+  target_tags = [local.cluster_network_tag]
+  destination_ranges = [
+    local.cluster_endpoint_for_nodes,
+    local.cluster_subnet_cidr,
+    local.cluster_alias_ranges_cidr[var.ip_range_pods],
+  ]
+
+  # Allow all possible protocols
+  allow { protocol = "tcp" }
+  allow { protocol = "udp" }
+  allow { protocol = "icmp" }
+  allow { protocol = "sctp" }
+  allow { protocol = "esp" }
+  allow { protocol = "ah" }
+
+  depends_on = [
+    google_container_cluster.primary,
+  ]
+}
+
+
+/******************************************
+  Allow GKE master to hit non 443 ports for
+  Webhooks/Admission Controllers
+
+  https://github.com/kubernetes/kubernetes/issues/79739
+ *****************************************/
+resource "google_compute_firewall" "master_webhooks" {
+  count       = var.firewall_enabled ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
+  description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "INGRESS"
+
+  source_ranges = [local.cluster_endpoint_for_nodes]
+  target_tags   = [local.cluster_network_tag]
+
+  allow {
+    protocol = "tcp"
+    ports    = var.firewall_inbound_ports
+  }
+
+  depends_on = [
+    google_container_cluster.primary,
+  ]
+
+}

--- a/firewall.tf
+++ b/firewall.tf
@@ -25,7 +25,7 @@
   a default-deny egress rule
  *****************************************/
 resource "google_compute_firewall" "intra_egress" {
-  count       = var.firewall_enabled ? 1 : 0
+  count       = var.add_cluster_firewall_rules ? 1 : 0
   name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
@@ -61,7 +61,7 @@ resource "google_compute_firewall" "intra_egress" {
   https://github.com/kubernetes/kubernetes/issues/79739
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
-  count       = var.firewall_enabled ? 1 : 0
+  count       = var.add_cluster_firewall_rules ? 1 : 0
   name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id

--- a/main.tf
+++ b/main.tf
@@ -59,8 +59,8 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
-  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.ip_cidr_range
-  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.*.ip_cidr_range
+  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.*.secondary_ip_range) : range.range_name => range.ip_cidr_range }
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/main.tf
+++ b/main.tf
@@ -59,8 +59,8 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
-  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.*.ip_cidr_range
-  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.*.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+  cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
+  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,9 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
+  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.ip_cidr_range
+  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+
   cluster_network_policy = var.network_policy ? [{
     enabled  = true
     provider = var.network_policy_provider
@@ -73,7 +76,8 @@ locals {
   cluster_output_zonal_zones    = local.zone_count > 1 ? slice(var.zones, 1, local.zone_count) : []
   cluster_output_zones          = local.cluster_output_regional_zones
 
-  cluster_endpoint = google_container_cluster.primary.endpoint
+  cluster_endpoint           = google_container_cluster.primary.endpoint
+  cluster_endpoint_for_nodes = "${google_container_cluster.primary.endpoint}/32"
 
   cluster_output_master_auth                        = concat(google_container_cluster.primary.*.master_auth, [])
   cluster_output_master_version                     = google_container_cluster.primary.master_version
@@ -101,6 +105,7 @@ locals {
   cluster_zones    = sort(local.cluster_output_zones)
 
   cluster_name                               = local.cluster_output_name
+  cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version
   cluster_min_master_version                 = local.cluster_output_min_master_version

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -178,6 +178,9 @@ Then perform the following commands on the root folder:
 | enable\_private\_nodes | (Beta) Whether nodes have internal IP addresses only | bool | `"false"` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | bool | `"true"` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | bool | `"false"` | no |
+| firewall\_enabled | Create additional firewall rules | bool | `"true"` | no |
+| firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
+| firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | bool | `"true"` | no |
 | http\_load\_balancing | Enable httpload balancer addon | bool | `"true"` | no |
@@ -320,6 +323,7 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 In order to execute this module you must have a Service Account with the
 following project roles:
 - roles/compute.viewer
+- roles/compute.securityAdmin
 - roles/container.clusterAdmin
 - roles/container.developer
 - roles/iam.serviceAccountAdmin

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -156,7 +156,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| add\_cluster\_firewall\_rules | Create additional firewall rules | bool | `"true"` | no |
+| add\_cluster\_firewall\_rules | Create additional firewall rules | bool | `"false"` | no |
 | authenticator\_security\_group | The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com | string | `"null"` | no |
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -156,6 +156,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| add\_cluster\_firewall\_rules | Create additional firewall rules | bool | `"true"` | no |
 | authenticator\_security\_group | The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com | string | `"null"` | no |
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |
@@ -178,7 +179,6 @@ Then perform the following commands on the root folder:
 | enable\_private\_nodes | (Beta) Whether nodes have internal IP addresses only | bool | `"false"` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | bool | `"true"` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | bool | `"false"` | no |
-| firewall\_enabled | Create additional firewall rules | bool | `"true"` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
@@ -323,7 +323,7 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 In order to execute this module you must have a Service Account with the
 following project roles:
 - roles/compute.viewer
-- roles/compute.securityAdmin
+- roles/compute.securityAdmin (only required if `add_cluster_firewall_rules` is set to `true`)
 - roles/container.clusterAdmin
 - roles/container.developer
 - roles/iam.serviceAccountAdmin

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -69,7 +69,8 @@ resource "google_container_cluster" "primary" {
     }
   }
 
-  default_max_pods_per_node   = var.default_max_pods_per_node
+  default_max_pods_per_node = var.default_max_pods_per_node
+
   enable_binary_authorization = var.enable_binary_authorization
   enable_intranode_visibility = var.enable_intranode_visibility
   enable_shielded_nodes       = var.enable_shielded_nodes
@@ -389,8 +390,8 @@ resource "google_container_node_pool" "pools" {
       }
     }
     tags = concat(
-      lookup(local.node_pools_tags, "default_values", [true, true])[0] ? ["gke-${var.name}"] : [],
-      lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["gke-${var.name}-${each.value["name"]}"] : [],
+      lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
+      lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-${each.value["name"]}"] : [],
       local.node_pools_tags["all"],
       local.node_pools_tags[each.value["name"]],
     )

--- a/modules/beta-private-cluster-update-variant/firewall.tf
+++ b/modules/beta-private-cluster-update-variant/firewall.tf
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was automatically generated from a template in ./autogen/main
+
+
+/******************************************
+  Match the gke-<CLUSTER>-<ID>-all INGRESS
+  firewall rule created by GKE but for EGRESS
+
+  Required for clusters when VPCs enforce
+  a default-deny egress rule
+ *****************************************/
+resource "google_compute_firewall" "intra_egress" {
+  count       = var.firewall_enabled ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
+  description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "EGRESS"
+
+  target_tags = [local.cluster_network_tag]
+  destination_ranges = [
+    local.cluster_endpoint_for_nodes,
+    local.cluster_subnet_cidr,
+    local.cluster_alias_ranges_cidr[var.ip_range_pods],
+  ]
+
+  # Allow all possible protocols
+  allow { protocol = "tcp" }
+  allow { protocol = "udp" }
+  allow { protocol = "icmp" }
+  allow { protocol = "sctp" }
+  allow { protocol = "esp" }
+  allow { protocol = "ah" }
+
+  depends_on = [
+    google_container_cluster.primary,
+  ]
+}
+
+
+/******************************************
+  Allow GKE master to hit non 443 ports for
+  Webhooks/Admission Controllers
+
+  https://github.com/kubernetes/kubernetes/issues/79739
+ *****************************************/
+resource "google_compute_firewall" "master_webhooks" {
+  count       = var.firewall_enabled ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
+  description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "INGRESS"
+
+  source_ranges = [local.cluster_endpoint_for_nodes]
+  target_tags   = [local.cluster_network_tag]
+
+  allow {
+    protocol = "tcp"
+    ports    = var.firewall_inbound_ports
+  }
+
+  depends_on = [
+    google_container_cluster.primary,
+  ]
+
+}

--- a/modules/beta-private-cluster-update-variant/firewall.tf
+++ b/modules/beta-private-cluster-update-variant/firewall.tf
@@ -25,7 +25,7 @@
   a default-deny egress rule
  *****************************************/
 resource "google_compute_firewall" "intra_egress" {
-  count       = var.firewall_enabled ? 1 : 0
+  count       = var.add_cluster_firewall_rules ? 1 : 0
   name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
@@ -61,7 +61,7 @@ resource "google_compute_firewall" "intra_egress" {
   https://github.com/kubernetes/kubernetes/issues/79739
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
-  count       = var.firewall_enabled ? 1 : 0
+  count       = var.add_cluster_firewall_rules ? 1 : 0
   name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -71,8 +71,8 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
-  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.ip_cidr_range
-  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.*.ip_cidr_range
+  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.*.secondary_ip_range) : range.range_name => range.ip_cidr_range }
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -71,6 +71,9 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
+  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.ip_cidr_range
+  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+
   cluster_network_policy = var.network_policy ? [{
     enabled  = true
     provider = var.network_policy_provider
@@ -97,8 +100,9 @@ locals {
   cluster_output_zonal_zones    = local.zone_count > 1 ? slice(var.zones, 1, local.zone_count) : []
   cluster_output_zones          = local.cluster_output_regional_zones
 
-  cluster_endpoint     = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
-  cluster_peering_name = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? google_container_cluster.primary.private_cluster_config.0.peering_name : null
+  cluster_endpoint           = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
+  cluster_peering_name       = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? google_container_cluster.primary.private_cluster_config.0.peering_name : null
+  cluster_endpoint_for_nodes = var.master_ipv4_cidr_block
 
   cluster_output_master_auth                        = concat(google_container_cluster.primary.*.master_auth, [])
   cluster_output_master_version                     = google_container_cluster.primary.master_version
@@ -133,6 +137,7 @@ locals {
   cluster_zones    = sort(local.cluster_output_zones)
 
   cluster_name                               = local.cluster_output_name
+  cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version
   cluster_min_master_version                 = local.cluster_output_min_master_version

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -71,8 +71,8 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
-  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.*.ip_cidr_range
-  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.*.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+  cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
+  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/modules/beta-private-cluster-update-variant/networks.tf
+++ b/modules/beta-private-cluster-update-variant/networks.tf
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was automatically generated from a template in ./autogen/main
+
+data "google_compute_network" "gke_network" {
+  provider = google
+
+  name    = var.network
+  project = local.network_project_id
+}
+
+data "google_compute_subnetwork" "gke_subnetwork" {
+  provider = google
+
+  name    = var.subnetwork
+  region  = local.region
+  project = local.network_project_id
+}

--- a/modules/beta-private-cluster-update-variant/networks.tf
+++ b/modules/beta-private-cluster-update-variant/networks.tf
@@ -16,16 +16,10 @@
 
 // This file was automatically generated from a template in ./autogen/main
 
-data "google_compute_network" "gke_network" {
-  provider = google
-
-  name    = var.network
-  project = local.network_project_id
-}
-
 data "google_compute_subnetwork" "gke_subnetwork" {
   provider = google
 
+  count   = var.add_cluster_firewall_rules ? 1 : 0
   name    = var.subnetwork
   region  = local.region
   project = local.network_project_id

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -480,3 +480,22 @@ variable "enable_shielded_nodes" {
   description = "Enable Shielded Nodes features on all nodes in this cluster"
   default     = true
 }
+
+
+variable "firewall_enabled" {
+  type        = bool
+  description = "Create additional firewall rules"
+  default     = true
+}
+
+variable "firewall_priority" {
+  type        = number
+  description = "Priority rule for firewall rules"
+  default     = 1000
+}
+
+variable "firewall_inbound_ports" {
+  type        = list(string)
+  description = "List of TCP ports for admission/webhook controllers"
+  default     = ["8443", "9443", "15017"]
+}

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -482,7 +482,7 @@ variable "enable_shielded_nodes" {
 }
 
 
-variable "firewall_enabled" {
+variable "add_cluster_firewall_rules" {
   type        = bool
   description = "Create additional firewall rules"
   default     = true

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -485,7 +485,7 @@ variable "enable_shielded_nodes" {
 variable "add_cluster_firewall_rules" {
   type        = bool
   description = "Create additional firewall rules"
-  default     = true
+  default     = false
 }
 
 variable "firewall_priority" {

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -134,6 +134,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| add\_cluster\_firewall\_rules | Create additional firewall rules | bool | `"true"` | no |
 | authenticator\_security\_group | The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com | string | `"null"` | no |
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |
@@ -156,7 +157,6 @@ Then perform the following commands on the root folder:
 | enable\_private\_nodes | (Beta) Whether nodes have internal IP addresses only | bool | `"false"` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | bool | `"true"` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | bool | `"false"` | no |
-| firewall\_enabled | Create additional firewall rules | bool | `"true"` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
@@ -301,7 +301,7 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 In order to execute this module you must have a Service Account with the
 following project roles:
 - roles/compute.viewer
-- roles/compute.securityAdmin
+- roles/compute.securityAdmin (only required if `add_cluster_firewall_rules` is set to `true`)
 - roles/container.clusterAdmin
 - roles/container.developer
 - roles/iam.serviceAccountAdmin

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -134,7 +134,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| add\_cluster\_firewall\_rules | Create additional firewall rules | bool | `"true"` | no |
+| add\_cluster\_firewall\_rules | Create additional firewall rules | bool | `"false"` | no |
 | authenticator\_security\_group | The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com | string | `"null"` | no |
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -156,6 +156,9 @@ Then perform the following commands on the root folder:
 | enable\_private\_nodes | (Beta) Whether nodes have internal IP addresses only | bool | `"false"` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | bool | `"true"` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | bool | `"false"` | no |
+| firewall\_enabled | Create additional firewall rules | bool | `"true"` | no |
+| firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
+| firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | bool | `"true"` | no |
 | http\_load\_balancing | Enable httpload balancer addon | bool | `"true"` | no |
@@ -298,6 +301,7 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 In order to execute this module you must have a Service Account with the
 following project roles:
 - roles/compute.viewer
+- roles/compute.securityAdmin
 - roles/container.clusterAdmin
 - roles/container.developer
 - roles/iam.serviceAccountAdmin

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -69,7 +69,8 @@ resource "google_container_cluster" "primary" {
     }
   }
 
-  default_max_pods_per_node   = var.default_max_pods_per_node
+  default_max_pods_per_node = var.default_max_pods_per_node
+
   enable_binary_authorization = var.enable_binary_authorization
   enable_intranode_visibility = var.enable_intranode_visibility
   enable_shielded_nodes       = var.enable_shielded_nodes
@@ -317,8 +318,8 @@ resource "google_container_node_pool" "pools" {
       }
     }
     tags = concat(
-      lookup(local.node_pools_tags, "default_values", [true, true])[0] ? ["gke-${var.name}"] : [],
-      lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["gke-${var.name}-${each.value["name"]}"] : [],
+      lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
+      lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-${each.value["name"]}"] : [],
       local.node_pools_tags["all"],
       local.node_pools_tags[each.value["name"]],
     )

--- a/modules/beta-private-cluster/firewall.tf
+++ b/modules/beta-private-cluster/firewall.tf
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was automatically generated from a template in ./autogen/main
+
+
+/******************************************
+  Match the gke-<CLUSTER>-<ID>-all INGRESS
+  firewall rule created by GKE but for EGRESS
+
+  Required for clusters when VPCs enforce
+  a default-deny egress rule
+ *****************************************/
+resource "google_compute_firewall" "intra_egress" {
+  count       = var.firewall_enabled ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
+  description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "EGRESS"
+
+  target_tags = [local.cluster_network_tag]
+  destination_ranges = [
+    local.cluster_endpoint_for_nodes,
+    local.cluster_subnet_cidr,
+    local.cluster_alias_ranges_cidr[var.ip_range_pods],
+  ]
+
+  # Allow all possible protocols
+  allow { protocol = "tcp" }
+  allow { protocol = "udp" }
+  allow { protocol = "icmp" }
+  allow { protocol = "sctp" }
+  allow { protocol = "esp" }
+  allow { protocol = "ah" }
+
+  depends_on = [
+    google_container_cluster.primary,
+  ]
+}
+
+
+/******************************************
+  Allow GKE master to hit non 443 ports for
+  Webhooks/Admission Controllers
+
+  https://github.com/kubernetes/kubernetes/issues/79739
+ *****************************************/
+resource "google_compute_firewall" "master_webhooks" {
+  count       = var.firewall_enabled ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
+  description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "INGRESS"
+
+  source_ranges = [local.cluster_endpoint_for_nodes]
+  target_tags   = [local.cluster_network_tag]
+
+  allow {
+    protocol = "tcp"
+    ports    = var.firewall_inbound_ports
+  }
+
+  depends_on = [
+    google_container_cluster.primary,
+  ]
+
+}

--- a/modules/beta-private-cluster/firewall.tf
+++ b/modules/beta-private-cluster/firewall.tf
@@ -25,7 +25,7 @@
   a default-deny egress rule
  *****************************************/
 resource "google_compute_firewall" "intra_egress" {
-  count       = var.firewall_enabled ? 1 : 0
+  count       = var.add_cluster_firewall_rules ? 1 : 0
   name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
@@ -61,7 +61,7 @@ resource "google_compute_firewall" "intra_egress" {
   https://github.com/kubernetes/kubernetes/issues/79739
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
-  count       = var.firewall_enabled ? 1 : 0
+  count       = var.add_cluster_firewall_rules ? 1 : 0
   name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -71,8 +71,8 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
-  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.ip_cidr_range
-  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.*.ip_cidr_range
+  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.*.secondary_ip_range) : range.range_name => range.ip_cidr_range }
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -71,6 +71,9 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
+  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.ip_cidr_range
+  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+
   cluster_network_policy = var.network_policy ? [{
     enabled  = true
     provider = var.network_policy_provider
@@ -97,8 +100,9 @@ locals {
   cluster_output_zonal_zones    = local.zone_count > 1 ? slice(var.zones, 1, local.zone_count) : []
   cluster_output_zones          = local.cluster_output_regional_zones
 
-  cluster_endpoint     = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
-  cluster_peering_name = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? google_container_cluster.primary.private_cluster_config.0.peering_name : null
+  cluster_endpoint           = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
+  cluster_peering_name       = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? google_container_cluster.primary.private_cluster_config.0.peering_name : null
+  cluster_endpoint_for_nodes = var.master_ipv4_cidr_block
 
   cluster_output_master_auth                        = concat(google_container_cluster.primary.*.master_auth, [])
   cluster_output_master_version                     = google_container_cluster.primary.master_version
@@ -133,6 +137,7 @@ locals {
   cluster_zones    = sort(local.cluster_output_zones)
 
   cluster_name                               = local.cluster_output_name
+  cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version
   cluster_min_master_version                 = local.cluster_output_min_master_version

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -71,8 +71,8 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
-  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.*.ip_cidr_range
-  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.*.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+  cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
+  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/modules/beta-private-cluster/networks.tf
+++ b/modules/beta-private-cluster/networks.tf
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was automatically generated from a template in ./autogen/main
+
+data "google_compute_network" "gke_network" {
+  provider = google
+
+  name    = var.network
+  project = local.network_project_id
+}
+
+data "google_compute_subnetwork" "gke_subnetwork" {
+  provider = google
+
+  name    = var.subnetwork
+  region  = local.region
+  project = local.network_project_id
+}

--- a/modules/beta-private-cluster/networks.tf
+++ b/modules/beta-private-cluster/networks.tf
@@ -16,16 +16,10 @@
 
 // This file was automatically generated from a template in ./autogen/main
 
-data "google_compute_network" "gke_network" {
-  provider = google
-
-  name    = var.network
-  project = local.network_project_id
-}
-
 data "google_compute_subnetwork" "gke_subnetwork" {
   provider = google
 
+  count   = var.add_cluster_firewall_rules ? 1 : 0
   name    = var.subnetwork
   region  = local.region
   project = local.network_project_id

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -480,3 +480,22 @@ variable "enable_shielded_nodes" {
   description = "Enable Shielded Nodes features on all nodes in this cluster"
   default     = true
 }
+
+
+variable "firewall_enabled" {
+  type        = bool
+  description = "Create additional firewall rules"
+  default     = true
+}
+
+variable "firewall_priority" {
+  type        = number
+  description = "Priority rule for firewall rules"
+  default     = 1000
+}
+
+variable "firewall_inbound_ports" {
+  type        = list(string)
+  description = "List of TCP ports for admission/webhook controllers"
+  default     = ["8443", "9443", "15017"]
+}

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -482,7 +482,7 @@ variable "enable_shielded_nodes" {
 }
 
 
-variable "firewall_enabled" {
+variable "add_cluster_firewall_rules" {
   type        = bool
   description = "Create additional firewall rules"
   default     = true

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -485,7 +485,7 @@ variable "enable_shielded_nodes" {
 variable "add_cluster_firewall_rules" {
   type        = bool
   description = "Create additional firewall rules"
-  default     = true
+  default     = false
 }
 
 variable "firewall_priority" {

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -135,6 +135,9 @@ Then perform the following commands on the root folder:
 | enable\_kubernetes\_alpha | Whether to enable Kubernetes Alpha features for this cluster. Note that when this option is enabled, the cluster cannot be upgraded and will be automatically deleted after 30 days. | bool | `"false"` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | bool | `"true"` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | bool | `"false"` | no |
+| firewall\_enabled | Create additional firewall rules | bool | `"true"` | no |
+| firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
+| firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | bool | `"true"` | no |
 | http\_load\_balancing | Enable httpload balancer addon | bool | `"true"` | no |
@@ -274,6 +277,7 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 In order to execute this module you must have a Service Account with the
 following project roles:
 - roles/compute.viewer
+- roles/compute.securityAdmin
 - roles/container.clusterAdmin
 - roles/container.developer
 - roles/iam.serviceAccountAdmin

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -116,6 +116,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| add\_cluster\_firewall\_rules | Create additional firewall rules | bool | `"true"` | no |
 | authenticator\_security\_group | The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com | string | `"null"` | no |
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |
@@ -135,7 +136,6 @@ Then perform the following commands on the root folder:
 | enable\_kubernetes\_alpha | Whether to enable Kubernetes Alpha features for this cluster. Note that when this option is enabled, the cluster cannot be upgraded and will be automatically deleted after 30 days. | bool | `"false"` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | bool | `"true"` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | bool | `"false"` | no |
-| firewall\_enabled | Create additional firewall rules | bool | `"true"` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
@@ -277,7 +277,7 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 In order to execute this module you must have a Service Account with the
 following project roles:
 - roles/compute.viewer
-- roles/compute.securityAdmin
+- roles/compute.securityAdmin (only required if `add_cluster_firewall_rules` is set to `true`)
 - roles/container.clusterAdmin
 - roles/container.developer
 - roles/iam.serviceAccountAdmin

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -116,7 +116,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| add\_cluster\_firewall\_rules | Create additional firewall rules | bool | `"true"` | no |
+| add\_cluster\_firewall\_rules | Create additional firewall rules | bool | `"false"` | no |
 | authenticator\_security\_group | The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com | string | `"null"` | no |
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -69,7 +69,8 @@ resource "google_container_cluster" "primary" {
     }
   }
 
-  default_max_pods_per_node   = var.default_max_pods_per_node
+  default_max_pods_per_node = var.default_max_pods_per_node
+
   enable_binary_authorization = var.enable_binary_authorization
   enable_intranode_visibility = var.enable_intranode_visibility
   enable_shielded_nodes       = var.enable_shielded_nodes
@@ -304,8 +305,8 @@ resource "google_container_node_pool" "pools" {
       }
     }
     tags = concat(
-      lookup(local.node_pools_tags, "default_values", [true, true])[0] ? ["gke-${var.name}"] : [],
-      lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["gke-${var.name}-${each.value["name"]}"] : [],
+      lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
+      lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-${each.value["name"]}"] : [],
       local.node_pools_tags["all"],
       local.node_pools_tags[each.value["name"]],
     )

--- a/modules/beta-public-cluster/firewall.tf
+++ b/modules/beta-public-cluster/firewall.tf
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was automatically generated from a template in ./autogen/main
+
+
+/******************************************
+  Match the gke-<CLUSTER>-<ID>-all INGRESS
+  firewall rule created by GKE but for EGRESS
+
+  Required for clusters when VPCs enforce
+  a default-deny egress rule
+ *****************************************/
+resource "google_compute_firewall" "intra_egress" {
+  count       = var.firewall_enabled ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
+  description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "EGRESS"
+
+  target_tags = [local.cluster_network_tag]
+  destination_ranges = [
+    local.cluster_endpoint_for_nodes,
+    local.cluster_subnet_cidr,
+    local.cluster_alias_ranges_cidr[var.ip_range_pods],
+  ]
+
+  # Allow all possible protocols
+  allow { protocol = "tcp" }
+  allow { protocol = "udp" }
+  allow { protocol = "icmp" }
+  allow { protocol = "sctp" }
+  allow { protocol = "esp" }
+  allow { protocol = "ah" }
+
+  depends_on = [
+    google_container_cluster.primary,
+  ]
+}
+
+
+/******************************************
+  Allow GKE master to hit non 443 ports for
+  Webhooks/Admission Controllers
+
+  https://github.com/kubernetes/kubernetes/issues/79739
+ *****************************************/
+resource "google_compute_firewall" "master_webhooks" {
+  count       = var.firewall_enabled ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
+  description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "INGRESS"
+
+  source_ranges = [local.cluster_endpoint_for_nodes]
+  target_tags   = [local.cluster_network_tag]
+
+  allow {
+    protocol = "tcp"
+    ports    = var.firewall_inbound_ports
+  }
+
+  depends_on = [
+    google_container_cluster.primary,
+  ]
+
+}

--- a/modules/beta-public-cluster/firewall.tf
+++ b/modules/beta-public-cluster/firewall.tf
@@ -25,7 +25,7 @@
   a default-deny egress rule
  *****************************************/
 resource "google_compute_firewall" "intra_egress" {
-  count       = var.firewall_enabled ? 1 : 0
+  count       = var.add_cluster_firewall_rules ? 1 : 0
   name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
@@ -61,7 +61,7 @@ resource "google_compute_firewall" "intra_egress" {
   https://github.com/kubernetes/kubernetes/issues/79739
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
-  count       = var.firewall_enabled ? 1 : 0
+  count       = var.add_cluster_firewall_rules ? 1 : 0
   name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -71,8 +71,8 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
-  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.ip_cidr_range
-  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.*.ip_cidr_range
+  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.*.secondary_ip_range) : range.range_name => range.ip_cidr_range }
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -71,8 +71,8 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
-  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.*.ip_cidr_range
-  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.*.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+  cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
+  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/modules/beta-public-cluster/networks.tf
+++ b/modules/beta-public-cluster/networks.tf
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was automatically generated from a template in ./autogen/main
+
+data "google_compute_network" "gke_network" {
+  provider = google
+
+  name    = var.network
+  project = local.network_project_id
+}
+
+data "google_compute_subnetwork" "gke_subnetwork" {
+  provider = google
+
+  name    = var.subnetwork
+  region  = local.region
+  project = local.network_project_id
+}

--- a/modules/beta-public-cluster/networks.tf
+++ b/modules/beta-public-cluster/networks.tf
@@ -16,16 +16,10 @@
 
 // This file was automatically generated from a template in ./autogen/main
 
-data "google_compute_network" "gke_network" {
-  provider = google
-
-  name    = var.network
-  project = local.network_project_id
-}
-
 data "google_compute_subnetwork" "gke_subnetwork" {
   provider = google
 
+  count   = var.add_cluster_firewall_rules ? 1 : 0
   name    = var.subnetwork
   region  = local.region
   project = local.network_project_id

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -456,3 +456,22 @@ variable "enable_shielded_nodes" {
   description = "Enable Shielded Nodes features on all nodes in this cluster"
   default     = true
 }
+
+
+variable "firewall_enabled" {
+  type        = bool
+  description = "Create additional firewall rules"
+  default     = true
+}
+
+variable "firewall_priority" {
+  type        = number
+  description = "Priority rule for firewall rules"
+  default     = 1000
+}
+
+variable "firewall_inbound_ports" {
+  type        = list(string)
+  description = "List of TCP ports for admission/webhook controllers"
+  default     = ["8443", "9443", "15017"]
+}

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -461,7 +461,7 @@ variable "enable_shielded_nodes" {
 variable "add_cluster_firewall_rules" {
   type        = bool
   description = "Create additional firewall rules"
-  default     = true
+  default     = false
 }
 
 variable "firewall_priority" {

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -458,7 +458,7 @@ variable "enable_shielded_nodes" {
 }
 
 
-variable "firewall_enabled" {
+variable "add_cluster_firewall_rules" {
   type        = bool
   description = "Create additional firewall rules"
   default     = true

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -152,6 +152,9 @@ Then perform the following commands on the root folder:
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | bool | `"true"` | no |
 | enable\_private\_endpoint | (Beta) Whether the master's internal IP address is used as the cluster endpoint | bool | `"false"` | no |
 | enable\_private\_nodes | (Beta) Whether nodes have internal IP addresses only | bool | `"false"` | no |
+| firewall\_enabled | Create additional firewall rules | bool | `"true"` | no |
+| firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
+| firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | bool | `"true"` | no |
 | http\_load\_balancing | Enable httpload balancer addon | bool | `"true"` | no |
@@ -266,6 +269,7 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 In order to execute this module you must have a Service Account with the
 following project roles:
 - roles/compute.viewer
+- roles/compute.securityAdmin
 - roles/container.clusterAdmin
 - roles/container.developer
 - roles/iam.serviceAccountAdmin

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -140,6 +140,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| add\_cluster\_firewall\_rules | Create additional firewall rules | bool | `"true"` | no |
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |
 | cluster\_ipv4\_cidr | The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR. | string | `"null"` | no |
@@ -152,7 +153,6 @@ Then perform the following commands on the root folder:
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | bool | `"true"` | no |
 | enable\_private\_endpoint | (Beta) Whether the master's internal IP address is used as the cluster endpoint | bool | `"false"` | no |
 | enable\_private\_nodes | (Beta) Whether nodes have internal IP addresses only | bool | `"false"` | no |
-| firewall\_enabled | Create additional firewall rules | bool | `"true"` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
@@ -269,7 +269,7 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 In order to execute this module you must have a Service Account with the
 following project roles:
 - roles/compute.viewer
-- roles/compute.securityAdmin
+- roles/compute.securityAdmin (only required if `add_cluster_firewall_rules` is set to `true`)
 - roles/container.clusterAdmin
 - roles/container.developer
 - roles/iam.serviceAccountAdmin

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -140,7 +140,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| add\_cluster\_firewall\_rules | Create additional firewall rules | bool | `"true"` | no |
+| add\_cluster\_firewall\_rules | Create additional firewall rules | bool | `"false"` | no |
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |
 | cluster\_ipv4\_cidr | The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR. | string | `"null"` | no |

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -51,6 +51,7 @@ resource "google_container_cluster" "primary" {
 
 
   default_max_pods_per_node = var.default_max_pods_per_node
+
   dynamic "master_authorized_networks_config" {
     for_each = local.master_authorized_networks_config
     content {
@@ -267,8 +268,8 @@ resource "google_container_node_pool" "pools" {
       },
     )
     tags = concat(
-      lookup(local.node_pools_tags, "default_values", [true, true])[0] ? ["gke-${var.name}"] : [],
-      lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["gke-${var.name}-${each.value["name"]}"] : [],
+      lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
+      lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-${each.value["name"]}"] : [],
       local.node_pools_tags["all"],
       local.node_pools_tags[each.value["name"]],
     )

--- a/modules/private-cluster-update-variant/firewall.tf
+++ b/modules/private-cluster-update-variant/firewall.tf
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was automatically generated from a template in ./autogen/main
+
+
+/******************************************
+  Match the gke-<CLUSTER>-<ID>-all INGRESS
+  firewall rule created by GKE but for EGRESS
+
+  Required for clusters when VPCs enforce
+  a default-deny egress rule
+ *****************************************/
+resource "google_compute_firewall" "intra_egress" {
+  count       = var.firewall_enabled ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
+  description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "EGRESS"
+
+  target_tags = [local.cluster_network_tag]
+  destination_ranges = [
+    local.cluster_endpoint_for_nodes,
+    local.cluster_subnet_cidr,
+    local.cluster_alias_ranges_cidr[var.ip_range_pods],
+  ]
+
+  # Allow all possible protocols
+  allow { protocol = "tcp" }
+  allow { protocol = "udp" }
+  allow { protocol = "icmp" }
+  allow { protocol = "sctp" }
+  allow { protocol = "esp" }
+  allow { protocol = "ah" }
+
+  depends_on = [
+    google_container_cluster.primary,
+  ]
+}
+
+
+/******************************************
+  Allow GKE master to hit non 443 ports for
+  Webhooks/Admission Controllers
+
+  https://github.com/kubernetes/kubernetes/issues/79739
+ *****************************************/
+resource "google_compute_firewall" "master_webhooks" {
+  count       = var.firewall_enabled ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
+  description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "INGRESS"
+
+  source_ranges = [local.cluster_endpoint_for_nodes]
+  target_tags   = [local.cluster_network_tag]
+
+  allow {
+    protocol = "tcp"
+    ports    = var.firewall_inbound_ports
+  }
+
+  depends_on = [
+    google_container_cluster.primary,
+  ]
+
+}

--- a/modules/private-cluster-update-variant/firewall.tf
+++ b/modules/private-cluster-update-variant/firewall.tf
@@ -25,7 +25,7 @@
   a default-deny egress rule
  *****************************************/
 resource "google_compute_firewall" "intra_egress" {
-  count       = var.firewall_enabled ? 1 : 0
+  count       = var.add_cluster_firewall_rules ? 1 : 0
   name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
@@ -61,7 +61,7 @@ resource "google_compute_firewall" "intra_egress" {
   https://github.com/kubernetes/kubernetes/issues/79739
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
-  count       = var.firewall_enabled ? 1 : 0
+  count       = var.add_cluster_firewall_rules ? 1 : 0
   name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id

--- a/modules/private-cluster-update-variant/main.tf
+++ b/modules/private-cluster-update-variant/main.tf
@@ -59,8 +59,8 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
-  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.ip_cidr_range
-  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.*.ip_cidr_range
+  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.*.secondary_ip_range) : range.range_name => range.ip_cidr_range }
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/modules/private-cluster-update-variant/main.tf
+++ b/modules/private-cluster-update-variant/main.tf
@@ -59,6 +59,9 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
+  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.ip_cidr_range
+  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+
   cluster_network_policy = var.network_policy ? [{
     enabled  = true
     provider = var.network_policy_provider
@@ -73,8 +76,9 @@ locals {
   cluster_output_zonal_zones    = local.zone_count > 1 ? slice(var.zones, 1, local.zone_count) : []
   cluster_output_zones          = local.cluster_output_regional_zones
 
-  cluster_endpoint     = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
-  cluster_peering_name = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? google_container_cluster.primary.private_cluster_config.0.peering_name : null
+  cluster_endpoint           = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
+  cluster_peering_name       = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? google_container_cluster.primary.private_cluster_config.0.peering_name : null
+  cluster_endpoint_for_nodes = var.master_ipv4_cidr_block
 
   cluster_output_master_auth                        = concat(google_container_cluster.primary.*.master_auth, [])
   cluster_output_master_version                     = google_container_cluster.primary.master_version
@@ -102,6 +106,7 @@ locals {
   cluster_zones    = sort(local.cluster_output_zones)
 
   cluster_name                               = local.cluster_output_name
+  cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version
   cluster_min_master_version                 = local.cluster_output_min_master_version

--- a/modules/private-cluster-update-variant/main.tf
+++ b/modules/private-cluster-update-variant/main.tf
@@ -59,8 +59,8 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
-  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.*.ip_cidr_range
-  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.*.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+  cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
+  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/modules/private-cluster-update-variant/networks.tf
+++ b/modules/private-cluster-update-variant/networks.tf
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was automatically generated from a template in ./autogen/main
+
+data "google_compute_network" "gke_network" {
+  provider = google
+
+  name    = var.network
+  project = local.network_project_id
+}
+
+data "google_compute_subnetwork" "gke_subnetwork" {
+  provider = google
+
+  name    = var.subnetwork
+  region  = local.region
+  project = local.network_project_id
+}

--- a/modules/private-cluster-update-variant/networks.tf
+++ b/modules/private-cluster-update-variant/networks.tf
@@ -16,16 +16,10 @@
 
 // This file was automatically generated from a template in ./autogen/main
 
-data "google_compute_network" "gke_network" {
-  provider = google
-
-  name    = var.network
-  project = local.network_project_id
-}
-
 data "google_compute_subnetwork" "gke_subnetwork" {
   provider = google
 
+  count   = var.add_cluster_firewall_rules ? 1 : 0
   name    = var.subnetwork
   region  = local.region
   project = local.network_project_id

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -331,3 +331,22 @@ variable "master_ipv4_cidr_block" {
   description = "(Beta) The IP range in CIDR notation to use for the hosted master network"
   default     = "10.0.0.0/28"
 }
+
+
+variable "firewall_enabled" {
+  type        = bool
+  description = "Create additional firewall rules"
+  default     = true
+}
+
+variable "firewall_priority" {
+  type        = number
+  description = "Priority rule for firewall rules"
+  default     = 1000
+}
+
+variable "firewall_inbound_ports" {
+  type        = list(string)
+  description = "List of TCP ports for admission/webhook controllers"
+  default     = ["8443", "9443", "15017"]
+}

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -336,7 +336,7 @@ variable "master_ipv4_cidr_block" {
 variable "add_cluster_firewall_rules" {
   type        = bool
   description = "Create additional firewall rules"
-  default     = true
+  default     = false
 }
 
 variable "firewall_priority" {

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -333,7 +333,7 @@ variable "master_ipv4_cidr_block" {
 }
 
 
-variable "firewall_enabled" {
+variable "add_cluster_firewall_rules" {
   type        = bool
   description = "Create additional firewall rules"
   default     = true

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -118,6 +118,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| add\_cluster\_firewall\_rules | Create additional firewall rules | bool | `"true"` | no |
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |
 | cluster\_ipv4\_cidr | The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR. | string | `"null"` | no |
@@ -130,7 +131,6 @@ Then perform the following commands on the root folder:
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | bool | `"true"` | no |
 | enable\_private\_endpoint | (Beta) Whether the master's internal IP address is used as the cluster endpoint | bool | `"false"` | no |
 | enable\_private\_nodes | (Beta) Whether nodes have internal IP addresses only | bool | `"false"` | no |
-| firewall\_enabled | Create additional firewall rules | bool | `"true"` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
 | firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
@@ -247,7 +247,7 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 In order to execute this module you must have a Service Account with the
 following project roles:
 - roles/compute.viewer
-- roles/compute.securityAdmin
+- roles/compute.securityAdmin (only required if `add_cluster_firewall_rules` is set to `true`)
 - roles/container.clusterAdmin
 - roles/container.developer
 - roles/iam.serviceAccountAdmin

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -118,7 +118,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| add\_cluster\_firewall\_rules | Create additional firewall rules | bool | `"true"` | no |
+| add\_cluster\_firewall\_rules | Create additional firewall rules | bool | `"false"` | no |
 | basic\_auth\_password | The password to be used with Basic Authentication. | string | `""` | no |
 | basic\_auth\_username | The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration. | string | `""` | no |
 | cluster\_ipv4\_cidr | The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR. | string | `"null"` | no |

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -130,6 +130,9 @@ Then perform the following commands on the root folder:
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | bool | `"true"` | no |
 | enable\_private\_endpoint | (Beta) Whether the master's internal IP address is used as the cluster endpoint | bool | `"false"` | no |
 | enable\_private\_nodes | (Beta) Whether nodes have internal IP addresses only | bool | `"false"` | no |
+| firewall\_enabled | Create additional firewall rules | bool | `"true"` | no |
+| firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | list(string) | `<list>` | no |
+| firewall\_priority | Priority rule for firewall rules | number | `"1000"` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | bool | `"false"` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | bool | `"true"` | no |
 | http\_load\_balancing | Enable httpload balancer addon | bool | `"true"` | no |
@@ -244,6 +247,7 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 In order to execute this module you must have a Service Account with the
 following project roles:
 - roles/compute.viewer
+- roles/compute.securityAdmin
 - roles/container.clusterAdmin
 - roles/container.developer
 - roles/iam.serviceAccountAdmin

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -51,6 +51,7 @@ resource "google_container_cluster" "primary" {
 
 
   default_max_pods_per_node = var.default_max_pods_per_node
+
   dynamic "master_authorized_networks_config" {
     for_each = local.master_authorized_networks_config
     content {
@@ -195,8 +196,8 @@ resource "google_container_node_pool" "pools" {
       },
     )
     tags = concat(
-      lookup(local.node_pools_tags, "default_values", [true, true])[0] ? ["gke-${var.name}"] : [],
-      lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["gke-${var.name}-${each.value["name"]}"] : [],
+      lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
+      lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-${each.value["name"]}"] : [],
       local.node_pools_tags["all"],
       local.node_pools_tags[each.value["name"]],
     )

--- a/modules/private-cluster/firewall.tf
+++ b/modules/private-cluster/firewall.tf
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was automatically generated from a template in ./autogen/main
+
+
+/******************************************
+  Match the gke-<CLUSTER>-<ID>-all INGRESS
+  firewall rule created by GKE but for EGRESS
+
+  Required for clusters when VPCs enforce
+  a default-deny egress rule
+ *****************************************/
+resource "google_compute_firewall" "intra_egress" {
+  count       = var.firewall_enabled ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
+  description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "EGRESS"
+
+  target_tags = [local.cluster_network_tag]
+  destination_ranges = [
+    local.cluster_endpoint_for_nodes,
+    local.cluster_subnet_cidr,
+    local.cluster_alias_ranges_cidr[var.ip_range_pods],
+  ]
+
+  # Allow all possible protocols
+  allow { protocol = "tcp" }
+  allow { protocol = "udp" }
+  allow { protocol = "icmp" }
+  allow { protocol = "sctp" }
+  allow { protocol = "esp" }
+  allow { protocol = "ah" }
+
+  depends_on = [
+    google_container_cluster.primary,
+  ]
+}
+
+
+/******************************************
+  Allow GKE master to hit non 443 ports for
+  Webhooks/Admission Controllers
+
+  https://github.com/kubernetes/kubernetes/issues/79739
+ *****************************************/
+resource "google_compute_firewall" "master_webhooks" {
+  count       = var.firewall_enabled ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
+  description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "INGRESS"
+
+  source_ranges = [local.cluster_endpoint_for_nodes]
+  target_tags   = [local.cluster_network_tag]
+
+  allow {
+    protocol = "tcp"
+    ports    = var.firewall_inbound_ports
+  }
+
+  depends_on = [
+    google_container_cluster.primary,
+  ]
+
+}

--- a/modules/private-cluster/firewall.tf
+++ b/modules/private-cluster/firewall.tf
@@ -25,7 +25,7 @@
   a default-deny egress rule
  *****************************************/
 resource "google_compute_firewall" "intra_egress" {
-  count       = var.firewall_enabled ? 1 : 0
+  count       = var.add_cluster_firewall_rules ? 1 : 0
   name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
@@ -61,7 +61,7 @@ resource "google_compute_firewall" "intra_egress" {
   https://github.com/kubernetes/kubernetes/issues/79739
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
-  count       = var.firewall_enabled ? 1 : 0
+  count       = var.add_cluster_firewall_rules ? 1 : 0
   name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -59,8 +59,8 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
-  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.ip_cidr_range
-  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.*.ip_cidr_range
+  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.*.secondary_ip_range) : range.range_name => range.ip_cidr_range }
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -59,6 +59,9 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
+  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.ip_cidr_range
+  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+
   cluster_network_policy = var.network_policy ? [{
     enabled  = true
     provider = var.network_policy_provider
@@ -73,8 +76,9 @@ locals {
   cluster_output_zonal_zones    = local.zone_count > 1 ? slice(var.zones, 1, local.zone_count) : []
   cluster_output_zones          = local.cluster_output_regional_zones
 
-  cluster_endpoint     = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
-  cluster_peering_name = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? google_container_cluster.primary.private_cluster_config.0.peering_name : null
+  cluster_endpoint           = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
+  cluster_peering_name       = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? google_container_cluster.primary.private_cluster_config.0.peering_name : null
+  cluster_endpoint_for_nodes = var.master_ipv4_cidr_block
 
   cluster_output_master_auth                        = concat(google_container_cluster.primary.*.master_auth, [])
   cluster_output_master_version                     = google_container_cluster.primary.master_version
@@ -102,6 +106,7 @@ locals {
   cluster_zones    = sort(local.cluster_output_zones)
 
   cluster_name                               = local.cluster_output_name
+  cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version
   cluster_min_master_version                 = local.cluster_output_min_master_version

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -59,8 +59,8 @@ locals {
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
   default_auto_upgrade = var.regional ? true : false
 
-  cluster_subnet_cidr       = data.google_compute_subnetwork.gke_subnetwork.*.ip_cidr_range
-  cluster_alias_ranges_cidr = { for range in toset(data.google_compute_subnetwork.gke_subnetwork.*.secondary_ip_range) : range.range_name => range.ip_cidr_range }
+  cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
+  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/modules/private-cluster/networks.tf
+++ b/modules/private-cluster/networks.tf
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file was automatically generated from a template in ./autogen/main
+
+data "google_compute_network" "gke_network" {
+  provider = google
+
+  name    = var.network
+  project = local.network_project_id
+}
+
+data "google_compute_subnetwork" "gke_subnetwork" {
+  provider = google
+
+  name    = var.subnetwork
+  region  = local.region
+  project = local.network_project_id
+}

--- a/modules/private-cluster/networks.tf
+++ b/modules/private-cluster/networks.tf
@@ -16,16 +16,10 @@
 
 // This file was automatically generated from a template in ./autogen/main
 
-data "google_compute_network" "gke_network" {
-  provider = google
-
-  name    = var.network
-  project = local.network_project_id
-}
-
 data "google_compute_subnetwork" "gke_subnetwork" {
   provider = google
 
+  count   = var.add_cluster_firewall_rules ? 1 : 0
   name    = var.subnetwork
   region  = local.region
   project = local.network_project_id

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -331,3 +331,22 @@ variable "master_ipv4_cidr_block" {
   description = "(Beta) The IP range in CIDR notation to use for the hosted master network"
   default     = "10.0.0.0/28"
 }
+
+
+variable "firewall_enabled" {
+  type        = bool
+  description = "Create additional firewall rules"
+  default     = true
+}
+
+variable "firewall_priority" {
+  type        = number
+  description = "Priority rule for firewall rules"
+  default     = 1000
+}
+
+variable "firewall_inbound_ports" {
+  type        = list(string)
+  description = "List of TCP ports for admission/webhook controllers"
+  default     = ["8443", "9443", "15017"]
+}

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -336,7 +336,7 @@ variable "master_ipv4_cidr_block" {
 variable "add_cluster_firewall_rules" {
   type        = bool
   description = "Create additional firewall rules"
-  default     = true
+  default     = false
 }
 
 variable "firewall_priority" {

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -333,7 +333,7 @@ variable "master_ipv4_cidr_block" {
 }
 
 
-variable "firewall_enabled" {
+variable "add_cluster_firewall_rules" {
   type        = bool
   description = "Create additional firewall rules"
   default     = true

--- a/networks.tf
+++ b/networks.tf
@@ -16,16 +16,10 @@
 
 // This file was automatically generated from a template in ./autogen/main
 
-data "google_compute_network" "gke_network" {
-  provider = google
-
-  name    = var.network
-  project = local.network_project_id
-}
-
 data "google_compute_subnetwork" "gke_subnetwork" {
   provider = google
 
+  count   = var.add_cluster_firewall_rules ? 1 : 0
   name    = var.subnetwork
   region  = local.region
   project = local.network_project_id

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -19,12 +19,12 @@ locals {
     "roles/cloudkms.admin",
     "roles/cloudkms.cryptoKeyEncrypterDecrypter",
     "roles/compute.networkAdmin",
+    "roles/compute.securityAdmin",
     "roles/container.admin",
     "roles/container.clusterAdmin",
     "roles/container.developer",
     "roles/iam.serviceAccountAdmin",
     "roles/iam.serviceAccountUser",
-    "roles/compute.networkAdmin",
     "roles/compute.viewer",
     "roles/resourcemanager.projectIamAdmin",
     "roles/composer.worker"

--- a/variables.tf
+++ b/variables.tf
@@ -312,7 +312,7 @@ variable "default_max_pods_per_node" {
 variable "add_cluster_firewall_rules" {
   type        = bool
   description = "Create additional firewall rules"
-  default     = true
+  default     = false
 }
 
 variable "firewall_priority" {

--- a/variables.tf
+++ b/variables.tf
@@ -307,3 +307,22 @@ variable "default_max_pods_per_node" {
   description = "The maximum number of pods to schedule per node"
   default     = 110
 }
+
+
+variable "firewall_enabled" {
+  type        = bool
+  description = "Create additional firewall rules"
+  default     = true
+}
+
+variable "firewall_priority" {
+  type        = number
+  description = "Priority rule for firewall rules"
+  default     = 1000
+}
+
+variable "firewall_inbound_ports" {
+  type        = list(string)
+  description = "List of TCP ports for admission/webhook controllers"
+  default     = ["8443", "9443", "15017"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -309,7 +309,7 @@ variable "default_max_pods_per_node" {
 }
 
 
-variable "firewall_enabled" {
+variable "add_cluster_firewall_rules" {
   type        = bool
   description = "Create additional firewall rules"
   default     = true


### PR DESCRIPTION
Closes #452  

Add the 2 firewall rules raised in that issue, which can be opted out using `var.firewall_enabled`.  

Common inbound ports are also white listed by default (8443/9443 and 15017 for istio 1.5) for a better UX (port list controlled by `var.firewall_inbound_ports`)


Refactoring:
- Save `"gke-${var.name}"` network tag format into locals, this module already adds that network tag to all node pools
- Move `networks.tf` to `autogen/` so module variants have access to `data.google_compute_subnetwork.gke_subnetwork` which can be used to determine pod CIDR
- Misc formatting fixes to templates so the latest docker image is happy for `make build docker_test_lint`


TODO:
- README update, this requires the terraform runner to have necessary IAM permissions to make firewall changes in the VPC project