### PR TITLE
Fix zonal bug

### DIFF
--- a/autogen/safer-cluster/main.tf.tmpl
+++ b/autogen/safer-cluster/main.tf.tmpl
@@ -28,6 +28,7 @@ module "gke" {
   name               = var.name
   regional           = var.regional
   region             = var.region
+  zones              = var.zones
   network            = var.network
   network_project_id = var.network_project_id
 

--- a/modules/safer-cluster-update-variant/main.tf
+++ b/modules/safer-cluster-update-variant/main.tf
@@ -24,7 +24,6 @@ module "gke" {
   name               = var.name
   regional           = var.regional
   region             = var.region
-  zones              = var.zones
   network            = var.network
   network_project_id = var.network_project_id
 

--- a/modules/safer-cluster-update-variant/main.tf
+++ b/modules/safer-cluster-update-variant/main.tf
@@ -24,6 +24,7 @@ module "gke" {
   name               = var.name
   regional           = var.regional
   region             = var.region
+  zones              = var.zones
   network            = var.network
   network_project_id = var.network_project_id
 

--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -26,6 +26,7 @@ module "gke" {
   region             = var.region
   network            = var.network
   network_project_id = var.network_project_id
+  zones              = var.zones
 
   // We need to enforce a minimum Kubernetes Version to ensure
   // that the necessary security features are enabled.

--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -26,7 +26,6 @@ module "gke" {
   region             = var.region
   network            = var.network
   network_project_id = var.network_project_id
-  zones              = var.zones
 
   // We need to enforce a minimum Kubernetes Version to ensure
   // that the necessary security features are enabled.

--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -24,6 +24,7 @@ module "gke" {
   name               = var.name
   regional           = var.regional
   region             = var.region
+  zones              = var.zones
   network            = var.network
   network_project_id = var.network_project_id
 


### PR DESCRIPTION
The Safer modules support regional and zonal clusters. However, the zones variable is never passed so the config errors when setting regional = false

https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/449