### PR TITLE
Nodelocal dnscache

### DIFF
--- a/autogen/main/README.md
+++ b/autogen/main/README.md
@@ -84,6 +84,7 @@ module "gke" {
   {% if beta_cluster %}
   istio = true
   cloudrun = true
+  dns_cache = false
   {% endif %}
 
   node_pools = [

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -157,6 +157,8 @@ resource "google_container_cluster" "primary" {
         disabled = cloudrun_config.value.disabled
       }
     }
+
+    dns_cache_config = var.dns_cache
     {% endif %}
   }
 

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -158,7 +158,9 @@ resource "google_container_cluster" "primary" {
       }
     }
 
-    dns_cache_config = var.dns_cache
+    dns_cache_config {
+      enabled   = var.dns_cache
+    }
     {% endif %}
   }
 

--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -160,6 +160,7 @@ locals {
   # BETA features
   cluster_istio_enabled                    = ! local.cluster_output_istio_disabled
   cluster_cloudrun_enabled                 = var.cloudrun
+  cluster_dns_cache_enabled                = var.dns_cache
   cluster_pod_security_policy_enabled      = local.cluster_output_pod_security_policy_enabled
   cluster_intranode_visibility_enabled     = local.cluster_output_intranode_visbility_enabled
   cluster_vertical_pod_autoscaling_enabled = local.cluster_output_vertical_pod_autoscaling_enabled

--- a/autogen/main/outputs.tf.tmpl
+++ b/autogen/main/outputs.tf.tmpl
@@ -138,6 +138,11 @@ output "cloudrun_enabled" {
   value       = local.cluster_cloudrun_enabled
 }
 
+output "dns_cache_enabled" {
+  description = "Whether DNS Cache enabled"
+  value       = local.cluster_dns_cache_enabled
+}
+
 output "pod_security_policy_enabled" {
   description = "Whether pod security policy is enabled"
   value       = local.cluster_pod_security_policy_enabled

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -399,6 +399,12 @@ variable "istio_auth" {
   default     = "AUTH_MUTUAL_TLS"
 }
 
+variable "dns_cache" {
+  type        = bool
+  description = "(Beta) The status of the NodeLocal DNSCache addon."
+  default     = false
+}
+
 variable "database_encryption" {
   description = "Application-layer Secrets Encryption settings. The object format is {state = string, key_name = string}. Valid values of state are: \"ENCRYPTED\"; \"DECRYPTED\". key_name is the name of a CloudKMS key."
   type        = list(object({ state = string, key_name = string }))

--- a/autogen/safer-cluster/main.tf.tmpl
+++ b/autogen/safer-cluster/main.tf.tmpl
@@ -122,6 +122,8 @@ module "gke" {
 
   cloudrun = var.cloudrun
 
+  dns_cache = var.dns_cache
+
   default_max_pods_per_node = var.default_max_pods_per_node
 
   database_encryption = var.database_encryption

--- a/autogen/safer-cluster/variables.tf.tmpl
+++ b/autogen/safer-cluster/variables.tf.tmpl
@@ -237,6 +237,12 @@ variable "istio_auth" {
   default     = "AUTH_MUTUAL_TLS"
 }
 
+variable "dns_cache" {
+  type        = bool
+  description = "(Beta) The status of the NodeLocal DNSCache addon."
+  default     = false
+}
+
 variable "default_max_pods_per_node" {
   description = "The maximum number of pods to schedule per node"
   default     = 110

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.1.0"
+  version = "~> 3.14.0"
   region  = var.region
 }
 

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.12.0"
+  version = "~> 3.1.0"
   region  = var.region
 }
 

--- a/examples/node_pool_update_variant/main.tf
+++ b/examples/node_pool_update_variant/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.12.0"
+  version = "~> 3.14.0"
   region  = var.region
 }
 

--- a/examples/node_pool_update_variant_beta/main.tf
+++ b/examples/node_pool_update_variant_beta/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version     = "~> 3.12.0"
+  version     = "~> 3.14.0"
   credentials = file(var.credentials_path)
   region      = var.region
 }

--- a/examples/safer_cluster/main.tf
+++ b/examples/safer_cluster/main.tf
@@ -30,11 +30,11 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.12.0"
+  version = "~> 3.14.0"
 }
 
 provider "google-beta" {
-  version = "~> 3.12.0"
+  version = "~> 3.14.0"
 }
 
 module "gke" {

--- a/examples/simple_regional_beta/README.md
+++ b/examples/simple_regional_beta/README.md
@@ -11,6 +11,7 @@ This example illustrates how to create a simple cluster with beta features.
 | cluster\_name\_suffix | A suffix to append to the default cluster name | string | `""` | no |
 | compute\_engine\_service\_account | Service account to associate to the nodes in the cluster | string | n/a | yes |
 | database\_encryption | Application-layer Secrets Encryption settings. The object format is {state = string, key_name = string}. Valid values of state are: "ENCRYPTED"; "DECRYPTED". key_name is the name of a CloudKMS key. | object | `<list>` | no |
+| dns\_cache | (Beta) The status of the NodeLocal DNSCache addon. | bool | `"false"` | no |
 | enable\_binary\_authorization | Enable BinAuthZ Admission controller | string | `"false"` | no |
 | ip\_range\_pods | The secondary ip range to use for pods | string | n/a | yes |
 | ip\_range\_services | The secondary ip range to use for services | string | n/a | yes |

--- a/examples/simple_regional_beta/main.tf
+++ b/examples/simple_regional_beta/main.tf
@@ -38,6 +38,7 @@ module "gke" {
   service_account             = var.compute_engine_service_account
   istio                       = var.istio
   cloudrun                    = var.cloudrun
+  dns_cache                   = var.dns_cache
   node_metadata               = var.node_metadata
   sandbox_enabled             = var.sandbox_enabled
   remove_default_node_pool    = var.remove_default_node_pool

--- a/examples/simple_regional_beta/main.tf
+++ b/examples/simple_regional_beta/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.12.0"
+  version = "~> 3.14.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_beta/variables.tf
+++ b/examples/simple_regional_beta/variables.tf
@@ -57,6 +57,12 @@ variable "cloudrun" {
   default     = true
 }
 
+variable "dns_cache" {
+  type        = bool
+  description = "(Beta) The status of the NodeLocal DNSCache addon."
+  default     = false
+}
+
 variable "node_metadata" {
   description = "Specifies how node metadata is exposed to the workload running on the node"
   default     = "SECURE"

--- a/examples/simple_regional_private_beta/main.tf
+++ b/examples/simple_regional_private_beta/main.tf
@@ -56,8 +56,9 @@ module "gke" {
     },
   ]
 
-  istio    = var.istio
-  cloudrun = var.cloudrun
+  istio     = var.istio
+  cloudrun  = var.cloudrun
+  dns_cache = var.dns_cache
 }
 
 data "google_client_config" "default" {

--- a/examples/simple_regional_private_beta/main.tf
+++ b/examples/simple_regional_private_beta/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.12.0"
+  version = "~> 3.14.0"
   region  = var.region
 }
 
 provider "google-beta" {
-  version = "~> 3.12.0"
+  version = "~> 3.14.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_private_beta/variables.tf
+++ b/examples/simple_regional_private_beta/variables.tf
@@ -57,3 +57,7 @@ variable "cloudrun" {
   default     = true
 }
 
+variable "dns_cache" {
+  description = "Boolean to enable / disable NodeLocal DNSCache "
+  default     = false
+}

--- a/examples/workload_identity/main.tf
+++ b/examples/workload_identity/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.12.0"
+  version = "~> 3.14.0"
   region  = var.region
 }
 

--- a/examples/workload_metadata_config/main.tf
+++ b/examples/workload_metadata_config/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.12.0"
+  version = "~> 3.14.0"
   region  = var.region
 }
 

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -76,6 +76,7 @@ module "gke" {
   master_ipv4_cidr_block     = "10.0.0.0/28"
   istio = true
   cloudrun = true
+  dns_cache = false
 
   node_pools = [
     {
@@ -169,6 +170,7 @@ Then perform the following commands on the root folder:
 | deploy\_using\_private\_endpoint | (Beta) A toggle for Terraform and kubectl to connect to the master's internal IP address during deployment. | bool | `"false"` | no |
 | description | The description of the cluster | string | `""` | no |
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | bool | `"true"` | no |
+| dns\_cache | (Beta) The status of the NodeLocal DNSCache addon. | bool | `"false"` | no |
 | enable\_binary\_authorization | Enable BinAuthZ Admission controller | string | `"false"` | no |
 | enable\_intranode\_visibility | Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network | bool | `"false"` | no |
 | enable\_kubernetes\_alpha | Whether to enable Kubernetes Alpha features for this cluster. Note that when this option is enabled, the cluster cannot be upgraded and will be automatically deleted after 30 days. | bool | `"false"` | no |
@@ -232,6 +234,7 @@ Then perform the following commands on the root folder:
 |------|-------------|
 | ca\_certificate | Cluster ca certificate (base64 encoded) |
 | cloudrun\_enabled | Whether CloudRun enabled |
+| dns\_cache\_enabled | Whether DNS Cache enabled |
 | endpoint | Cluster endpoint |
 | horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |
 | http\_load\_balancing\_enabled | Whether http load balancing enabled |

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -143,7 +143,9 @@ resource "google_container_cluster" "primary" {
       }
     }
 
-    dns_cache_config = var.dns_cache
+    dns_cache_config {
+      enabled = var.dns_cache
+    }
   }
 
   ip_allocation_policy {

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -142,6 +142,8 @@ resource "google_container_cluster" "primary" {
         disabled = cloudrun_config.value.disabled
       }
     }
+
+    dns_cache_config = var.dns_cache
   }
 
   ip_allocation_policy {

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -145,6 +145,7 @@ locals {
   # BETA features
   cluster_istio_enabled                    = ! local.cluster_output_istio_disabled
   cluster_cloudrun_enabled                 = var.cloudrun
+  cluster_dns_cache_enabled                = var.dns_cache
   cluster_pod_security_policy_enabled      = local.cluster_output_pod_security_policy_enabled
   cluster_intranode_visibility_enabled     = local.cluster_output_intranode_visbility_enabled
   cluster_vertical_pod_autoscaling_enabled = local.cluster_output_vertical_pod_autoscaling_enabled

--- a/modules/beta-private-cluster-update-variant/outputs.tf
+++ b/modules/beta-private-cluster-update-variant/outputs.tf
@@ -135,6 +135,11 @@ output "cloudrun_enabled" {
   value       = local.cluster_cloudrun_enabled
 }
 
+output "dns_cache_enabled" {
+  description = "Whether DNS Cache enabled"
+  value       = local.cluster_dns_cache_enabled
+}
+
 output "pod_security_policy_enabled" {
   description = "Whether pod security policy is enabled"
   value       = local.cluster_pod_security_policy_enabled

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -392,6 +392,12 @@ variable "istio_auth" {
   default     = "AUTH_MUTUAL_TLS"
 }
 
+variable "dns_cache" {
+  type        = bool
+  description = "(Beta) The status of the NodeLocal DNSCache addon."
+  default     = false
+}
+
 variable "database_encryption" {
   description = "Application-layer Secrets Encryption settings. The object format is {state = string, key_name = string}. Valid values of state are: \"ENCRYPTED\"; \"DECRYPTED\". key_name is the name of a CloudKMS key."
   type        = list(object({ state = string, key_name = string }))

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -54,6 +54,7 @@ module "gke" {
   master_ipv4_cidr_block     = "10.0.0.0/28"
   istio = true
   cloudrun = true
+  dns_cache = false
 
   node_pools = [
     {
@@ -147,6 +148,7 @@ Then perform the following commands on the root folder:
 | deploy\_using\_private\_endpoint | (Beta) A toggle for Terraform and kubectl to connect to the master's internal IP address during deployment. | bool | `"false"` | no |
 | description | The description of the cluster | string | `""` | no |
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | bool | `"true"` | no |
+| dns\_cache | (Beta) The status of the NodeLocal DNSCache addon. | bool | `"false"` | no |
 | enable\_binary\_authorization | Enable BinAuthZ Admission controller | string | `"false"` | no |
 | enable\_intranode\_visibility | Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network | bool | `"false"` | no |
 | enable\_kubernetes\_alpha | Whether to enable Kubernetes Alpha features for this cluster. Note that when this option is enabled, the cluster cannot be upgraded and will be automatically deleted after 30 days. | bool | `"false"` | no |
@@ -210,6 +212,7 @@ Then perform the following commands on the root folder:
 |------|-------------|
 | ca\_certificate | Cluster ca certificate (base64 encoded) |
 | cloudrun\_enabled | Whether CloudRun enabled |
+| dns\_cache\_enabled | Whether DNS Cache enabled |
 | endpoint | Cluster endpoint |
 | horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |
 | http\_load\_balancing\_enabled | Whether http load balancing enabled |

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -143,7 +143,9 @@ resource "google_container_cluster" "primary" {
       }
     }
 
-    dns_cache_config = var.dns_cache
+    dns_cache_config {
+      enabled = var.dns_cache
+    }
   }
 
   ip_allocation_policy {

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -142,6 +142,8 @@ resource "google_container_cluster" "primary" {
         disabled = cloudrun_config.value.disabled
       }
     }
+
+    dns_cache_config = var.dns_cache
   }
 
   ip_allocation_policy {

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -145,6 +145,7 @@ locals {
   # BETA features
   cluster_istio_enabled                    = ! local.cluster_output_istio_disabled
   cluster_cloudrun_enabled                 = var.cloudrun
+  cluster_dns_cache_enabled                = var.dns_cache
   cluster_pod_security_policy_enabled      = local.cluster_output_pod_security_policy_enabled
   cluster_intranode_visibility_enabled     = local.cluster_output_intranode_visbility_enabled
   cluster_vertical_pod_autoscaling_enabled = local.cluster_output_vertical_pod_autoscaling_enabled

--- a/modules/beta-private-cluster/outputs.tf
+++ b/modules/beta-private-cluster/outputs.tf
@@ -135,6 +135,11 @@ output "cloudrun_enabled" {
   value       = local.cluster_cloudrun_enabled
 }
 
+output "dns_cache_enabled" {
+  description = "Whether DNS Cache enabled"
+  value       = local.cluster_dns_cache_enabled
+}
+
 output "pod_security_policy_enabled" {
   description = "Whether pod security policy is enabled"
   value       = local.cluster_pod_security_policy_enabled

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -392,6 +392,12 @@ variable "istio_auth" {
   default     = "AUTH_MUTUAL_TLS"
 }
 
+variable "dns_cache" {
+  type        = bool
+  description = "(Beta) The status of the NodeLocal DNSCache addon."
+  default     = false
+}
+
 variable "database_encryption" {
   description = "Application-layer Secrets Encryption settings. The object format is {state = string, key_name = string}. Valid values of state are: \"ENCRYPTED\"; \"DECRYPTED\". key_name is the name of a CloudKMS key."
   type        = list(object({ state = string, key_name = string }))

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -36,6 +36,7 @@ module "gke" {
   network_policy             = true
   istio = true
   cloudrun = true
+  dns_cache = false
 
   node_pools = [
     {
@@ -128,6 +129,7 @@ Then perform the following commands on the root folder:
 | default\_max\_pods\_per\_node | The maximum number of pods to schedule per node | string | `"110"` | no |
 | description | The description of the cluster | string | `""` | no |
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | bool | `"true"` | no |
+| dns\_cache | (Beta) The status of the NodeLocal DNSCache addon. | bool | `"false"` | no |
 | enable\_binary\_authorization | Enable BinAuthZ Admission controller | string | `"false"` | no |
 | enable\_intranode\_visibility | Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network | bool | `"false"` | no |
 | enable\_kubernetes\_alpha | Whether to enable Kubernetes Alpha features for this cluster. Note that when this option is enabled, the cluster cannot be upgraded and will be automatically deleted after 30 days. | bool | `"false"` | no |
@@ -188,6 +190,7 @@ Then perform the following commands on the root folder:
 |------|-------------|
 | ca\_certificate | Cluster ca certificate (base64 encoded) |
 | cloudrun\_enabled | Whether CloudRun enabled |
+| dns\_cache\_enabled | Whether DNS Cache enabled |
 | endpoint | Cluster endpoint |
 | horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |
 | http\_load\_balancing\_enabled | Whether http load balancing enabled |

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -143,7 +143,9 @@ resource "google_container_cluster" "primary" {
       }
     }
 
-    dns_cache_config = var.dns_cache
+    dns_cache_config {
+      enabled = var.dns_cache
+    }
   }
 
   ip_allocation_policy {

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -142,6 +142,8 @@ resource "google_container_cluster" "primary" {
         disabled = cloudrun_config.value.disabled
       }
     }
+
+    dns_cache_config = var.dns_cache
   }
 
   ip_allocation_policy {

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -145,6 +145,7 @@ locals {
   # BETA features
   cluster_istio_enabled                    = ! local.cluster_output_istio_disabled
   cluster_cloudrun_enabled                 = var.cloudrun
+  cluster_dns_cache_enabled                = var.dns_cache
   cluster_pod_security_policy_enabled      = local.cluster_output_pod_security_policy_enabled
   cluster_intranode_visibility_enabled     = local.cluster_output_intranode_visbility_enabled
   cluster_vertical_pod_autoscaling_enabled = local.cluster_output_vertical_pod_autoscaling_enabled

--- a/modules/beta-public-cluster/outputs.tf
+++ b/modules/beta-public-cluster/outputs.tf
@@ -129,6 +129,11 @@ output "cloudrun_enabled" {
   value       = local.cluster_cloudrun_enabled
 }
 
+output "dns_cache_enabled" {
+  description = "Whether DNS Cache enabled"
+  value       = local.cluster_dns_cache_enabled
+}
+
 output "pod_security_policy_enabled" {
   description = "Whether pod security policy is enabled"
   value       = local.cluster_pod_security_policy_enabled

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -368,6 +368,12 @@ variable "istio_auth" {
   default     = "AUTH_MUTUAL_TLS"
 }
 
+variable "dns_cache" {
+  type        = bool
+  description = "(Beta) The status of the NodeLocal DNSCache addon."
+  default     = false
+}
+
 variable "database_encryption" {
   description = "Application-layer Secrets Encryption settings. The object format is {state = string, key_name = string}. Valid values of state are: \"ENCRYPTED\"; \"DECRYPTED\". key_name is the name of a CloudKMS key."
   type        = list(object({ state = string, key_name = string }))

--- a/modules/safer-cluster-update-variant/README.md
+++ b/modules/safer-cluster-update-variant/README.md
@@ -207,6 +207,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | database\_encryption | Application-layer Secrets Encryption settings. The object format is {state = string, key_name = string}. Valid values of state are: "ENCRYPTED"; "DECRYPTED". key_name is the name of a CloudKMS key. | object | `<list>` | no |
 | default\_max\_pods\_per\_node | The maximum number of pods to schedule per node | string | `"110"` | no |
 | description | The description of the cluster | string | `""` | no |
+| dns\_cache | (Beta) The status of the NodeLocal DNSCache addon. | bool | `"false"` | no |
 | enable\_intranode\_visibility | Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network | bool | `"false"` | no |
 | enable\_private\_endpoint | When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled. When false, either endpoint can be used. This field only applies to private clusters, when enable_private_nodes is true | bool | `"true"` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster. | bool | `"true"` | no |

--- a/modules/safer-cluster-update-variant/main.tf
+++ b/modules/safer-cluster-update-variant/main.tf
@@ -118,6 +118,8 @@ module "gke" {
 
   cloudrun = var.cloudrun
 
+  dns_cache = var.dns_cache
+
   default_max_pods_per_node = var.default_max_pods_per_node
 
   database_encryption = var.database_encryption

--- a/modules/safer-cluster-update-variant/variables.tf
+++ b/modules/safer-cluster-update-variant/variables.tf
@@ -237,6 +237,12 @@ variable "istio_auth" {
   default     = "AUTH_MUTUAL_TLS"
 }
 
+variable "dns_cache" {
+  type        = bool
+  description = "(Beta) The status of the NodeLocal DNSCache addon."
+  default     = false
+}
+
 variable "default_max_pods_per_node" {
   description = "The maximum number of pods to schedule per node"
   default     = 110

--- a/modules/safer-cluster/README.md
+++ b/modules/safer-cluster/README.md
@@ -207,6 +207,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | database\_encryption | Application-layer Secrets Encryption settings. The object format is {state = string, key_name = string}. Valid values of state are: "ENCRYPTED"; "DECRYPTED". key_name is the name of a CloudKMS key. | object | `<list>` | no |
 | default\_max\_pods\_per\_node | The maximum number of pods to schedule per node | string | `"110"` | no |
 | description | The description of the cluster | string | `""` | no |
+| dns\_cache | (Beta) The status of the NodeLocal DNSCache addon. | bool | `"false"` | no |
 | enable\_intranode\_visibility | Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network | bool | `"false"` | no |
 | enable\_private\_endpoint | When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled. When false, either endpoint can be used. This field only applies to private clusters, when enable_private_nodes is true | bool | `"true"` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster. | bool | `"true"` | no |

--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -118,6 +118,8 @@ module "gke" {
 
   cloudrun = var.cloudrun
 
+  dns_cache = var.dns_cache
+
   default_max_pods_per_node = var.default_max_pods_per_node
 
   database_encryption = var.database_encryption

--- a/modules/safer-cluster/variables.tf
+++ b/modules/safer-cluster/variables.tf
@@ -237,6 +237,12 @@ variable "istio_auth" {
   default     = "AUTH_MUTUAL_TLS"
 }
 
+variable "dns_cache" {
+  type        = bool
+  description = "(Beta) The status of the NodeLocal DNSCache addon."
+  default     = false
+}
+
 variable "default_max_pods_per_node" {
   description = "The maximum number of pods to schedule per node"
   default     = 110

--- a/test/fixtures/beta_cluster/main.tf
+++ b/test/fixtures/beta_cluster/main.tf
@@ -54,6 +54,8 @@ module "this" {
 
   cloudrun = true
 
+  dns_cache = true
+
   enable_binary_authorization = true
 
   pod_security_policy_config = [{

--- a/test/integration/beta_cluster/controls/gcloud.rb
+++ b/test/integration/beta_cluster/controls/gcloud.rb
@@ -58,6 +58,9 @@ control "gcloud" do
           "networkPolicyConfig" => {},
           "istioConfig" => {"auth"=>"AUTH_MUTUAL_TLS"},
           "cloudRunConfig" => {},
+          "dnsCacheConfig" => {
+            "enabled" => true,
+          }
         })
       end
 


### PR DESCRIPTION
Added support for NodeLocal DNSCache addon that came in provider version 3.14.0

https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/428

https://github.com/terraform-providers/terraform-provider-google/releases/tag/v3.14.0