### PR TITLE
Add peering_name output for private cluster modules

### DIFF
--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -106,7 +106,8 @@ locals {
   cluster_output_zones          = local.cluster_output_regional_zones
 
 {% if private_cluster %}
-  cluster_endpoint = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
+  cluster_endpoint     = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
+  cluster_peering_name = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? google_container_cluster.primary.private_cluster_config.0.peering_name : null
 {% else %}
   cluster_endpoint = google_container_cluster.primary.endpoint
 {% endif %}

--- a/autogen/main/outputs.tf.tmpl
+++ b/autogen/main/outputs.tf.tmpl
@@ -125,6 +125,10 @@ output "master_ipv4_cidr_block" {
   value       = var.master_ipv4_cidr_block
 }
 
+output "peering_name" {
+  description = "The name of the peering between this cluster and the Google owned VPC."
+  value       = local.cluster_peering_name
+}
 {% endif %}
 {% if beta_cluster %}
 

--- a/autogen/safer-cluster/outputs.tf.tmpl
+++ b/autogen/safer-cluster/outputs.tf.tmpl
@@ -121,3 +121,8 @@ output "master_ipv4_cidr_block" {
   description = "The IP range in CIDR notation used for the hosted master network"
   value       = var.master_ipv4_cidr_block
 }
+
+output "peering_name" {
+  description = "The name of the peering between this cluster and the Google owned VPC."
+  value       = module.gke.peering_name
+}

--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   region  = var.region
 }
 

--- a/examples/disable_client_cert/main.tf
+++ b/examples/disable_client_cert/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   region  = var.region
 }
 

--- a/examples/private_zonal_with_networking/outputs.tf
+++ b/examples/private_zonal_with_networking/outputs.tf
@@ -56,4 +56,7 @@ output "subnet_secondary_ranges" {
   value       = module.gcp-network.subnets_secondary_ranges
 }
 
-
+output "peering_name" {
+  description = "The name of the peering between this cluster and the Google owned VPC."
+  value       = module.gke.peering_name
+}

--- a/examples/regional_private_node_pool_oauth_scopes/provider.tf
+++ b/examples/regional_private_node_pool_oauth_scopes/provider.tf
@@ -15,9 +15,9 @@
  */
 
 provider "google" {
-  version = "3.3.0"
+  version = "3.14.0"
 }
 
 provider "google-beta" {
-  version = "3.3.0"
+  version = "3.14.0"
 }

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   region  = var.region
 }
 

--- a/examples/simple_regional/main.tf
+++ b/examples/simple_regional/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_private/main.tf
+++ b/examples/simple_regional_private/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_with_networking/main.tf
+++ b/examples/simple_regional_with_networking/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
 }
 
 module "gcp-network" {

--- a/examples/simple_zonal_private/main.tf
+++ b/examples/simple_zonal_private/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   region  = var.region
 }
 

--- a/examples/simple_zonal_with_acm/main.tf
+++ b/examples/simple_zonal_with_acm/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   region  = var.region
 }
 

--- a/examples/stub_domains/main.tf
+++ b/examples/stub_domains/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   region  = var.region
 }
 

--- a/examples/stub_domains_private/main.tf
+++ b/examples/stub_domains_private/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   region  = var.region
 }
 

--- a/examples/stub_domains_upstream_nameservers/main.tf
+++ b/examples/stub_domains_upstream_nameservers/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   region  = var.region
 }
 

--- a/examples/upstream_nameservers/main.tf
+++ b/examples/upstream_nameservers/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   region  = var.region
 }
 

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -252,6 +252,7 @@ Then perform the following commands on the root folder:
 | network\_policy\_enabled | Whether network policy enabled |
 | node\_pools\_names | List of node pools names |
 | node\_pools\_versions | List of node pools versions |
+| peering\_name | The name of the peering between this cluster and the Google owned VPC. |
 | pod\_security\_policy\_enabled | Whether pod security policy is enabled |
 | region | Cluster region |
 | release\_channel | The release channel of this cluster |

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -97,7 +97,8 @@ locals {
   cluster_output_zonal_zones    = local.zone_count > 1 ? slice(var.zones, 1, local.zone_count) : []
   cluster_output_zones          = local.cluster_output_regional_zones
 
-  cluster_endpoint = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
+  cluster_endpoint     = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
+  cluster_peering_name = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? google_container_cluster.primary.private_cluster_config.0.peering_name : null
 
   cluster_output_master_auth                        = concat(google_container_cluster.primary.*.master_auth, [])
   cluster_output_master_version                     = google_container_cluster.primary.master_version

--- a/modules/beta-private-cluster-update-variant/outputs.tf
+++ b/modules/beta-private-cluster-update-variant/outputs.tf
@@ -124,6 +124,10 @@ output "master_ipv4_cidr_block" {
   value       = var.master_ipv4_cidr_block
 }
 
+output "peering_name" {
+  description = "The name of the peering between this cluster and the Google owned VPC."
+  value       = local.cluster_peering_name
+}
 
 output "istio_enabled" {
   description = "Whether Istio is enabled"

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -230,6 +230,7 @@ Then perform the following commands on the root folder:
 | network\_policy\_enabled | Whether network policy enabled |
 | node\_pools\_names | List of node pools names |
 | node\_pools\_versions | List of node pools versions |
+| peering\_name | The name of the peering between this cluster and the Google owned VPC. |
 | pod\_security\_policy\_enabled | Whether pod security policy is enabled |
 | region | Cluster region |
 | release\_channel | The release channel of this cluster |

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -97,7 +97,8 @@ locals {
   cluster_output_zonal_zones    = local.zone_count > 1 ? slice(var.zones, 1, local.zone_count) : []
   cluster_output_zones          = local.cluster_output_regional_zones
 
-  cluster_endpoint = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
+  cluster_endpoint     = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
+  cluster_peering_name = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? google_container_cluster.primary.private_cluster_config.0.peering_name : null
 
   cluster_output_master_auth                        = concat(google_container_cluster.primary.*.master_auth, [])
   cluster_output_master_version                     = google_container_cluster.primary.master_version

--- a/modules/beta-private-cluster/outputs.tf
+++ b/modules/beta-private-cluster/outputs.tf
@@ -124,6 +124,10 @@ output "master_ipv4_cidr_block" {
   value       = var.master_ipv4_cidr_block
 }
 
+output "peering_name" {
+  description = "The name of the peering between this cluster and the Google owned VPC."
+  value       = local.cluster_peering_name
+}
 
 output "istio_enabled" {
   description = "Whether Istio is enabled"

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -210,6 +210,7 @@ Then perform the following commands on the root folder:
 | network\_policy\_enabled | Whether network policy enabled |
 | node\_pools\_names | List of node pools names |
 | node\_pools\_versions | List of node pools versions |
+| peering\_name | The name of the peering between this cluster and the Google owned VPC. |
 | region | Cluster region |
 | service\_account | The service account to default running nodes as if not overridden in `node_pools`. |
 | type | Cluster type (regional / zonal) |

--- a/modules/private-cluster-update-variant/main.tf
+++ b/modules/private-cluster-update-variant/main.tf
@@ -73,7 +73,8 @@ locals {
   cluster_output_zonal_zones    = local.zone_count > 1 ? slice(var.zones, 1, local.zone_count) : []
   cluster_output_zones          = local.cluster_output_regional_zones
 
-  cluster_endpoint = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
+  cluster_endpoint     = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
+  cluster_peering_name = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? google_container_cluster.primary.private_cluster_config.0.peering_name : null
 
   cluster_output_master_auth                        = concat(google_container_cluster.primary.*.master_auth, [])
   cluster_output_master_version                     = google_container_cluster.primary.master_version

--- a/modules/private-cluster-update-variant/outputs.tf
+++ b/modules/private-cluster-update-variant/outputs.tf
@@ -124,3 +124,7 @@ output "master_ipv4_cidr_block" {
   value       = var.master_ipv4_cidr_block
 }
 
+output "peering_name" {
+  description = "The name of the peering between this cluster and the Google owned VPC."
+  value       = local.cluster_peering_name
+}

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -188,6 +188,7 @@ Then perform the following commands on the root folder:
 | network\_policy\_enabled | Whether network policy enabled |
 | node\_pools\_names | List of node pools names |
 | node\_pools\_versions | List of node pools versions |
+| peering\_name | The name of the peering between this cluster and the Google owned VPC. |
 | region | Cluster region |
 | service\_account | The service account to default running nodes as if not overridden in `node_pools`. |
 | type | Cluster type (regional / zonal) |

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -73,7 +73,8 @@ locals {
   cluster_output_zonal_zones    = local.zone_count > 1 ? slice(var.zones, 1, local.zone_count) : []
   cluster_output_zones          = local.cluster_output_regional_zones
 
-  cluster_endpoint = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
+  cluster_endpoint     = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? (var.deploy_using_private_endpoint ? google_container_cluster.primary.private_cluster_config.0.private_endpoint : google_container_cluster.primary.private_cluster_config.0.public_endpoint) : google_container_cluster.primary.endpoint
+  cluster_peering_name = (var.enable_private_nodes && length(google_container_cluster.primary.private_cluster_config) > 0) ? google_container_cluster.primary.private_cluster_config.0.peering_name : null
 
   cluster_output_master_auth                        = concat(google_container_cluster.primary.*.master_auth, [])
   cluster_output_master_version                     = google_container_cluster.primary.master_version

--- a/modules/private-cluster/outputs.tf
+++ b/modules/private-cluster/outputs.tf
@@ -124,3 +124,7 @@ output "master_ipv4_cidr_block" {
   value       = var.master_ipv4_cidr_block
 }
 
+output "peering_name" {
+  description = "The name of the peering between this cluster and the Google owned VPC."
+  value       = local.cluster_peering_name
+}

--- a/modules/safer-cluster-update-variant/README.md
+++ b/modules/safer-cluster-update-variant/README.md
@@ -268,6 +268,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | network\_policy\_enabled | Whether network policy enabled |
 | node\_pools\_names | List of node pools names |
 | node\_pools\_versions | List of node pools versions |
+| peering\_name | The name of the peering between this cluster and the Google owned VPC. |
 | region | Cluster region |
 | service\_account | The service account to default running nodes as if not overridden in `node_pools`. |
 | type | Cluster type (regional / zonal) |

--- a/modules/safer-cluster-update-variant/outputs.tf
+++ b/modules/safer-cluster-update-variant/outputs.tf
@@ -121,3 +121,8 @@ output "master_ipv4_cidr_block" {
   description = "The IP range in CIDR notation used for the hosted master network"
   value       = var.master_ipv4_cidr_block
 }
+
+output "peering_name" {
+  description = "The name of the peering between this cluster and the Google owned VPC."
+  value       = module.gke.peering_name
+}

--- a/modules/safer-cluster/README.md
+++ b/modules/safer-cluster/README.md
@@ -268,6 +268,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | network\_policy\_enabled | Whether network policy enabled |
 | node\_pools\_names | List of node pools names |
 | node\_pools\_versions | List of node pools versions |
+| peering\_name | The name of the peering between this cluster and the Google owned VPC. |
 | region | Cluster region |
 | service\_account | The service account to default running nodes as if not overridden in `node_pools`. |
 | type | Cluster type (regional / zonal) |

--- a/modules/safer-cluster/outputs.tf
+++ b/modules/safer-cluster/outputs.tf
@@ -121,3 +121,8 @@ output "master_ipv4_cidr_block" {
   description = "The IP range in CIDR notation used for the hosted master network"
   value       = var.master_ipv4_cidr_block
 }
+
+output "peering_name" {
+  description = "The name of the peering between this cluster and the Google owned VPC."
+  value       = module.gke.peering_name
+}

--- a/test/fixtures/deploy_service/network.tf
+++ b/test/fixtures/deploy_service/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/disable_client_cert/network.tf
+++ b/test/fixtures/disable_client_cert/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/private_zonal_with_networking/outputs.tf
+++ b/test/fixtures/private_zonal_with_networking/outputs.tf
@@ -71,3 +71,7 @@ output "ip_range_services_name" {
   description = "The secondary range name for services"
   value       = module.example.ip_range_services_name
 }
+output "peering_name" {
+  description = "The name of the peering between this cluster and the Google owned VPC."
+  value       = module.example.peering_name
+}

--- a/test/fixtures/shared_vpc/network.tf
+++ b/test/fixtures/shared_vpc/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/simple_regional/network.tf
+++ b/test/fixtures/simple_regional/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/simple_zonal/network.tf
+++ b/test/fixtures/simple_zonal/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   project = var.project_ids[1]
 }
 

--- a/test/fixtures/stub_domains/network.tf
+++ b/test/fixtures/stub_domains/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   project = var.project_ids[1]
 }
 

--- a/test/fixtures/stub_domains_upstream_nameservers/network.tf
+++ b/test/fixtures/stub_domains_upstream_nameservers/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   project = var.project_ids[1]
 }
 

--- a/test/fixtures/upstream_nameservers/network.tf
+++ b/test/fixtures/upstream_nameservers/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.14.0"
   project = var.project_ids[1]
 }
 

--- a/test/integration/private_zonal_with_networking/controls/gcloud.rb
+++ b/test/integration/private_zonal_with_networking/controls/gcloud.rb
@@ -15,6 +15,7 @@
 project_id = attribute('project_id')
 location = attribute('location')
 cluster_name = attribute('cluster_name')
+peering_name = attribute('peering_name')
 
 control "gcloud" do
   title "Google Compute Engine GKE configuration"
@@ -49,6 +50,10 @@ control "gcloud" do
 
       it "uses private nodes" do
         expect(data['privateClusterConfig']['enablePrivateNodes']).to eq true
+      end
+
+      it "has corresponding peering name" do
+        expect(data['privateClusterConfig']['peeringName']).to eq peering_name
       end
 
       it "has the expected addon settings" do

--- a/test/integration/private_zonal_with_networking/inspec.yml
+++ b/test/integration/private_zonal_with_networking/inspec.yml
@@ -34,3 +34,6 @@ attributes:
   - name: ip_range_services_name
     required: true
     type: string
+  - name: peering_name
+    required: true
+    type: string


### PR DESCRIPTION
fixes #483 
Surface `peering_name` as an output for private gke modules inorder to pass it to `google_compute_network_peering_routes_config` and [support this use case](https://www.terraform.io/docs/providers/google/r/compute_network_peering_routes_config.html#example-usage-network-peering-routes-config-gke).