### PR TITLE
Add roles/stackdriver.resourceMetadata.writer to SA

### DIFF
--- a/autogen/main/sa.tf.tmpl
+++ b/autogen/main/sa.tf.tmpl
@@ -62,6 +62,13 @@ resource "google_project_iam_member" "cluster_service_account-monitoring_viewer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
+resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
+  count   = var.create_service_account ? 1 : 0
+  project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
 resource "google_project_iam_member" "cluster_service_account-gcr" {
   count   = var.create_service_account && var.grant_registry_access ? 1 : 0
   project = var.registry_project_id == "" ? var.project_id : var.registry_project_id

--- a/modules/beta-private-cluster-update-variant/sa.tf
+++ b/modules/beta-private-cluster-update-variant/sa.tf
@@ -62,6 +62,13 @@ resource "google_project_iam_member" "cluster_service_account-monitoring_viewer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
+resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
+  count   = var.create_service_account ? 1 : 0
+  project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
 resource "google_project_iam_member" "cluster_service_account-gcr" {
   count   = var.create_service_account && var.grant_registry_access ? 1 : 0
   project = var.registry_project_id == "" ? var.project_id : var.registry_project_id

--- a/modules/beta-private-cluster/sa.tf
+++ b/modules/beta-private-cluster/sa.tf
@@ -62,6 +62,13 @@ resource "google_project_iam_member" "cluster_service_account-monitoring_viewer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
+resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
+  count   = var.create_service_account ? 1 : 0
+  project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
 resource "google_project_iam_member" "cluster_service_account-gcr" {
   count   = var.create_service_account && var.grant_registry_access ? 1 : 0
   project = var.registry_project_id == "" ? var.project_id : var.registry_project_id

--- a/modules/beta-public-cluster/sa.tf
+++ b/modules/beta-public-cluster/sa.tf
@@ -62,6 +62,13 @@ resource "google_project_iam_member" "cluster_service_account-monitoring_viewer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
+resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
+  count   = var.create_service_account ? 1 : 0
+  project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
 resource "google_project_iam_member" "cluster_service_account-gcr" {
   count   = var.create_service_account && var.grant_registry_access ? 1 : 0
   project = var.registry_project_id == "" ? var.project_id : var.registry_project_id

--- a/modules/private-cluster-update-variant/sa.tf
+++ b/modules/private-cluster-update-variant/sa.tf
@@ -62,6 +62,13 @@ resource "google_project_iam_member" "cluster_service_account-monitoring_viewer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
+resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
+  count   = var.create_service_account ? 1 : 0
+  project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
 resource "google_project_iam_member" "cluster_service_account-gcr" {
   count   = var.create_service_account && var.grant_registry_access ? 1 : 0
   project = var.registry_project_id == "" ? var.project_id : var.registry_project_id

--- a/modules/private-cluster/sa.tf
+++ b/modules/private-cluster/sa.tf
@@ -62,6 +62,13 @@ resource "google_project_iam_member" "cluster_service_account-monitoring_viewer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
+resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
+  count   = var.create_service_account ? 1 : 0
+  project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
 resource "google_project_iam_member" "cluster_service_account-gcr" {
   count   = var.create_service_account && var.grant_registry_access ? 1 : 0
   project = var.registry_project_id == "" ? var.project_id : var.registry_project_id

--- a/sa.tf
+++ b/sa.tf
@@ -62,6 +62,13 @@ resource "google_project_iam_member" "cluster_service_account-monitoring_viewer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
+resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
+  count   = var.create_service_account ? 1 : 0
+  project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
+  role    = "roles/stackdriver.resourceMetadata.writer"
+  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
 resource "google_project_iam_member" "cluster_service_account-gcr" {
   count   = var.create_service_account && var.grant_registry_access ? 1 : 0
   project = var.registry_project_id == "" ? var.project_id : var.registry_project_id


### PR DESCRIPTION
fixes #473 

- `roles/stackdriver.resourceMetadata.writer` is needed for stackdriver-metadata-agent  to send metadata as explained at the[ bottom of this page](https://cloud.google.com/monitoring/kubernetes-engine/observing).