### PR TITLE
Fixes #489 Identity namespace output for beta clusters

### DIFF
--- a/autogen/main/outputs.tf.tmpl
+++ b/autogen/main/outputs.tf.tmpl
@@ -169,7 +169,7 @@ output "release_channel" {
 
 output "identity_namespace" {
   description = "Workload Identity namespace"
-  value       = var.identity_namespace
+  value       = length(local.cluster_workload_identity_config) > 0 ? local.local.cluster_workload_identity_config[0].identity_namespace : null
   depends_on = [
     google_container_cluster.primary
   ]

--- a/autogen/main/outputs.tf.tmpl
+++ b/autogen/main/outputs.tf.tmpl
@@ -169,7 +169,7 @@ output "release_channel" {
 
 output "identity_namespace" {
   description = "Workload Identity namespace"
-  value       = length(local.cluster_workload_identity_config) > 0 ? local.local.cluster_workload_identity_config[0].identity_namespace : null
+  value       = length(local.cluster_workload_identity_config) > 0 ? local.cluster_workload_identity_config[0].identity_namespace : null
   depends_on = [
     google_container_cluster.primary
   ]

--- a/examples/simple_regional_beta/README.md
+++ b/examples/simple_regional_beta/README.md
@@ -36,6 +36,7 @@ This example illustrates how to create a simple cluster with beta features.
 | ca\_certificate |  |
 | client\_token |  |
 | cluster\_name | Cluster name |
+| identity\_namespace |  |
 | ip\_range\_pods | The secondary IP range used for pods |
 | ip\_range\_services | The secondary IP range used for services |
 | kubernetes\_endpoint |  |

--- a/examples/simple_regional_beta/test_outputs.tf
+++ b/examples/simple_regional_beta/test_outputs.tf
@@ -61,3 +61,7 @@ output "master_kubernetes_version" {
   description = "The master Kubernetes version"
   value       = module.gke.master_version
 }
+
+output "identity_namespace" {
+  value = module.gke.identity_namespace
+}

--- a/modules/beta-private-cluster-update-variant/outputs.tf
+++ b/modules/beta-private-cluster-update-variant/outputs.tf
@@ -166,7 +166,7 @@ output "release_channel" {
 
 output "identity_namespace" {
   description = "Workload Identity namespace"
-  value       = var.identity_namespace
+  value       = length(local.cluster_workload_identity_config) > 0 ? local.local.cluster_workload_identity_config[0].identity_namespace : null
   depends_on = [
     google_container_cluster.primary
   ]

--- a/modules/beta-private-cluster-update-variant/outputs.tf
+++ b/modules/beta-private-cluster-update-variant/outputs.tf
@@ -166,7 +166,7 @@ output "release_channel" {
 
 output "identity_namespace" {
   description = "Workload Identity namespace"
-  value       = length(local.cluster_workload_identity_config) > 0 ? local.local.cluster_workload_identity_config[0].identity_namespace : null
+  value       = length(local.cluster_workload_identity_config) > 0 ? local.cluster_workload_identity_config[0].identity_namespace : null
   depends_on = [
     google_container_cluster.primary
   ]

--- a/modules/beta-private-cluster/outputs.tf
+++ b/modules/beta-private-cluster/outputs.tf
@@ -166,7 +166,7 @@ output "release_channel" {
 
 output "identity_namespace" {
   description = "Workload Identity namespace"
-  value       = var.identity_namespace
+  value       = length(local.cluster_workload_identity_config) > 0 ? local.local.cluster_workload_identity_config[0].identity_namespace : null
   depends_on = [
     google_container_cluster.primary
   ]

--- a/modules/beta-private-cluster/outputs.tf
+++ b/modules/beta-private-cluster/outputs.tf
@@ -166,7 +166,7 @@ output "release_channel" {
 
 output "identity_namespace" {
   description = "Workload Identity namespace"
-  value       = length(local.cluster_workload_identity_config) > 0 ? local.local.cluster_workload_identity_config[0].identity_namespace : null
+  value       = length(local.cluster_workload_identity_config) > 0 ? local.cluster_workload_identity_config[0].identity_namespace : null
   depends_on = [
     google_container_cluster.primary
   ]

--- a/modules/beta-public-cluster/outputs.tf
+++ b/modules/beta-public-cluster/outputs.tf
@@ -156,7 +156,7 @@ output "release_channel" {
 
 output "identity_namespace" {
   description = "Workload Identity namespace"
-  value       = var.identity_namespace
+  value       = length(local.cluster_workload_identity_config) > 0 ? local.cluster_workload_identity_config[0].identity_namespace : null
   depends_on = [
     google_container_cluster.primary
   ]

--- a/test/fixtures/beta_cluster/outputs.tf
+++ b/test/fixtures/beta_cluster/outputs.tf
@@ -82,3 +82,7 @@ output "service_account" {
 output "database_encryption_key_name" {
   value = google_kms_crypto_key.db.self_link
 }
+
+output "identity_namespace" {
+  value = module.this.identity_namespace
+}

--- a/test/integration/beta_cluster/controls/gcloud.rb
+++ b/test/integration/beta_cluster/controls/gcloud.rb
@@ -91,6 +91,13 @@ control "gcloud" do
           "keyName" => attribute('database_encryption_key_name'),
         })
       end
+
+      it "has the expected workload identity config" do
+        expect(data['workloadIdentityConfig']).to eq({
+          "identityNamespace" => attribute('identity_namespace'),
+          "workloadPool" => attribute('identity_namespace'),
+        })
+      end
     end
 
     describe "default node pool" do

--- a/test/integration/beta_cluster/inspec.yml
+++ b/test/integration/beta_cluster/inspec.yml
@@ -31,3 +31,6 @@ attributes:
   - name: database_encryption_key_name
     required: true
     type: string
+  - name: identity_namespace
+    required: true
+    type: string


### PR DESCRIPTION
The identity namespace flag was "enabled". Changed the output value to reference the actual identity namespace of the cluster / the project.

This PR fixes #489.