### PR TITLE
Enable GKE_METADATA_SERVER as node_metadata for beta-clusters (#490)

### DIFF
--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -454,7 +454,7 @@ variable "pod_security_policy_config" {
 
 variable "node_metadata" {
   description = "Specifies how node metadata is exposed to the workload running on the node"
-  default     = "SECURE"
+  default     = "GKE_METADATA_SERVER"
   type        = string
 }
 

--- a/examples/simple_regional_beta/README.md
+++ b/examples/simple_regional_beta/README.md
@@ -18,7 +18,6 @@ This example illustrates how to create a simple cluster with beta features.
 | ip\_range\_services | The secondary ip range to use for services | string | n/a | yes |
 | istio | Boolean to enable / disable Istio | string | `"true"` | no |
 | network | The VPC network to host the cluster in | string | n/a | yes |
-| node\_metadata | Specifies how node metadata is exposed to the workload running on the node | string | `"SECURE"` | no |
 | node\_pools | List of maps containing node pools | list(map(string)) | `<list>` | no |
 | pod\_security\_policy\_config | enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. | list | `<list>` | no |
 | project\_id | The project ID to host the cluster in | string | n/a | yes |

--- a/examples/simple_regional_beta/main.tf
+++ b/examples/simple_regional_beta/main.tf
@@ -40,7 +40,6 @@ module "gke" {
   cloudrun                    = var.cloudrun
   dns_cache                   = var.dns_cache
   gce_pd_csi_driver           = var.gce_pd_csi_driver
-  node_metadata               = var.node_metadata
   sandbox_enabled             = var.sandbox_enabled
   remove_default_node_pool    = var.remove_default_node_pool
   node_pools                  = var.node_pools

--- a/examples/simple_regional_beta/variables.tf
+++ b/examples/simple_regional_beta/variables.tf
@@ -69,12 +69,6 @@ variable "gce_pd_csi_driver" {
   default     = false
 }
 
-variable "node_metadata" {
-  description = "Specifies how node metadata is exposed to the workload running on the node"
-  default     = "SECURE"
-  type        = string
-}
-
 variable "sandbox_enabled" {
   type        = bool
   description = "(Beta) Enable GKE Sandbox (Do not forget to set `image_type` = `COS_CONTAINERD` and `node_version` = `1.12.7-gke.17` or later to use it)."

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -209,7 +209,7 @@ Then perform the following commands on the root folder:
 | network\_policy | Enable network policy addon | bool | `"true"` | no |
 | network\_policy\_provider | The network policy provider. | string | `"CALICO"` | no |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | string | `""` | no |
-| node\_metadata | Specifies how node metadata is exposed to the workload running on the node | string | `"SECURE"` | no |
+| node\_metadata | Specifies how node metadata is exposed to the workload running on the node | string | `"GKE_METADATA_SERVER"` | no |
 | node\_pools | List of maps containing node pools | list(map(string)) | `<list>` | no |
 | node\_pools\_labels | Map of maps containing node labels by node-pool name | map(map(string)) | `<map>` | no |
 | node\_pools\_metadata | Map of maps containing node metadata by node-pool name | map(map(string)) | `<map>` | no |

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -447,7 +447,7 @@ variable "pod_security_policy_config" {
 
 variable "node_metadata" {
   description = "Specifies how node metadata is exposed to the workload running on the node"
-  default     = "SECURE"
+  default     = "GKE_METADATA_SERVER"
   type        = string
 }
 

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -187,7 +187,7 @@ Then perform the following commands on the root folder:
 | network\_policy | Enable network policy addon | bool | `"true"` | no |
 | network\_policy\_provider | The network policy provider. | string | `"CALICO"` | no |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | string | `""` | no |
-| node\_metadata | Specifies how node metadata is exposed to the workload running on the node | string | `"SECURE"` | no |
+| node\_metadata | Specifies how node metadata is exposed to the workload running on the node | string | `"GKE_METADATA_SERVER"` | no |
 | node\_pools | List of maps containing node pools | list(map(string)) | `<list>` | no |
 | node\_pools\_labels | Map of maps containing node labels by node-pool name | map(map(string)) | `<map>` | no |
 | node\_pools\_metadata | Map of maps containing node metadata by node-pool name | map(map(string)) | `<map>` | no |

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -447,7 +447,7 @@ variable "pod_security_policy_config" {
 
 variable "node_metadata" {
   description = "Specifies how node metadata is exposed to the workload running on the node"
-  default     = "SECURE"
+  default     = "GKE_METADATA_SERVER"
   type        = string
 }
 

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -165,7 +165,7 @@ Then perform the following commands on the root folder:
 | network\_policy | Enable network policy addon | bool | `"true"` | no |
 | network\_policy\_provider | The network policy provider. | string | `"CALICO"` | no |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | string | `""` | no |
-| node\_metadata | Specifies how node metadata is exposed to the workload running on the node | string | `"SECURE"` | no |
+| node\_metadata | Specifies how node metadata is exposed to the workload running on the node | string | `"GKE_METADATA_SERVER"` | no |
 | node\_pools | List of maps containing node pools | list(map(string)) | `<list>` | no |
 | node\_pools\_labels | Map of maps containing node labels by node-pool name | map(map(string)) | `<map>` | no |
 | node\_pools\_metadata | Map of maps containing node metadata by node-pool name | map(map(string)) | `<map>` | no |

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -423,7 +423,7 @@ variable "pod_security_policy_config" {
 
 variable "node_metadata" {
   description = "Specifies how node metadata is exposed to the workload running on the node"
-  default     = "SECURE"
+  default     = "GKE_METADATA_SERVER"
   type        = string
 }
 

--- a/test/fixtures/beta_cluster/main.tf
+++ b/test/fixtures/beta_cluster/main.tf
@@ -63,8 +63,6 @@ module "this" {
   pod_security_policy_config = [{
     enabled = true
   }]
-
-  node_metadata = "EXPOSE"
 }
 
 data "google_client_config" "default" {

--- a/test/fixtures/sandbox_enabled/example.tf
+++ b/test/fixtures/sandbox_enabled/example.tf
@@ -27,7 +27,6 @@ module "example" {
   compute_engine_service_account = var.compute_engine_service_accounts[0]
   istio                          = false
   cloudrun                       = false
-  node_metadata                  = "UNSPECIFIED"
   sandbox_enabled                = true
   remove_default_node_pool       = true
 

--- a/test/integration/beta_cluster/controls/gcloud.rb
+++ b/test/integration/beta_cluster/controls/gcloud.rb
@@ -74,8 +74,9 @@ control "gcloud" do
       end
 
       it "has the expected nodeMetadata conseal config" do
-        expect(data['nodeConfig']['workloadMetadataConfig']).to include({
-          "nodeMetadata" => 'EXPOSE',
+        expect(data['nodeConfig']['workloadMetadataConfig']).to eq({
+          "mode" => "GKE_METADATA",
+          "nodeMetadata" => 'GKE_METADATA_SERVER',
         })
       end
 
@@ -206,6 +207,19 @@ control "gcloud" do
           including(
             "management" => including(
               "autoRepair" => true,
+            ),
+          )
+        )
+      end
+
+      it "has the expected node metadata for workload identity" do
+        expect(node_pools).to include(
+          including(
+            "config" => including(
+              "workloadMetadataConfig" => eq(
+                "mode" => "GKE_METADATA",
+                "nodeMetadata" => 'GKE_METADATA_SERVER',
+              ),
             ),
           )
         )


### PR DESCRIPTION
Fixes #490.

Since workload identity is enabled by default for beta-clusters, GKE_METADATA should be the default for exposing metadata to running pods as well in order to enabled workload identity in full.