### PR TITLE
Add boot_disk_kms_key variable for node pools

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -496,6 +496,8 @@ resource "google_container_node_pool" "pools" {
         sandbox_type = sandbox_config.value
       }
     }
+
+    boot_disk_kms_key = lookup(each.value, "boot_disk_kms_key", "")
     {% endif %}
 
     shielded_instance_config {

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -452,6 +452,8 @@ resource "google_container_node_pool" "pools" {
       }
     }
 
+    boot_disk_kms_key = lookup(each.value, "boot_disk_kms_key", "")
+
     shielded_instance_config {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -380,6 +380,8 @@ resource "google_container_node_pool" "pools" {
       }
     }
 
+    boot_disk_kms_key = lookup(each.value, "boot_disk_kms_key", "")
+
     shielded_instance_config {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -367,6 +367,8 @@ resource "google_container_node_pool" "pools" {
       }
     }
 
+    boot_disk_kms_key = lookup(each.value, "boot_disk_kms_key", "")
+
     shielded_instance_config {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)


### PR DESCRIPTION
Add support for boot_disk_kms_key for node pools that allows encrypting boot disks. Additional documentation available on https://cloud.google.com/kubernetes-engine/docs/how-to/using-cmek#gcloud_3