### PR TITLE
fix: Update auth module to handle empty clusters

### DIFF
--- a/modules/auth/main.tf
+++ b/modules/auth/main.tf
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+locals {
+  cluster_ca_certificate = data.google_container_cluster.gke_cluster.master_auth != null ? data.google_container_cluster.gke_cluster.master_auth[0].cluster_ca_certificate : ""
+  endpoint               = data.google_container_cluster.gke_cluster.endpoint != null ? data.google_container_cluster.gke_cluster.endpoint : ""
+  host                   = data.google_container_cluster.gke_cluster.endpoint != null ? "https://${data.google_container_cluster.gke_cluster.endpoint}" : ""
+  context                = data.google_container_cluster.gke_cluster.name != null ? data.google_container_cluster.gke_cluster.name : ""
+}
+
 data "google_container_cluster" "gke_cluster" {
   name     = var.cluster_name
   location = var.location
@@ -26,9 +33,9 @@ data "template_file" "kubeconfig" {
   template = file("${path.module}/templates/kubeconfig-template.yaml.tpl")
 
   vars = {
-    context                = data.google_container_cluster.gke_cluster.name
-    cluster_ca_certificate = data.google_container_cluster.gke_cluster.master_auth[0].cluster_ca_certificate
-    endpoint               = data.google_container_cluster.gke_cluster.endpoint
+    context                = local.context
+    cluster_ca_certificate = local.cluster_ca_certificate
+    endpoint               = local.endpoint
     token                  = data.google_client_config.provider.access_token
   }
 }

--- a/modules/auth/outputs.tf
+++ b/modules/auth/outputs.tf
@@ -27,12 +27,12 @@ output "kubeconfig_raw" {
 output "cluster_ca_certificate" {
   sensitive   = true
   description = "The cluster_ca_certificate value for use with the kubernetes provider."
-  value       = base64decode(data.google_container_cluster.gke_cluster.master_auth[0].cluster_ca_certificate)
+  value       = base64decode(local.cluster_ca_certificate)
 }
 
 output "host" {
   description = "The host value for use with the kubernetes provider."
-  value       = "https://${data.google_container_cluster.gke_cluster.endpoint}"
+  value       = local.host
 }
 
 output "token" {


### PR DESCRIPTION
When cluster creation stalls out halfway, outputs will fail and block you out from plan/apply.