### PR TITLE
Support cluster with network outside of its own project

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -34,7 +34,7 @@ resource "google_container_cluster" "primary" {
   location          = local.location
   node_locations    = local.node_locations
   cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = "projects/${local.network_project_id}/global/networks/${var.network}"
+  network           = local.explicit_network
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -68,6 +68,7 @@ locals {
 
   custom_kube_dns_config      = length(keys(var.stub_domains)) > 0
   upstream_nameservers_config = length(var.upstream_nameservers) > 0
+  explicit_network            = length(var.network) > 9 && subst(var.network, 0, 9) == "projects/" ? var.network : "projects/${local.network_project_id}/global/networks/${var.network}"
   network_project_id          = var.network_project_id != "" ? var.network_project_id : var.project_id
   zone_count                  = length(var.zones)
   cluster_type                = var.regional ? "regional" : "zonal"

--- a/cluster.tf
+++ b/cluster.tf
@@ -30,7 +30,7 @@ resource "google_container_cluster" "primary" {
   location          = local.location
   node_locations    = local.node_locations
   cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = "projects/${local.network_project_id}/global/networks/${var.network}"
+  network           = local.explicit_network
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/main.tf
+++ b/main.tf
@@ -50,6 +50,7 @@ locals {
 
   custom_kube_dns_config      = length(keys(var.stub_domains)) > 0
   upstream_nameservers_config = length(var.upstream_nameservers) > 0
+  explicit_network            = length(var.network) > 9 && subst(var.network, 0, 9) == "projects/" ? var.network : "projects/${local.network_project_id}/global/networks/${var.network}"
   network_project_id          = var.network_project_id != "" ? var.network_project_id : var.project_id
   zone_count                  = length(var.zones)
   cluster_type                = var.regional ? "regional" : "zonal"

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -30,7 +30,7 @@ resource "google_container_cluster" "primary" {
   location          = local.location
   node_locations    = local.node_locations
   cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = "projects/${local.network_project_id}/global/networks/${var.network}"
+  network           = local.explicit_network
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -62,6 +62,7 @@ locals {
 
   custom_kube_dns_config      = length(keys(var.stub_domains)) > 0
   upstream_nameservers_config = length(var.upstream_nameservers) > 0
+  explicit_network            = length(var.network) > 9 && subst(var.network, 0, 9) == "projects/" ? var.network : "projects/${local.network_project_id}/global/networks/${var.network}"
   network_project_id          = var.network_project_id != "" ? var.network_project_id : var.project_id
   zone_count                  = length(var.zones)
   cluster_type                = var.regional ? "regional" : "zonal"

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -30,7 +30,7 @@ resource "google_container_cluster" "primary" {
   location          = local.location
   node_locations    = local.node_locations
   cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = "projects/${local.network_project_id}/global/networks/${var.network}"
+  network           = local.explicit_network
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -62,6 +62,7 @@ locals {
 
   custom_kube_dns_config      = length(keys(var.stub_domains)) > 0
   upstream_nameservers_config = length(var.upstream_nameservers) > 0
+  explicit_network            = length(var.network) > 9 && subst(var.network, 0, 9) == "projects/" ? var.network : "projects/${local.network_project_id}/global/networks/${var.network}"
   network_project_id          = var.network_project_id != "" ? var.network_project_id : var.project_id
   zone_count                  = length(var.zones)
   cluster_type                = var.regional ? "regional" : "zonal"

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -30,7 +30,7 @@ resource "google_container_cluster" "primary" {
   location          = local.location
   node_locations    = local.node_locations
   cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = "projects/${local.network_project_id}/global/networks/${var.network}"
+  network           = local.explicit_network
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -62,6 +62,7 @@ locals {
 
   custom_kube_dns_config      = length(keys(var.stub_domains)) > 0
   upstream_nameservers_config = length(var.upstream_nameservers) > 0
+  explicit_network            = length(var.network) > 9 && subst(var.network, 0, 9) == "projects/" ? var.network : "projects/${local.network_project_id}/global/networks/${var.network}"
   network_project_id          = var.network_project_id != "" ? var.network_project_id : var.project_id
   zone_count                  = length(var.zones)
   cluster_type                = var.regional ? "regional" : "zonal"

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -30,7 +30,7 @@ resource "google_container_cluster" "primary" {
   location          = local.location
   node_locations    = local.node_locations
   cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = "projects/${local.network_project_id}/global/networks/${var.network}"
+  network           = local.explicit_network
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/modules/private-cluster-update-variant/main.tf
+++ b/modules/private-cluster-update-variant/main.tf
@@ -50,6 +50,7 @@ locals {
 
   custom_kube_dns_config      = length(keys(var.stub_domains)) > 0
   upstream_nameservers_config = length(var.upstream_nameservers) > 0
+  explicit_network            = length(var.network) > 9 && subst(var.network, 0, 9) == "projects/" ? var.network : "projects/${local.network_project_id}/global/networks/${var.network}"
   network_project_id          = var.network_project_id != "" ? var.network_project_id : var.project_id
   zone_count                  = length(var.zones)
   cluster_type                = var.regional ? "regional" : "zonal"

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -30,7 +30,7 @@ resource "google_container_cluster" "primary" {
   location          = local.location
   node_locations    = local.node_locations
   cluster_ipv4_cidr = var.cluster_ipv4_cidr
-  network           = "projects/${local.network_project_id}/global/networks/${var.network}"
+  network           = local.explicit_network
 
   dynamic "network_policy" {
     for_each = local.cluster_network_policy

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -50,6 +50,7 @@ locals {
 
   custom_kube_dns_config      = length(keys(var.stub_domains)) > 0
   upstream_nameservers_config = length(var.upstream_nameservers) > 0
+  explicit_network            = length(var.network) > 9 && subst(var.network, 0, 9) == "projects/" ? var.network : "projects/${local.network_project_id}/global/networks/${var.network}"
   network_project_id          = var.network_project_id != "" ? var.network_project_id : var.project_id
   zone_count                  = length(var.zones)
   cluster_type                = var.regional ? "regional" : "zonal"


### PR DESCRIPTION
At present the network is assumed to be under `projects/${local.network_project_id}/global/networks/${var.network}` which is not always the case.

This PR checks to see if the specified network starts with `projects/` and if so treats it as an explicit network.