### PR TITLE
Add example for public beta upgrade variant

### DIFF
--- a/examples/node_pool_update_variant_public_beta/README.md
+++ b/examples/node_pool_update_variant_public_beta/README.md
@@ -1,0 +1,46 @@
+# Node Pool Cluster
+
+This example illustrates how to create a cluster with multiple custom node-pool configurations with node labels, taints, and network tags.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| cluster\_name\_suffix | A suffix to append to the default cluster name | `string` | `""` | no |
+| compute\_engine\_service\_account | Service account to associate to the nodes in the cluster | `any` | n/a | yes |
+| credentials\_path | The path to the GCP credentials JSON file | `any` | n/a | yes |
+| ip\_range\_pods | The secondary ip range to use for pods | `any` | n/a | yes |
+| ip\_range\_services | The secondary ip range to use for services | `any` | n/a | yes |
+| network | The VPC network to host the cluster in | `any` | n/a | yes |
+| project\_id | The project ID to host the cluster in | `any` | n/a | yes |
+| region | The region to host the cluster in | `any` | n/a | yes |
+| subnetwork | The subnetwork to host the cluster in | `any` | n/a | yes |
+| zones | The zone to host the cluster in (required if is a zonal cluster) | `list(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| ca\_certificate | n/a |
+| client\_token | n/a |
+| cluster\_name | Cluster name |
+| ip\_range\_pods | The secondary IP range used for pods |
+| ip\_range\_services | The secondary IP range used for services |
+| kubernetes\_endpoint | n/a |
+| location | n/a |
+| master\_kubernetes\_version | The master Kubernetes version |
+| network | n/a |
+| project\_id | n/a |
+| region | n/a |
+| service\_account | The service account to default running nodes as if not overridden in `node_pools`. |
+| subnetwork | n/a |
+| zones | List of zones in which the cluster resides |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+To provision this example, run the following from within this directory:
+- `terraform init` to get the plugins
+- `terraform plan` to see the infrastructure plan
+- `terraform apply` to apply the infrastructure build
+- `terraform destroy` to destroy the built infrastructure

--- a/examples/node_pool_update_variant_public_beta/data/shutdown-script.sh
+++ b/examples/node_pool_update_variant_public_beta/data/shutdown-script.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kubectl --kubeconfig=/var/lib/kubelet/kubeconfig drain --force=true --ignore-daemonsets=true --delete-local-data "$HOSTNAME"

--- a/examples/node_pool_update_variant_public_beta/main.tf
+++ b/examples/node_pool_update_variant_public_beta/main.tf
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  cluster_type = "node-pool-update-variant-public-beta"
+}
+
+provider "google-beta" {
+  version     = "~> 3.42.0"
+  credentials = file(var.credentials_path)
+  region      = var.region
+}
+
+data "google_compute_subnetwork" "subnetwork" {
+  name    = var.subnetwork
+  project = var.project_id
+  region  = var.region
+}
+
+module "gke" {
+  source                 = "../../modules/beta-public-cluster-update-variant"
+  project_id             = var.project_id
+  name                   = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
+  region                 = var.region
+  zones                  = var.zones
+  network                = var.network
+  subnetwork             = var.subnetwork
+  ip_range_pods          = var.ip_range_pods
+  ip_range_services      = var.ip_range_services
+  create_service_account = false
+  service_account        = var.compute_engine_service_account
+
+  master_authorized_networks = [
+    {
+      cidr_block   = data.google_compute_subnetwork.subnetwork.ip_cidr_range
+      display_name = "VPC"
+    },
+  ]
+
+  node_pools = [
+    {
+      name            = "pool-01"
+      min_count       = 1
+      max_count       = 2
+      service_account = var.compute_engine_service_account
+      auto_upgrade    = true
+    },
+    {
+      name              = "pool-02"
+      machine_type      = "n1-standard-2"
+      min_count         = 1
+      max_count         = 2
+      disk_size_gb      = 30
+      disk_type         = "pd-standard"
+      accelerator_count = 1
+      accelerator_type  = "nvidia-tesla-p4"
+      image_type        = "COS"
+      auto_repair       = false
+      service_account   = var.compute_engine_service_account
+    },
+  ]
+
+  node_pools_oauth_scopes = {
+    all     = []
+    pool-01 = []
+    pool-02 = []
+  }
+
+  node_pools_metadata = {
+    all = {}
+    pool-01 = {
+      shutdown-script = file("${path.module}/data/shutdown-script.sh")
+    }
+    pool-02 = {}
+  }
+
+  node_pools_labels = {
+    all = {
+      all-pools-example = true
+    }
+    pool-01 = {
+      pool-01-example = true
+    }
+    pool-02 = {}
+  }
+
+  node_pools_taints = {
+    all = [
+      {
+        key    = "all-pools-example"
+        value  = true
+        effect = "PREFER_NO_SCHEDULE"
+      },
+    ]
+    pool-01 = [
+      {
+        key    = "pool-01-example"
+        value  = true
+        effect = "PREFER_NO_SCHEDULE"
+      },
+    ]
+    pool-02 = []
+  }
+
+  node_pools_tags = {
+    all = [
+      "all-node-example",
+    ]
+    pool-01 = [
+      "pool-01-example",
+    ]
+    pool-02 = []
+  }
+}
+
+data "google_client_config" "default" {
+}

--- a/examples/node_pool_update_variant_public_beta/outputs.tf
+++ b/examples/node_pool_update_variant_public_beta/outputs.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "kubernetes_endpoint" {
+  sensitive = true
+  value     = module.gke.endpoint
+}
+
+output "client_token" {
+  sensitive = true
+  value     = base64encode(data.google_client_config.default.access_token)
+}
+
+output "ca_certificate" {
+  value = module.gke.ca_certificate
+}
+
+output "service_account" {
+  description = "The service account to default running nodes as if not overridden in `node_pools`."
+  value       = module.gke.service_account
+}
+

--- a/examples/node_pool_update_variant_public_beta/test_outputs.tf
+++ b/examples/node_pool_update_variant_public_beta/test_outputs.tf
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// These outputs are used to test the module with kitchen-terraform
+// They do not need to be included in real-world uses of this module
+
+output "project_id" {
+  value = var.project_id
+}
+
+output "region" {
+  value = module.gke.region
+}
+
+output "cluster_name" {
+  description = "Cluster name"
+  value       = module.gke.name
+}
+
+output "network" {
+  value = var.network
+}
+
+output "subnetwork" {
+  value = var.subnetwork
+}
+
+output "location" {
+  value = module.gke.location
+}
+
+output "ip_range_pods" {
+  description = "The secondary IP range used for pods"
+  value       = var.ip_range_pods
+}
+
+output "ip_range_services" {
+  description = "The secondary IP range used for services"
+  value       = var.ip_range_services
+}
+
+output "zones" {
+  description = "List of zones in which the cluster resides"
+  value       = module.gke.zones
+}
+
+output "master_kubernetes_version" {
+  description = "The master Kubernetes version"
+  value       = module.gke.master_version
+}

--- a/examples/node_pool_update_variant_public_beta/variables.tf
+++ b/examples/node_pool_update_variant_public_beta/variables.tf
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The project ID to host the cluster in"
+}
+
+variable "credentials_path" {
+  description = "The path to the GCP credentials JSON file"
+}
+
+variable "cluster_name_suffix" {
+  description = "A suffix to append to the default cluster name"
+  default     = ""
+}
+
+variable "region" {
+  description = "The region to host the cluster in"
+}
+
+variable "zones" {
+  type        = list(string)
+  description = "The zone to host the cluster in (required if is a zonal cluster)"
+}
+
+variable "network" {
+  description = "The VPC network to host the cluster in"
+}
+
+variable "subnetwork" {
+  description = "The subnetwork to host the cluster in"
+}
+
+variable "ip_range_pods" {
+  description = "The secondary ip range to use for pods"
+}
+
+variable "ip_range_services" {
+  description = "The secondary ip range to use for services"
+}
+
+variable "compute_engine_service_account" {
+  description = "Service account to associate to the nodes in the cluster"
+}


### PR DESCRIPTION
As asked for in #546 (@morgante), this adds an example for the beta-public-update-variant module.

I copied the node_pool_update_variant_beta and removed the variables that do not exist.
Not quite sure if this works & is the way to go to be honest :-)