### PR TITLE
Fix CI test project creation issue

### DIFF
--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -16,18 +16,19 @@
 
 module "gke-project-1" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 3.0"
+  version = "~> 8.0"
 
-  name              = "ci-gke"
-  random_project_id = true
-  org_id            = var.org_id
-  folder_id         = var.folder_id
-  billing_account   = var.billing_account
+  name                 = "ci-gke"
+  random_project_id    = true
+  org_id               = var.org_id
+  folder_id            = var.folder_id
+  billing_account      = var.billing_account
+  skip_gcloud_download = true
 
   auto_create_network = true
 
   activate_apis = [
-    "bigquery-json.googleapis.com",
+    "bigquery.googleapis.com",
     "cloudkms.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "compute.googleapis.com",
@@ -44,16 +45,17 @@ module "gke-project-1" {
 
 module "gke-project-2" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 3.0"
+  version = "~> 8.0"
 
-  name              = "ci-gke"
-  random_project_id = true
-  org_id            = var.org_id
-  folder_id         = var.folder_id
-  billing_account   = var.billing_account
+  name                 = "ci-gke"
+  random_project_id    = true
+  org_id               = var.org_id
+  folder_id            = var.folder_id
+  billing_account      = var.billing_account
+  skip_gcloud_download = true
 
   activate_apis = [
-    "bigquery-json.googleapis.com",
+    "bigquery.googleapis.com",
     "cloudkms.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "compute.googleapis.com",

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -19,9 +19,9 @@ terraform {
 }
 
 provider "google" {
-  version = "2.20.1"
+  version = "3.25.0"
 }
 
 provider "google-beta" {
-  version = "3.21.0"
+  version = "3.25.0"
 }


### PR DESCRIPTION
Test project creation using PF [can be flaky ](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/559#issuecomment-643247733)due to https://github.com/terraform-providers/terraform-provider-google/issues/6377

This bumps the provider to a version with the fix and also a newer PF version.