### PR TITLE
Fix typo in README.md

### DIFF
--- a/autogen/safer-cluster/README.md
+++ b/autogen/safer-cluster/README.md
@@ -7,7 +7,7 @@ objects that permit a safer-than-default configuration.
 ## Module Usage
 
 The module fixes a set of parameters to values suggested in the
-[GKE harderning guide](https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster),
+[GKE hardening guide](https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster),
 the CIS framework, and other best practices.
 
 The motivation for each setting, and its relation to harderning guides or other recommendations

--- a/modules/asm/scripts/install_asm.sh
+++ b/modules/asm/scripts/install_asm.sh
@@ -45,7 +45,7 @@ if [[ -d ./asm-patch ]]; then
     echo "ASM patch directory exists. Skipping download..."
 else
     echo "Downloading ASM patch"
-    kpt pkg get https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages.git/asm-patch@release-1.5-asm .
+    kpt pkg get https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages.git/asm-patch@release-1.6-asm .
 fi
 gcloud beta anthos export "${CLUSTER_NAME}" --output-directory ${BASE_DIR} --project "${PROJECT_ID}" --location "${CLUSTER_LOCATION}"
 kpt cfg set asm-patch/ base-dir ../${BASE_DIR}

--- a/modules/binary-authorization/README.md
+++ b/modules/binary-authorization/README.md
@@ -35,6 +35,8 @@ module "quality-attestor" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | attestor-name | Name of the attestor | string | n/a | yes |
+| disable\_dependent\_services | Whether services that are enabled and which depend on this service should also be disabled when this service is destroyed. https://www.terraform.io/docs/providers/google/r/google_project_service.html#disable_dependent_services | bool | `"false"` | no |
+| disable\_services\_on\_destroy | Whether project services will be disabled when the resources are destroyed. https://www.terraform.io/docs/providers/google/r/google_project_service.html#disable_on_destroy | bool | `"false"` | no |
 | project\_id | Project ID to apply services into | string | n/a | yes |
 
 ## Outputs

--- a/modules/binary-authorization/main.tf
+++ b/modules/binary-authorization/main.tf
@@ -27,9 +27,11 @@ module "project-services" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
   version = "~> 8.0"
 
-  project_id = var.project_id
-
+  project_id    = var.project_id
   activate_apis = local.required_enabled_apis
+
+  disable_services_on_destroy = var.disable_services_on_destroy
+  disable_dependent_services  = var.disable_dependent_services
 }
 
 resource "google_binary_authorization_attestor" "attestor" {

--- a/modules/binary-authorization/variables.tf
+++ b/modules/binary-authorization/variables.tf
@@ -34,3 +34,15 @@ variable crypto-algorithm {
   default     = "RSA_SIGN_PKCS1_4096_SHA512"
   description = "Algorithm used for the async signing keys"
 }
+
+variable "disable_services_on_destroy" {
+  description = "Whether project services will be disabled when the resources are destroyed. https://www.terraform.io/docs/providers/google/r/google_project_service.html#disable_on_destroy"
+  default     = false
+  type        = bool
+}
+
+variable "disable_dependent_services" {
+  description = "Whether services that are enabled and which depend on this service should also be disabled when this service is destroyed. https://www.terraform.io/docs/providers/google/r/google_project_service.html#disable_dependent_services"
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
Updating the README.md file for safer-cluster in `autogen` - see https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/591 for context.