### PR TITLE
fix: Explicitly specify VPC-native clusters for beta modules.

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -171,6 +171,9 @@ resource "google_container_cluster" "primary" {
     {% endif %}
   }
 
+  {% if beta_cluster %}
+  networking_mode = "VPC_NATIVE"
+  {% endif %}
   ip_allocation_policy {
     cluster_secondary_range_name  = var.ip_range_pods
     services_secondary_range_name = var.ip_range_services

--- a/autogen/main/versions.tf.tmpl
+++ b/autogen/main/versions.tf.tmpl
@@ -19,7 +19,7 @@ terraform {
 
   required_providers {
 {% if beta_cluster %}
-    google-beta = ">= 3.23.0, <4.0.0"
+    google-beta = ">= 3.29.0, <4.0.0"
 {% else %}
     google = ">= 3.16, <4.0.0"
 {% endif %}

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.23.0"
+  version = "~> 3.29.0"
   region  = var.region
 }
 

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -48,6 +48,7 @@ module "gke" {
     },
     {
       name              = "pool-02"
+      machine_type      = "n1-standard-2"
       min_count         = 1
       max_count         = 2
       local_ssd_count   = 0

--- a/examples/node_pool_update_variant/main.tf
+++ b/examples/node_pool_update_variant/main.tf
@@ -63,6 +63,7 @@ module "gke" {
     },
     {
       name              = "pool-02"
+      machine_type      = "n1-standard-2"
       min_count         = 1
       max_count         = 2
       disk_size_gb      = 30

--- a/examples/node_pool_update_variant_beta/main.tf
+++ b/examples/node_pool_update_variant_beta/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version     = "~> 3.23.0"
+  version     = "~> 3.29.0"
   credentials = file(var.credentials_path)
   region      = var.region
 }

--- a/examples/node_pool_update_variant_beta/main.tf
+++ b/examples/node_pool_update_variant_beta/main.tf
@@ -64,6 +64,7 @@ module "gke" {
     },
     {
       name              = "pool-02"
+      machine_type      = "n1-standard-2"
       min_count         = 1
       max_count         = 2
       disk_size_gb      = 30

--- a/examples/regional_private_node_pool_oauth_scopes/provider.tf
+++ b/examples/regional_private_node_pool_oauth_scopes/provider.tf
@@ -15,9 +15,9 @@
  */
 
 provider "google" {
-  version = "3.16.0"
+  version = "~> 3.16.0"
 }
 
 provider "google-beta" {
-  version = "3.23.0"
+  version = "~> 3.29.0"
 }

--- a/examples/safer_cluster/main.tf
+++ b/examples/safer_cluster/main.tf
@@ -34,7 +34,7 @@ provider "google" {
 }
 
 provider "google-beta" {
-  version = "~> 3.23.0"
+  version = "~> 3.29.0"
 }
 
 module "gke" {

--- a/examples/safer_cluster_iap_bastion/cluster.tf
+++ b/examples/safer_cluster_iap_bastion/cluster.tf
@@ -15,8 +15,8 @@
  */
 
 module "gke" {
-  source                  = "terraform-google-modules/kubernetes-engine/google//modules/safer-cluster"
-  version                 = "~> 9.0"
+  source = "../../modules/safer-cluster"
+
   project_id              = module.enabled_google_apis.project_id
   name                    = var.cluster_name
   region                  = var.region

--- a/examples/safer_cluster_iap_bastion/provider.tf
+++ b/examples/safer_cluster_iap_bastion/provider.tf
@@ -15,9 +15,9 @@
  */
 
 provider "google" {
-  version = "~>  3.23"
+  version = "~> 3.29.0"
 }
 
 provider "google-beta" {
-  version = "~>  3.23"
+  version = "~> 3.29.0"
 }

--- a/examples/simple_regional_beta/main.tf
+++ b/examples/simple_regional_beta/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.23.0"
+  version = "~> 3.29.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_private_beta/main.tf
+++ b/examples/simple_regional_private_beta/main.tf
@@ -24,7 +24,7 @@ provider "google" {
 }
 
 provider "google-beta" {
-  version = "~> 3.23.0"
+  version = "~> 3.29.0"
   region  = var.region
 }
 

--- a/examples/simple_zonal_with_asm/main.tf
+++ b/examples/simple_zonal_with_asm/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.23.0"
+  version = "~> 3.29.0"
   region  = var.region
 }
 

--- a/examples/workload_metadata_config/main.tf
+++ b/examples/workload_metadata_config/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.23.0"
+  version = "~> 3.29.0"
   region  = var.region
 }
 

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -155,6 +155,7 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  networking_mode = "VPC_NATIVE"
   ip_allocation_policy {
     cluster_secondary_range_name  = var.ip_range_pods
     services_secondary_range_name = var.ip_range_services

--- a/modules/beta-private-cluster-update-variant/versions.tf
+++ b/modules/beta-private-cluster-update-variant/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    google-beta = ">= 3.23.0, <4.0.0"
+    google-beta = ">= 3.29.0, <4.0.0"
   }
 }

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -155,6 +155,7 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  networking_mode = "VPC_NATIVE"
   ip_allocation_policy {
     cluster_secondary_range_name  = var.ip_range_pods
     services_secondary_range_name = var.ip_range_services

--- a/modules/beta-private-cluster/versions.tf
+++ b/modules/beta-private-cluster/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    google-beta = ">= 3.23.0, <4.0.0"
+    google-beta = ">= 3.29.0, <4.0.0"
   }
 }

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -155,6 +155,7 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  networking_mode = "VPC_NATIVE"
   ip_allocation_policy {
     cluster_secondary_range_name  = var.ip_range_pods
     services_secondary_range_name = var.ip_range_services

--- a/modules/beta-public-cluster-update-variant/versions.tf
+++ b/modules/beta-public-cluster-update-variant/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    google-beta = ">= 3.23.0, <4.0.0"
+    google-beta = ">= 3.29.0, <4.0.0"
   }
 }

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -155,6 +155,7 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  networking_mode = "VPC_NATIVE"
   ip_allocation_policy {
     cluster_secondary_range_name  = var.ip_range_pods
     services_secondary_range_name = var.ip_range_services

--- a/modules/beta-public-cluster/versions.tf
+++ b/modules/beta-public-cluster/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    google-beta = ">= 3.23.0, <4.0.0"
+    google-beta = ">= 3.29.0, <4.0.0"
   }
 }

--- a/test/fixtures/sandbox_enabled/example.tf
+++ b/test/fixtures/sandbox_enabled/example.tf
@@ -32,8 +32,9 @@ module "example" {
 
   node_pools = [
     {
-      name       = "default-node-pool"
-      image_type = "COS_CONTAINERD"
+      name         = "default-node-pool"
+      image_type   = "COS_CONTAINERD"
+      machine_type = "n1-standard-2"
     },
   ]
 }

--- a/test/integration/node_pool/controls/gcloud.rb
+++ b/test/integration/node_pool/controls/gcloud.rb
@@ -190,7 +190,7 @@ control "gcloud" do
             including(
               "name" => "pool-02",
               "config" => including(
-                "machineType" => "e2-medium",
+                "machineType" => "n1-standard-2",
               ),
             )
           )


### PR DESCRIPTION
Fixes #593

BREAKING CHANGE: Minimum provider version for beta modules increased to v3.29.0.