### PR TITLE
Bump gcloud module to 1.3.0

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -542,7 +542,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 1.0.1"
+  version = "~> 1.3.0"
   enabled = var.skip_provisioners
 
   upgrade       = var.gcloud_upgrade

--- a/autogen/main/dns.tf.tmpl
+++ b/autogen/main/dns.tf.tmpl
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 1.0.1"
+  version               = "~> 1.3.0"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/cluster.tf
+++ b/cluster.tf
@@ -251,7 +251,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 1.0.1"
+  version = "~> 1.3.0"
   enabled = var.skip_provisioners
 
   upgrade       = var.gcloud_upgrade

--- a/dns.tf
+++ b/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 1.0.1"
+  version               = "~> 1.3.0"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -490,7 +490,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 1.0.1"
+  version = "~> 1.3.0"
   enabled = var.skip_provisioners
 
   upgrade       = var.gcloud_upgrade

--- a/modules/beta-private-cluster-update-variant/dns.tf
+++ b/modules/beta-private-cluster-update-variant/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 1.0.1"
+  version               = "~> 1.3.0"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -417,7 +417,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 1.0.1"
+  version = "~> 1.3.0"
   enabled = var.skip_provisioners
 
   upgrade       = var.gcloud_upgrade

--- a/modules/beta-private-cluster/dns.tf
+++ b/modules/beta-private-cluster/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 1.0.1"
+  version               = "~> 1.3.0"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -471,7 +471,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 1.0.1"
+  version = "~> 1.3.0"
   enabled = var.skip_provisioners
 
   upgrade       = var.gcloud_upgrade

--- a/modules/beta-public-cluster-update-variant/dns.tf
+++ b/modules/beta-public-cluster-update-variant/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 1.0.1"
+  version               = "~> 1.3.0"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -398,7 +398,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 1.0.1"
+  version = "~> 1.3.0"
   enabled = var.skip_provisioners
 
   upgrade       = var.gcloud_upgrade

--- a/modules/beta-public-cluster/dns.tf
+++ b/modules/beta-public-cluster/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 1.0.1"
+  version               = "~> 1.3.0"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -337,7 +337,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 1.0.1"
+  version = "~> 1.3.0"
   enabled = var.skip_provisioners
 
   upgrade       = var.gcloud_upgrade

--- a/modules/private-cluster-update-variant/dns.tf
+++ b/modules/private-cluster-update-variant/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 1.0.1"
+  version               = "~> 1.3.0"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -264,7 +264,7 @@ resource "google_container_node_pool" "pools" {
 
 module "gcloud_wait_for_cluster" {
   source  = "terraform-google-modules/gcloud/google"
-  version = "~> 1.0.1"
+  version = "~> 1.3.0"
   enabled = var.skip_provisioners
 
   upgrade       = var.gcloud_upgrade

--- a/modules/private-cluster/dns.tf
+++ b/modules/private-cluster/dns.tf
@@ -21,7 +21,7 @@
  *****************************************/
 module "gcloud_delete_default_kube_dns_configmap" {
   source                = "terraform-google-modules/gcloud/google"
-  version               = "~> 1.0.1"
+  version               = "~> 1.3.0"
   enabled               = (local.custom_kube_dns_config || local.upstream_nameservers_config) && ! var.skip_provisioners
   additional_components = ["kubectl"]
 


### PR DESCRIPTION
Old version wasn't working with version gcloud installed via `apt-get install` as it  is always trying to `gcloud component install` 