### PR TITLE
chore: relax tf version to allow 0.13

### DIFF
--- a/autogen/main/versions.tf.tmpl
+++ b/autogen/main/versions.tf.tmpl
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 
   required_providers {
 {% if beta_cluster %}

--- a/autogen/safer-cluster/versions.tf.tmpl
+++ b/autogen/safer-cluster/versions.tf.tmpl
@@ -17,5 +17,5 @@
 {{ autogeneration_note }}
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12, <0.14"
 }

--- a/examples/safer_cluster/versions.tf
+++ b/examples/safer_cluster/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12, <0.14"
 }

--- a/examples/simple_regional_beta/versions.tf
+++ b/examples/simple_regional_beta/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12, <0.14"
 }

--- a/examples/simple_regional_private_beta/versions.tf
+++ b/examples/simple_regional_private_beta/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12, <0.14"
 }

--- a/examples/simple_zonal_with_asm/versions.tf
+++ b/examples/simple_zonal_with_asm/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12, <0.14"
 }

--- a/examples/stub_domains_upstream_nameservers/versions.tf
+++ b/examples/stub_domains_upstream_nameservers/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12, <0.14"
 }

--- a/examples/upstream_nameservers/versions.tf
+++ b/examples/upstream_nameservers/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12, <0.14"
 }

--- a/examples/workload_metadata_config/versions.tf
+++ b/examples/workload_metadata_config/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12, <0.14"
 }

--- a/modules/beta-private-cluster-update-variant/versions.tf
+++ b/modules/beta-private-cluster-update-variant/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 
   required_providers {
     google-beta = ">= 3.29.0, <4.0.0"

--- a/modules/beta-private-cluster/versions.tf
+++ b/modules/beta-private-cluster/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 
   required_providers {
     google-beta = ">= 3.29.0, <4.0.0"

--- a/modules/beta-public-cluster-update-variant/versions.tf
+++ b/modules/beta-public-cluster-update-variant/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 
   required_providers {
     google-beta = ">= 3.29.0, <4.0.0"

--- a/modules/beta-public-cluster/versions.tf
+++ b/modules/beta-public-cluster/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 
   required_providers {
     google-beta = ">= 3.29.0, <4.0.0"

--- a/modules/private-cluster-update-variant/versions.tf
+++ b/modules/private-cluster-update-variant/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 
   required_providers {
     google = ">= 3.16, <4.0.0"

--- a/modules/private-cluster/versions.tf
+++ b/modules/private-cluster/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 
   required_providers {
     google = ">= 3.16, <4.0.0"

--- a/modules/safer-cluster-update-variant/versions.tf
+++ b/modules/safer-cluster-update-variant/versions.tf
@@ -17,5 +17,5 @@
 // This file was automatically generated from a template in ./autogen/safer-cluster
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12, <0.14"
 }

--- a/modules/safer-cluster/versions.tf
+++ b/modules/safer-cluster/versions.tf
@@ -17,5 +17,5 @@
 // This file was automatically generated from a template in ./autogen/safer-cluster
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12, <0.14"
 }

--- a/test/fixtures/stub_domains_upstream_nameservers/versions.tf
+++ b/test/fixtures/stub_domains_upstream_nameservers/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12, <0.14"
 }

--- a/test/fixtures/upstream_nameservers/versions.tf
+++ b/test/fixtures/upstream_nameservers/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12, <0.14"
 }

--- a/test/fixtures/workload_metadata_config/versions.tf
+++ b/test/fixtures/workload_metadata_config/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12, <0.14"
 }

--- a/test/integration/simple_zonal_with_asm/controls/gcloud.rb
+++ b/test/integration/simple_zonal_with_asm/controls/gcloud.rb
@@ -40,7 +40,7 @@ control "gcloud" do
     end
   end
 
-  describe command("gcloud container hub memberships describe gke-asm-membership --format=json") do
+  describe command("gcloud container hub memberships describe gke-asm-membership --project=#{project_id} --format=json") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq '' }
 

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">=0.12, <0.14"
 }
 
 provider "google" {

--- a/versions.tf
+++ b/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 
   required_providers {
     google = ">= 3.16, <4.0.0"


### PR DESCRIPTION
- relax version constraint to allow usage with 0.13
- Kitchen tests [run with `v0.13.0-rc1`](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/commit/88017ad3bc0d40473ac3d94546660328aeee878d) 
   - All tests pass except `safer_cluster`, `private_zonal_with_networking`, `simple_regional_with_networking`, `safer_cluster_iap_bastion` due to dependencies on other modules with version constraints
- module `for_each` and `depends_on` spot checked and seems to be working without issues
- small fix for GKE hub gcloud command