### PR TITLE
Set auto_provisioning_defaults.service_account

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -79,9 +79,13 @@ resource "google_container_cluster" "primary" {
   cluster_autoscaling {
     enabled = var.cluster_autoscaling.enabled
 {% if beta_cluster %}
-    auto_provisioning_defaults {
-      service_account = local.service_account
-      oauth_scopes = local.node_pools_oauth_scopes["all"]
+    dynamic "auto_provisioning_defaults" {
+      for_each = var.cluster_autoscaling.enabled ? [1] : []
+
+      content {
+        service_account = local.service_account
+        oauth_scopes = local.node_pools_oauth_scopes["all"]
+      }
     }
     autoscaling_profile = var.cluster_autoscaling.autoscaling_profile != null ? var.cluster_autoscaling.autoscaling_profile : "BALANCED"
 {% endif %}

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -77,8 +77,11 @@ resource "google_container_cluster" "primary" {
 {% endif %}
 
   cluster_autoscaling {
-    enabled             = var.cluster_autoscaling.enabled
+    enabled = var.cluster_autoscaling.enabled
 {% if beta_cluster %}
+    auto_provisioning_defaults {
+      service_account = local.service_account
+    }
     autoscaling_profile = var.cluster_autoscaling.autoscaling_profile != null ? var.cluster_autoscaling.autoscaling_profile : "BALANCED"
 {% endif %}
     dynamic "resource_limits" {

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -81,6 +81,7 @@ resource "google_container_cluster" "primary" {
 {% if beta_cluster %}
     auto_provisioning_defaults {
       service_account = local.service_account
+      oauth_scopes = var.cluster_autoscaling.oauth_scopes
     }
     autoscaling_profile = var.cluster_autoscaling.autoscaling_profile != null ? var.cluster_autoscaling.autoscaling_profile : "BALANCED"
 {% endif %}

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -81,7 +81,7 @@ resource "google_container_cluster" "primary" {
 {% if beta_cluster %}
     auto_provisioning_defaults {
       service_account = local.service_account
-      oauth_scopes = var.cluster_autoscaling.oauth_scopes
+      oauth_scopes = local.node_pools_oauth_scopes["all"]
     }
     autoscaling_profile = var.cluster_autoscaling.autoscaling_profile != null ? var.cluster_autoscaling.autoscaling_profile : "BALANCED"
 {% endif %}

--- a/autogen/main/sa.tf.tmpl
+++ b/autogen/main/sa.tf.tmpl
@@ -23,7 +23,7 @@ locals {
       ["dummy"],
     ),
   )
-  // if user set var.service_accont it will be used even if var.create_service_account==true, so service account will be created but not used
+  // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 }
 

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -225,7 +225,6 @@ variable "cluster_autoscaling" {
     max_cpu_cores       = number
     min_memory_gb       = number
     max_memory_gb       = number
-    oauth_scopes        = list(string)
   })
   default = {
     enabled             = false
@@ -236,10 +235,6 @@ variable "cluster_autoscaling" {
     min_cpu_cores       = 0
     max_memory_gb       = 0
     min_memory_gb       = 0
-    oauth_scopes        = [
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring"
-    ]
   }
   description = "Cluster autoscaling configuration. See [more details](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#clusterautoscaling)"
 }

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -225,6 +225,7 @@ variable "cluster_autoscaling" {
     max_cpu_cores       = number
     min_memory_gb       = number
     max_memory_gb       = number
+    oauth_scopes        = list(string)
   })
   default = {
     enabled             = false
@@ -235,6 +236,10 @@ variable "cluster_autoscaling" {
     min_cpu_cores       = 0
     max_memory_gb       = 0
     min_memory_gb       = 0
+    oauth_scopes        = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring"
+    ]
   }
   description = "Cluster autoscaling configuration. See [more details](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#clusterautoscaling)"
 }

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -66,7 +66,15 @@ resource "google_container_cluster" "primary" {
   monitoring_service = local.cluster_telemetry_type_is_set ? null : var.monitoring_service
 
   cluster_autoscaling {
-    enabled             = var.cluster_autoscaling.enabled
+    enabled = var.cluster_autoscaling.enabled
+    dynamic "auto_provisioning_defaults" {
+      for_each = var.cluster_autoscaling.enabled ? [1] : []
+
+      content {
+        service_account = local.service_account
+        oauth_scopes    = local.node_pools_oauth_scopes["all"]
+      }
+    }
     autoscaling_profile = var.cluster_autoscaling.autoscaling_profile != null ? var.cluster_autoscaling.autoscaling_profile : "BALANCED"
     dynamic "resource_limits" {
       for_each = local.autoscalling_resource_limits

--- a/modules/beta-private-cluster-update-variant/sa.tf
+++ b/modules/beta-private-cluster-update-variant/sa.tf
@@ -23,7 +23,7 @@ locals {
       ["dummy"],
     ),
   )
-  // if user set var.service_accont it will be used even if var.create_service_account==true, so service account will be created but not used
+  // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 }
 

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -66,7 +66,15 @@ resource "google_container_cluster" "primary" {
   monitoring_service = local.cluster_telemetry_type_is_set ? null : var.monitoring_service
 
   cluster_autoscaling {
-    enabled             = var.cluster_autoscaling.enabled
+    enabled = var.cluster_autoscaling.enabled
+    dynamic "auto_provisioning_defaults" {
+      for_each = var.cluster_autoscaling.enabled ? [1] : []
+
+      content {
+        service_account = local.service_account
+        oauth_scopes    = local.node_pools_oauth_scopes["all"]
+      }
+    }
     autoscaling_profile = var.cluster_autoscaling.autoscaling_profile != null ? var.cluster_autoscaling.autoscaling_profile : "BALANCED"
     dynamic "resource_limits" {
       for_each = local.autoscalling_resource_limits

--- a/modules/beta-private-cluster/sa.tf
+++ b/modules/beta-private-cluster/sa.tf
@@ -23,7 +23,7 @@ locals {
       ["dummy"],
     ),
   )
-  // if user set var.service_accont it will be used even if var.create_service_account==true, so service account will be created but not used
+  // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 }
 

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -66,7 +66,15 @@ resource "google_container_cluster" "primary" {
   monitoring_service = local.cluster_telemetry_type_is_set ? null : var.monitoring_service
 
   cluster_autoscaling {
-    enabled             = var.cluster_autoscaling.enabled
+    enabled = var.cluster_autoscaling.enabled
+    dynamic "auto_provisioning_defaults" {
+      for_each = var.cluster_autoscaling.enabled ? [1] : []
+
+      content {
+        service_account = local.service_account
+        oauth_scopes    = local.node_pools_oauth_scopes["all"]
+      }
+    }
     autoscaling_profile = var.cluster_autoscaling.autoscaling_profile != null ? var.cluster_autoscaling.autoscaling_profile : "BALANCED"
     dynamic "resource_limits" {
       for_each = local.autoscalling_resource_limits

--- a/modules/beta-public-cluster-update-variant/sa.tf
+++ b/modules/beta-public-cluster-update-variant/sa.tf
@@ -23,7 +23,7 @@ locals {
       ["dummy"],
     ),
   )
-  // if user set var.service_accont it will be used even if var.create_service_account==true, so service account will be created but not used
+  // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 }
 

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -66,7 +66,15 @@ resource "google_container_cluster" "primary" {
   monitoring_service = local.cluster_telemetry_type_is_set ? null : var.monitoring_service
 
   cluster_autoscaling {
-    enabled             = var.cluster_autoscaling.enabled
+    enabled = var.cluster_autoscaling.enabled
+    dynamic "auto_provisioning_defaults" {
+      for_each = var.cluster_autoscaling.enabled ? [1] : []
+
+      content {
+        service_account = local.service_account
+        oauth_scopes    = local.node_pools_oauth_scopes["all"]
+      }
+    }
     autoscaling_profile = var.cluster_autoscaling.autoscaling_profile != null ? var.cluster_autoscaling.autoscaling_profile : "BALANCED"
     dynamic "resource_limits" {
       for_each = local.autoscalling_resource_limits

--- a/modules/beta-public-cluster/sa.tf
+++ b/modules/beta-public-cluster/sa.tf
@@ -23,7 +23,7 @@ locals {
       ["dummy"],
     ),
   )
-  // if user set var.service_accont it will be used even if var.create_service_account==true, so service account will be created but not used
+  // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 }
 

--- a/modules/private-cluster-update-variant/sa.tf
+++ b/modules/private-cluster-update-variant/sa.tf
@@ -23,7 +23,7 @@ locals {
       ["dummy"],
     ),
   )
-  // if user set var.service_accont it will be used even if var.create_service_account==true, so service account will be created but not used
+  // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 }
 

--- a/modules/private-cluster/sa.tf
+++ b/modules/private-cluster/sa.tf
@@ -23,7 +23,7 @@ locals {
       ["dummy"],
     ),
   )
-  // if user set var.service_accont it will be used even if var.create_service_account==true, so service account will be created but not used
+  // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 }
 

--- a/sa.tf
+++ b/sa.tf
@@ -23,7 +23,7 @@ locals {
       ["dummy"],
     ),
   )
-  // if user set var.service_accont it will be used even if var.create_service_account==true, so service account will be created but not used
+  // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 }
 

--- a/test/integration/node_pool/controls/gcloud.rb
+++ b/test/integration/node_pool/controls/gcloud.rb
@@ -37,7 +37,7 @@ control "gcloud" do
       it "has the expected cluster autoscaling settings" do
         expect(data['autoscaling']).to eq({
             "autoprovisioningNodePoolDefaults" => {
-                "oauthScopes" => %w(https://www.googleapis.com/auth/logging.write https://www.googleapis.com/auth/monitoring),
+                "oauthScopes" => %w(https://www.googleapis.com/auth/cloud-platform),
                 "serviceAccount" => "default"
             },
             "autoscalingProfile" => "OPTIMIZE_UTILIZATION",


### PR DESCRIPTION
This sets the Service Account that should be used by node VMs created by
node auto-provisioning. This should cause the auto-provisioned nodes to
have the same permissions as the nodes that are manually provisioned.

This is to address #560. I will be testing this in my cluster that has NAP enabled. As far as I can tell, it's safe to set this value whether auto-provisioning is actually enabled or disabled, and that using `local.service_account` is the right default. That's the default for any manual `node_pool` that isn't specifically overridden.