### PR TITLE
bug: Bump providers, update ASM script

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -432,3 +432,5 @@ substitutions:
   _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'
 options:
   machineType: 'N1_HIGHCPU_8'
+  env:
+  - TF_LOG=DEBUG

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -432,5 +432,3 @@ substitutions:
   _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'
 options:
   machineType: 'N1_HIGHCPU_8'
-  env:
-  - TF_LOG=DEBUG

--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 

--- a/examples/disable_client_cert/main.tf
+++ b/examples/disable_client_cert/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.32.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 

--- a/examples/node_pool_update_variant/main.tf
+++ b/examples/node_pool_update_variant/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 

--- a/examples/node_pool_update_variant_beta/main.tf
+++ b/examples/node_pool_update_variant_beta/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version     = "~> 3.32.0"
+  version     = "~> 3.35.0"
   credentials = file(var.credentials_path)
   region      = var.region
 }

--- a/examples/regional_private_node_pool_oauth_scopes/provider.tf
+++ b/examples/regional_private_node_pool_oauth_scopes/provider.tf
@@ -15,9 +15,9 @@
  */
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
 }
 
 provider "google-beta" {
-  version = "~> 3.32.0"
+  version = "~> 3.35.0"
 }

--- a/examples/safer_cluster/main.tf
+++ b/examples/safer_cluster/main.tf
@@ -30,11 +30,11 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
 }
 
 provider "google-beta" {
-  version = "~> 3.32.0"
+  version = "~> 3.35.0"
 }
 
 module "gke" {

--- a/examples/safer_cluster_iap_bastion/provider.tf
+++ b/examples/safer_cluster_iap_bastion/provider.tf
@@ -15,9 +15,9 @@
  */
 
 provider "google" {
-  version = "~> 3.32.0"
+  version = "~> 3.35.0"
 }
 
 provider "google-beta" {
-  version = "~> 3.32.0"
+  version = "~> 3.35.0"
 }

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 

--- a/examples/simple_regional/main.tf
+++ b/examples/simple_regional/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_beta/main.tf
+++ b/examples/simple_regional_beta/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.32.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_private/main.tf
+++ b/examples/simple_regional_private/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_private_beta/main.tf
+++ b/examples/simple_regional_private_beta/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 
 provider "google-beta" {
-  version = "~> 3.32.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_with_kubeconfig/main.tf
+++ b/examples/simple_regional_with_kubeconfig/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_with_networking/main.tf
+++ b/examples/simple_regional_with_networking/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
 }
 
 module "gcp-network" {

--- a/examples/simple_zonal_private/main.tf
+++ b/examples/simple_zonal_private/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 

--- a/examples/simple_zonal_with_acm/main.tf
+++ b/examples/simple_zonal_with_acm/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 

--- a/examples/simple_zonal_with_asm/main.tf
+++ b/examples/simple_zonal_with_asm/main.tf
@@ -59,7 +59,6 @@ module "asm" {
   cluster_endpoint = module.gke.endpoint
   project_id       = var.project_id
   location         = module.gke.location
-  asm_version      = "6941cf9f714485518f3f87eb0eda0cd47ffb96e4"
 }
 
 data "google_client_config" "default" {

--- a/examples/simple_zonal_with_asm/main.tf
+++ b/examples/simple_zonal_with_asm/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.32.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 
@@ -59,6 +59,7 @@ module "asm" {
   cluster_endpoint = module.gke.endpoint
   project_id       = var.project_id
   location         = module.gke.location
+  asm_version      = "6941cf9f714485518f3f87eb0eda0cd47ffb96e4"
 }
 
 data "google_client_config" "default" {

--- a/examples/stub_domains/main.tf
+++ b/examples/stub_domains/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 

--- a/examples/stub_domains_private/main.tf
+++ b/examples/stub_domains_private/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 

--- a/examples/stub_domains_upstream_nameservers/main.tf
+++ b/examples/stub_domains_upstream_nameservers/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 

--- a/examples/upstream_nameservers/main.tf
+++ b/examples/upstream_nameservers/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 

--- a/examples/workload_identity/main.tf
+++ b/examples/workload_identity/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 

--- a/examples/workload_metadata_config/main.tf
+++ b/examples/workload_metadata_config/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.32.0"
+  version = "~> 3.35.0"
   region  = var.region
 }
 

--- a/modules/asm/scripts/install_asm.sh
+++ b/modules/asm/scripts/install_asm.sh
@@ -54,8 +54,12 @@ kpt cfg set asm-patch/ gcloud.core.project "${PROJECT_ID}"
 kpt cfg set asm-patch/ gcloud.container.cluster "${CLUSTER_NAME}"
 kpt cfg set asm-patch/ gcloud.compute.location "${CLUSTER_LOCATION}"
 kpt cfg list-setters asm-patch/
-pushd ${BASE_DIR} && kustomize create --autodetect --namespace "${PROJECT_ID}" && popd
-pushd asm-patch && kustomize build -o ../${BASE_DIR}/all.yaml && popd
+pushd ${BASE_DIR}
+kustomize create --autodetect --namespace "${PROJECT_ID}"
+popd
+pushd asm-patch
+kustomize build -o ../${BASE_DIR}/all.yaml
+popd
 # # skip validate as we should investigate if we can check this without having to resort to dind
 # if [[ ${SKIP_ASM_VALIDATION} ]]; then
 #  echo "Skipping ASM validation..."

--- a/test/fixtures/deploy_service/network.tf
+++ b/test/fixtures/deploy_service/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/disable_client_cert/network.tf
+++ b/test/fixtures/disable_client_cert/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/shared_vpc/network.tf
+++ b/test/fixtures/shared_vpc/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/simple_regional/network.tf
+++ b/test/fixtures/simple_regional/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/simple_regional_with_kubeconfig/network.tf
+++ b/test/fixtures/simple_regional_with_kubeconfig/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/simple_zonal/network.tf
+++ b/test/fixtures/simple_zonal/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   project = var.project_ids[1]
 }
 

--- a/test/fixtures/simple_zonal_with_asm/network.tf
+++ b/test/fixtures/simple_zonal_with_asm/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   project = var.project_ids[2]
 }
 

--- a/test/fixtures/stub_domains/network.tf
+++ b/test/fixtures/stub_domains/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   project = var.project_ids[1]
 }
 

--- a/test/fixtures/stub_domains_upstream_nameservers/network.tf
+++ b/test/fixtures/stub_domains_upstream_nameservers/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   project = var.project_ids[1]
 }
 

--- a/test/fixtures/upstream_nameservers/network.tf
+++ b/test/fixtures/upstream_nameservers/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.16.0"
+  version = "~> 3.35.0"
   project = var.project_ids[1]
 }
 

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -32,15 +32,9 @@ module "gke-project-1" {
   auto_create_network = true
 
   activate_apis = [
-    "bigquery.googleapis.com",
     "cloudkms.googleapis.com",
     "cloudresourcemanager.googleapis.com",
-    "compute.googleapis.com",
     "container.googleapis.com",
-    "containerregistry.googleapis.com",
-    "iam.googleapis.com",
-    "iamcredentials.googleapis.com",
-    "oslogin.googleapis.com",
     "pubsub.googleapis.com",
     "serviceusage.googleapis.com",
     "storage-api.googleapis.com",
@@ -59,15 +53,9 @@ module "gke-project-2" {
   skip_gcloud_download = true
 
   activate_apis = [
-    "bigquery.googleapis.com",
     "cloudkms.googleapis.com",
     "cloudresourcemanager.googleapis.com",
-    "compute.googleapis.com",
     "container.googleapis.com",
-    "containerregistry.googleapis.com",
-    "iam.googleapis.com",
-    "iamcredentials.googleapis.com",
-    "oslogin.googleapis.com",
     "pubsub.googleapis.com",
     "serviceusage.googleapis.com",
     "storage-api.googleapis.com",
@@ -87,17 +75,11 @@ module "gke-project-asm" {
   skip_gcloud_download = true
 
   activate_apis = [
-    "container.googleapis.com",
-    "compute.googleapis.com",
-    "monitoring.googleapis.com",
     "logging.googleapis.com",
     "meshca.googleapis.com",
     "meshtelemetry.googleapis.com",
     "meshconfig.googleapis.com",
-    "iamcredentials.googleapis.com",
     "anthos.googleapis.com",
-    "gkeconnect.googleapis.com",
-    "gkehub.googleapis.com",
     "cloudresourcemanager.googleapis.com",
   ]
 }


### PR DESCRIPTION
- ~~Pins ASM example to prevent CI breaking. ASM tracking issue: https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/issues/125~~ ASM Issue was fixed upstream
- Update script to not use `&&` as `set -e` [does not cause exit](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#set). 
- De dupe APIs for setup inorder to reduce test flakiness due to ` googleapi: Error 400: Another activation or deactivation is in progress for the following service`
- Bump all example provider version to "~> 3.35.0" 
