### PR TITLE
Expose service account variable

### DIFF
--- a/modules/asm/README.md
+++ b/modules/asm/README.md
@@ -51,6 +51,7 @@ To deploy this config:
 | internal\_ip | Use internal ip for the cluster endpoint. | bool | `"false"` | no |
 | location | The location (zone or region) this cluster has been created in. | string | n/a | yes |
 | project\_id | The project in which the resource belongs. | string | n/a | yes |
+| service\_account\_key\_file | Path to service account key file to auth as for running `gcloud container clusters get-credentials`. | string | `""` | no |
 | skip\_gcloud\_download | Whether to skip downloading gcloud (assumes gcloud and kubectl already available outside the module) | bool | `"true"` | no |
 
 ## Outputs

--- a/modules/asm/main.tf
+++ b/modules/asm/main.tf
@@ -19,13 +19,14 @@ module "asm_install" {
   version           = "~> 1.4"
   module_depends_on = [var.cluster_endpoint]
 
-  gcloud_sdk_version    = var.gcloud_sdk_version
-  skip_download         = var.skip_gcloud_download
-  upgrade               = true
-  additional_components = ["kubectl", "kpt", "beta", "kustomize"]
-  cluster_name          = var.cluster_name
-  cluster_location      = var.location
-  project_id            = var.project_id
+  gcloud_sdk_version       = var.gcloud_sdk_version
+  skip_download            = var.skip_gcloud_download
+  upgrade                  = true
+  additional_components    = ["kubectl", "kpt", "beta", "kustomize"]
+  cluster_name             = var.cluster_name
+  cluster_location         = var.location
+  project_id               = var.project_id
+  service_account_key_file = var.service_account_key_file
 
 
   kubectl_create_command  = "${path.module}/scripts/install_asm.sh ${var.project_id} ${var.cluster_name} ${var.location} ${var.asm_dir} ${var.asm_version}"

--- a/modules/asm/variables.tf
+++ b/modules/asm/variables.tf
@@ -81,3 +81,9 @@ variable "asm_version" {
   type        = string
   default     = "release-1.6-asm"
 }
+
+variable "service_account_key_file" {
+  description = "Path to service account key file to auth as for running `gcloud container clusters get-credentials`."
+  default     = ""
+}
+


### PR DESCRIPTION
Default service account will not necessarily have the required permissions to run kubectl commands. Expose service_account_key_file variable from kubectl_wrapper module to use with ASM module.