### PR TITLE
fix: docs generation, update private cluster docs to absolute

### DIFF
--- a/autogen/main/README.md
+++ b/autogen/main/README.md
@@ -13,7 +13,7 @@ Sub modules are provided from creating private clusters, beta private clusters, 
 
 {% if private_cluster %}
 ## Private Cluster Details
-For details on configuring private clusters with this module, check the [troubleshooting guide](../../docs/private_clusters.md).
+For details on configuring private clusters with this module, check the [troubleshooting guide](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/master/docs/private_clusters.md).
 
 {% endif %}
 {% if update_variant %}
@@ -48,7 +48,7 @@ This module is meant for use with Terraform 0.12. If you haven't
 intended for Terraform 0.11.x is [3.0.0].
 
 ## Usage
-There are multiple examples included in the [examples](./examples/) folder but simple usage is as follows:
+There are multiple examples included in the [examples](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/examples/) folder but simple usage is as follows:
 
 ```hcl
 module "gke" {

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -11,7 +11,7 @@ The resources/services/activations/deletions that this module will create/trigge
 Sub modules are provided from creating private clusters, beta private clusters, and beta public clusters as well.  Beta sub modules allow for the use of various GKE beta features. See the modules directory for the various sub modules.
 
 ## Private Cluster Details
-For details on configuring private clusters with this module, check the [troubleshooting guide](../../docs/private_clusters.md).
+For details on configuring private clusters with this module, check the [troubleshooting guide](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/master/docs/private_clusters.md).
 
 ## Node Pool Update Variant
 
@@ -43,7 +43,7 @@ This module is meant for use with Terraform 0.12. If you haven't
 intended for Terraform 0.11.x is [3.0.0].
 
 ## Usage
-There are multiple examples included in the [examples](./examples/) folder but simple usage is as follows:
+There are multiple examples included in the [examples](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/examples/) folder but simple usage is as follows:
 
 ```hcl
 module "gke" {

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -11,7 +11,7 @@ The resources/services/activations/deletions that this module will create/trigge
 Sub modules are provided from creating private clusters, beta private clusters, and beta public clusters as well.  Beta sub modules allow for the use of various GKE beta features. See the modules directory for the various sub modules.
 
 ## Private Cluster Details
-For details on configuring private clusters with this module, check the [troubleshooting guide](../../docs/private_clusters.md).
+For details on configuring private clusters with this module, check the [troubleshooting guide](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/master/docs/private_clusters.md).
 
 ## Compatibility
 
@@ -21,7 +21,7 @@ This module is meant for use with Terraform 0.12. If you haven't
 intended for Terraform 0.11.x is [3.0.0].
 
 ## Usage
-There are multiple examples included in the [examples](./examples/) folder but simple usage is as follows:
+There are multiple examples included in the [examples](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/examples/) folder but simple usage is as follows:
 
 ```hcl
 module "gke" {

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -40,7 +40,7 @@ This module is meant for use with Terraform 0.12. If you haven't
 intended for Terraform 0.11.x is [3.0.0].
 
 ## Usage
-There are multiple examples included in the [examples](./examples/) folder but simple usage is as follows:
+There are multiple examples included in the [examples](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/examples/) folder but simple usage is as follows:
 
 ```hcl
 module "gke" {

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -18,7 +18,7 @@ This module is meant for use with Terraform 0.12. If you haven't
 intended for Terraform 0.11.x is [3.0.0].
 
 ## Usage
-There are multiple examples included in the [examples](./examples/) folder but simple usage is as follows:
+There are multiple examples included in the [examples](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/examples/) folder but simple usage is as follows:
 
 ```hcl
 module "gke" {

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -11,7 +11,7 @@ The resources/services/activations/deletions that this module will create/trigge
 Sub modules are provided from creating private clusters, beta private clusters, and beta public clusters as well.  Beta sub modules allow for the use of various GKE beta features. See the modules directory for the various sub modules.
 
 ## Private Cluster Details
-For details on configuring private clusters with this module, check the [troubleshooting guide](../../docs/private_clusters.md).
+For details on configuring private clusters with this module, check the [troubleshooting guide](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/master/docs/private_clusters.md).
 
 ## Node Pool Update Variant
 
@@ -43,7 +43,7 @@ This module is meant for use with Terraform 0.12. If you haven't
 intended for Terraform 0.11.x is [3.0.0].
 
 ## Usage
-There are multiple examples included in the [examples](./examples/) folder but simple usage is as follows:
+There are multiple examples included in the [examples](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/examples/) folder but simple usage is as follows:
 
 ```hcl
 module "gke" {

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -11,7 +11,7 @@ The resources/services/activations/deletions that this module will create/trigge
 Sub modules are provided from creating private clusters, beta private clusters, and beta public clusters as well.  Beta sub modules allow for the use of various GKE beta features. See the modules directory for the various sub modules.
 
 ## Private Cluster Details
-For details on configuring private clusters with this module, check the [troubleshooting guide](../../docs/private_clusters.md).
+For details on configuring private clusters with this module, check the [troubleshooting guide](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/master/docs/private_clusters.md).
 
 ## Compatibility
 
@@ -21,7 +21,7 @@ This module is meant for use with Terraform 0.12. If you haven't
 intended for Terraform 0.11.x is [3.0.0].
 
 ## Usage
-There are multiple examples included in the [examples](./examples/) folder but simple usage is as follows:
+There are multiple examples included in the [examples](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/examples/) folder but simple usage is as follows:
 
 ```hcl
 module "gke" {


### PR DESCRIPTION
- Docs in #654 seems to have not been added to autogen and bot failed to catch that (will investigate seperately), although linter failed
- Following #653 make link to private cluster docs absolute
