### PR TITLE
Make wait-for-cluster logic more robust

### DIFF
--- a/autogen/main/scripts/wait-for-cluster.sh
+++ b/autogen/main/scripts/wait-for-cluster.sh
@@ -27,7 +27,7 @@ echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
 while
   current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-  [[ "${current_status}" == "RECONCILING" ]]
+  [[ "${current_status}" != "RUNNING" ]]
 do printf ".";sleep 5; done
 
 echo "Cluster is ready!"

--- a/modules/beta-private-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/beta-private-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -27,7 +27,7 @@ echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
 while
   current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-  [[ "${current_status}" == "RECONCILING" ]]
+  [[ "${current_status}" != "RUNNING" ]]
 do printf ".";sleep 5; done
 
 echo "Cluster is ready!"

--- a/modules/beta-private-cluster/scripts/wait-for-cluster.sh
+++ b/modules/beta-private-cluster/scripts/wait-for-cluster.sh
@@ -27,7 +27,7 @@ echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
 while
   current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-  [[ "${current_status}" == "RECONCILING" ]]
+  [[ "${current_status}" != "RUNNING" ]]
 do printf ".";sleep 5; done
 
 echo "Cluster is ready!"

--- a/modules/beta-public-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/beta-public-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -27,7 +27,7 @@ echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
 while
   current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-  [[ "${current_status}" == "RECONCILING" ]]
+  [[ "${current_status}" != "RUNNING" ]]
 do printf ".";sleep 5; done
 
 echo "Cluster is ready!"

--- a/modules/beta-public-cluster/scripts/wait-for-cluster.sh
+++ b/modules/beta-public-cluster/scripts/wait-for-cluster.sh
@@ -27,7 +27,7 @@ echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
 while
   current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-  [[ "${current_status}" == "RECONCILING" ]]
+  [[ "${current_status}" != "RUNNING" ]]
 do printf ".";sleep 5; done
 
 echo "Cluster is ready!"

--- a/modules/private-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/private-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -27,7 +27,7 @@ echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
 while
   current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-  [[ "${current_status}" == "RECONCILING" ]]
+  [[ "${current_status}" != "RUNNING" ]]
 do printf ".";sleep 5; done
 
 echo "Cluster is ready!"

--- a/modules/private-cluster/scripts/wait-for-cluster.sh
+++ b/modules/private-cluster/scripts/wait-for-cluster.sh
@@ -27,7 +27,7 @@ echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
 while
   current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-  [[ "${current_status}" == "RECONCILING" ]]
+  [[ "${current_status}" != "RUNNING" ]]
 do printf ".";sleep 5; done
 
 echo "Cluster is ready!"

--- a/scripts/wait-for-cluster.sh
+++ b/scripts/wait-for-cluster.sh
@@ -27,7 +27,7 @@ echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
 
 while
   current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)")
-  [[ "${current_status}" == "RECONCILING" ]]
+  [[ "${current_status}" != "RUNNING" ]]
 do printf ".";sleep 5; done
 
 echo "Cluster is ready!"


### PR DESCRIPTION
The status is PROVISIONING at the beginning, thus the original logic will always exit and say "Cluster is ready!". If we wait for the RUNNING status, we will know for sure the cluster is up.

Note: if the initial cluster node pool is removed it will say RUNNING for a second then go back to RECONCILING again while the node pool is removed. This might cause issues as well.