### PR TITLE
ACM submodule: fix bug when not using `ssh` secret type

### DIFF
--- a/modules/k8s-operator-crd-support/main.tf
+++ b/modules/k8s-operator-crd-support/main.tf
@@ -63,6 +63,8 @@ resource "tls_private_key" "k8sop_creds" {
 module "k8sop_creds_secret" {
   source                   = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
   version                  = "~> 2.0.2"
+  
+  enabled                  = var.secret_type == ssh ? 1 : 0
   module_depends_on        = [module.k8s_operator.wait]
   skip_download            = var.skip_gcloud_download
   cluster_name             = var.cluster_name

--- a/modules/k8s-operator-crd-support/main.tf
+++ b/modules/k8s-operator-crd-support/main.tf
@@ -24,8 +24,6 @@ locals {
   policy_dir_node               = var.policy_dir != "" ? format("policyDir: %s", var.policy_dir) : ""
   hierarchy_controller_map_node = var.hierarchy_controller == null ? "" : format("hierarchy_controller:\n    %s", yamlencode(var.hierarchy_controller))
   source_format_node            = var.source_format != "" ? format("sourceFormat: %s", var.source_format) : ""
-  secret_kubectl_command        = local.private_key != null ? "kubectl create secret generic ${var.operator_credential_name} -n=${var.operator_credential_namespace} --from-literal=${local.k8sop_creds_secret_key}='${local.private_key}'" : ""
-
 }
 
 module "k8sop_manifest" {
@@ -74,7 +72,7 @@ module "k8sop_creds_secret" {
   project_id               = var.project_id
   service_account_key_file = var.service_account_key_file
 
-kubectl_create_command  = local.secret_kubectl_command
+kubectl_create_command  = local.private_key != null ? "kubectl create secret generic ${var.operator_credential_name} -n=${var.operator_credential_namespace} --from-literal=${local.k8sop_creds_secret_key}='${local.private_key}'" : ""
 kubectl_destroy_command = "kubectl delete secret ${var.operator_credential_name} -n=${var.operator_credential_namespace}"
 }
 

--- a/modules/k8s-operator-crd-support/main.tf
+++ b/modules/k8s-operator-crd-support/main.tf
@@ -61,9 +61,9 @@ resource "tls_private_key" "k8sop_creds" {
 }
 
 module "k8sop_creds_secret" {
-  source                   = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
-  version                  = "~> 2.0.2"
-  
+  source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
+  version = "~> 2.0.2"
+
   enabled                  = var.secret_type == "ssh" ? "true" : "false"
   module_depends_on        = [module.k8s_operator.wait]
   skip_download            = var.skip_gcloud_download

--- a/modules/k8s-operator-crd-support/main.tf
+++ b/modules/k8s-operator-crd-support/main.tf
@@ -16,7 +16,7 @@
 
 locals {
   cluster_endpoint              = "https://${var.cluster_endpoint}"
-  private_key                   = var.create_ssh_key && var.ssh_auth_key == null ? tls_private_key.k8sop_creds[0].private_key_pem : var.ssh_auth_key
+  private_key                   = var.ssh_auth_key == null ? tls_private_key.k8sop_creds.private_key_pem : var.ssh_auth_key
   k8sop_creds_secret_key        = var.secret_type == "cookiefile" ? "cookie_file" : var.secret_type
   should_download_manifest      = var.operator_path == null ? true : false
   manifest_path                 = local.should_download_manifest ? "${path.root}/.terraform/tmp/${var.project_id}-${var.cluster_name}/config-management-operator.yaml" : var.operator_path
@@ -55,7 +55,6 @@ module "k8s_operator" {
 
 
 resource "tls_private_key" "k8sop_creds" {
-  count     = var.create_ssh_key ? 1 : 0
   algorithm = "RSA"
   rsa_bits  = 4096
 }

--- a/modules/k8s-operator-crd-support/main.tf
+++ b/modules/k8s-operator-crd-support/main.tf
@@ -64,7 +64,7 @@ module "k8sop_creds_secret" {
   source                   = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
   version                  = "~> 2.0.2"
   
-  enabled                  = var.secret_type == ssh ? 1 : 0
+  enabled                  = var.secret_type == ssh ? "true" : "false"
   module_depends_on        = [module.k8s_operator.wait]
   skip_download            = var.skip_gcloud_download
   cluster_name             = var.cluster_name

--- a/modules/k8s-operator-crd-support/main.tf
+++ b/modules/k8s-operator-crd-support/main.tf
@@ -64,7 +64,7 @@ module "k8sop_creds_secret" {
   source                   = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
   version                  = "~> 2.0.2"
   
-  enabled                  = var.secret_type == ssh ? "true" : "false"
+  enabled                  = var.secret_type == "ssh" ? "true" : "false"
   module_depends_on        = [module.k8s_operator.wait]
   skip_download            = var.skip_gcloud_download
   cluster_name             = var.cluster_name

--- a/modules/k8s-operator-crd-support/main.tf
+++ b/modules/k8s-operator-crd-support/main.tf
@@ -55,7 +55,7 @@ module "k8s_operator" {
 
 
 resource "tls_private_key" "k8sop_creds" {
-  count = var.create_ssh_key ? 1 : 0
+  count     = var.create_ssh_key ? 1 : 0
   algorithm = "RSA"
   rsa_bits  = 4096
 }
@@ -72,8 +72,8 @@ module "k8sop_creds_secret" {
   project_id               = var.project_id
   service_account_key_file = var.service_account_key_file
 
-kubectl_create_command  = local.private_key != null ? "kubectl create secret generic ${var.operator_credential_name} -n=${var.operator_credential_namespace} --from-literal=${local.k8sop_creds_secret_key}='${local.private_key}'" : ""
-kubectl_destroy_command = "kubectl delete secret ${var.operator_credential_name} -n=${var.operator_credential_namespace}"
+  kubectl_create_command  = local.private_key != null ? "kubectl create secret generic ${var.operator_credential_name} -n=${var.operator_credential_namespace} --from-literal=${local.k8sop_creds_secret_key}='${local.private_key}'" : ""
+  kubectl_destroy_command = "kubectl delete secret ${var.operator_credential_name} -n=${var.operator_credential_namespace}"
 }
 
 


### PR DESCRIPTION
Module failed as it tried to create `git-creds` secret regardless of secret type. Add enabled flag to k8sop_creds_secret module.