### PR TITLE
Enable auto-upgrade in beta clusters with a release channel

### DIFF
--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -71,8 +71,12 @@ locals {
   network_project_id          = var.network_project_id != "" ? var.network_project_id : var.project_id
   zone_count                  = length(var.zones)
   cluster_type                = var.regional ? "regional" : "zonal"
-  // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
+  // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous. When a release channel is used, node auto-upgrade are enabled and cannot be disabled.
+{% if beta_cluster %}
+  default_auto_upgrade = var.regional || var.release_channel != null ? true : false
+{% else %}
   default_auto_upgrade = var.regional ? true : false
+{% endif %}
 
   cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
   cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}

--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -71,8 +71,9 @@ locals {
   network_project_id          = var.network_project_id != "" ? var.network_project_id : var.project_id
   zone_count                  = length(var.zones)
   cluster_type                = var.regional ? "regional" : "zonal"
-  // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous. When a release channel is used, node auto-upgrade are enabled and cannot be disabled.
+  // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
 {% if beta_cluster %}
+  // When a release channel is used, node auto-upgrade are enabled and cannot be disabled.
   default_auto_upgrade = var.regional || var.release_channel != null ? true : false
 {% else %}
   default_auto_upgrade = var.regional ? true : false

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -66,7 +66,8 @@ locals {
   zone_count                  = length(var.zones)
   cluster_type                = var.regional ? "regional" : "zonal"
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
-  default_auto_upgrade = var.regional ? true : false
+  // When a release channel is used, node auto-upgrade are enabled and cannot be disabled.
+  default_auto_upgrade = var.regional || var.release_channel != null ? true : false
 
   cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
   cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -66,7 +66,8 @@ locals {
   zone_count                  = length(var.zones)
   cluster_type                = var.regional ? "regional" : "zonal"
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
-  default_auto_upgrade = var.regional ? true : false
+  // When a release channel is used, node auto-upgrade are enabled and cannot be disabled.
+  default_auto_upgrade = var.regional || var.release_channel != null ? true : false
 
   cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
   cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}

--- a/modules/beta-public-cluster-update-variant/main.tf
+++ b/modules/beta-public-cluster-update-variant/main.tf
@@ -66,7 +66,8 @@ locals {
   zone_count                  = length(var.zones)
   cluster_type                = var.regional ? "regional" : "zonal"
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
-  default_auto_upgrade = var.regional ? true : false
+  // When a release channel is used, node auto-upgrade are enabled and cannot be disabled.
+  default_auto_upgrade = var.regional || var.release_channel != null ? true : false
 
   cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
   cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -66,7 +66,8 @@ locals {
   zone_count                  = length(var.zones)
   cluster_type                = var.regional ? "regional" : "zonal"
   // auto upgrade by defaults only for regional cluster as long it has multiple masters versus zonal clusters have only have a single master so upgrades are more dangerous.
-  default_auto_upgrade = var.regional ? true : false
+  // When a release channel is used, node auto-upgrade are enabled and cannot be disabled.
+  default_auto_upgrade = var.regional || var.release_channel != null ? true : false
 
   cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
   cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}


### PR DESCRIPTION
I have been testing some changes with zonal clusters, but receive this error:

```
Error: error creating NodePool: googleapi: Error 400: Auto_upgrade cannot be false when release_channel REGULAR is set., badRequest
```

The node pools I define do have autoupgrade enabled, but I think the default node pool (which I am deleting with `remove_default_node_pool` anyway) is the problem node pool. Regional clusters already have auto-upgrade enabled by default, so I'm guessing nobody has used the specific combination of a zonal cluster and release channels with this module yet.

This [is noted in the documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels#new-cluster) as a disallowed configuration:

> Note: Node auto-upgrade and auto-repair are enabled and cannot be disabled when using release channels.

It's complicated slightly because release channels still only exist in the beta Google Terraform provider, as far as I can tell. I have left the non-beta configuration untouched and added an `if beta_cluster` block for my changes.