### PR TITLE
fix: set project number for ASM install 

### DIFF
--- a/modules/asm/main.tf
+++ b/modules/asm/main.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+data "google_project" "asm_project" {
+  project_id = var.project_id
+}
+
+
 module "asm_install" {
   source            = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
   version           = "~> 2.0.2"
@@ -29,6 +34,6 @@ module "asm_install" {
   service_account_key_file = var.service_account_key_file
 
 
-  kubectl_create_command  = "${path.module}/scripts/install_asm.sh ${var.project_id} ${var.cluster_name} ${var.location} ${var.asm_dir} ${var.asm_version}"
+  kubectl_create_command  = "${path.module}/scripts/install_asm.sh ${var.project_id} ${var.cluster_name} ${var.location} ${var.asm_dir} ${var.asm_version} ${data.google_project.asm_project.number}"
   kubectl_destroy_command = "kubectl delete ns istio-system"
 }

--- a/modules/asm/scripts/install_asm.sh
+++ b/modules/asm/scripts/install_asm.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-if [ "$#" -lt 5 ]; then
+if [ "$#" -lt 6 ]; then
     >&2 echo "Not all expected arguments set."
     exit 1
 fi
@@ -25,6 +25,7 @@ CLUSTER_NAME=$2
 CLUSTER_LOCATION=$3
 ASM_RESOURCES=$4
 ASM_VERSION=$5
+PROJECT_NUM=$6
 BASE_DIR="asm-base-dir"
 # check for needed binaries
 # kustomize is a requirement for installing ASM and is not available via gcloud. Safely exit if not available.
@@ -53,6 +54,7 @@ kpt cfg set asm-patch/ base-dir ../${BASE_DIR}
 kpt cfg set asm-patch/ gcloud.core.project "${PROJECT_ID}"
 kpt cfg set asm-patch/ gcloud.container.cluster "${CLUSTER_NAME}"
 kpt cfg set asm-patch/ gcloud.compute.location "${CLUSTER_LOCATION}"
+kpt cfg set asm-patch/ gcloud.project.environProjectNumber "${PROJECT_NUM}"
 kpt cfg list-setters asm-patch/
 pushd ${BASE_DIR}
 kustomize create --autodetect --namespace "${PROJECT_ID}"


### PR DESCRIPTION
fixes #683 
Spot checked for `release-1.6-asm` by enabling sidecar injection, deploying workload and checking that `ISTIO_META_MESH_ID:` is set correctly.