### PR TITLE
feat!: dynamic operator yaml

### DIFF
--- a/docs/upgrading_to_v13.0.md
+++ b/docs/upgrading_to_v13.0.md
@@ -28,3 +28,10 @@ module. This release adapts to this requirement.
 +  version                 = "~> 13.0"
 }
 ```
+
+### ACM submodule `local_file` removed
+
+[ACM submodule](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/tree/master/modules/acm) no longer creates a local file called `operator_cr.yaml`. 
+The yaml contents are rendered dynamically and passed via STDIN which fixes errors due to `operator_cr.yaml` file not being present between ephemeral pipeline runs. 
+
+This is destructive and will result in deletion and recreation of the ACM operator.

--- a/docs/upgrading_to_v13.0.md
+++ b/docs/upgrading_to_v13.0.md
@@ -31,7 +31,7 @@ module. This release adapts to this requirement.
 
 ### ACM submodule `local_file` removed
 
-[ACM submodule](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/tree/master/modules/acm) no longer creates a local file called `operator_cr.yaml`. 
-The yaml contents are rendered dynamically and passed via STDIN which fixes errors due to `operator_cr.yaml` file not being present between ephemeral pipeline runs. 
+[ACM submodule](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/tree/master/modules/acm) no longer creates a local file called `operator_cr.yaml`.
+The yaml contents are rendered dynamically and passed via STDIN which fixes errors due to `operator_cr.yaml` file not being present between ephemeral pipeline runs.
 
 This is destructive and will result in deletion and recreation of the ACM operator.

--- a/modules/k8s-operator-crd-support/main.tf
+++ b/modules/k8s-operator-crd-support/main.tf
@@ -94,11 +94,6 @@ data "template_file" "k8sop_config" {
   }
 }
 
-resource "local_file" "operator_cr" {
-  content  = data.template_file.k8sop_config.rendered
-  filename = "${path.module}/${var.project_id}-${var.cluster_name}/operator_cr.yaml"
-}
-
 module "k8sop_config" {
   source                   = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
   version                  = "~> 2.0.2"
@@ -107,12 +102,11 @@ module "k8sop_config" {
   cluster_name             = var.cluster_name
   cluster_location         = var.location
   project_id               = var.project_id
-  create_cmd_triggers      = { configmanagement = local_file.operator_cr.content }
+  create_cmd_triggers      = { configmanagement = data.template_file.k8sop_config.rendered }
   service_account_key_file = var.service_account_key_file
 
-  kubectl_create_command  = "kubectl apply -f ${local_file.operator_cr.filename}"
-  kubectl_destroy_command = "kubectl delete -f ${local_file.operator_cr.filename}"
-}
+  kubectl_create_command  = "kubectl apply -f - <<EOF\n${data.template_file.k8sop_config.rendered}EOF"
+  kubectl_destroy_command = "kubectl delete -f - <<EOF\n${data.template_file.k8sop_config.rendered}EOF"
 
 module "wait_for_gatekeeper" {
   source                   = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"

--- a/modules/k8s-operator-crd-support/main.tf
+++ b/modules/k8s-operator-crd-support/main.tf
@@ -107,6 +107,7 @@ module "k8sop_config" {
 
   kubectl_create_command  = "kubectl apply -f - <<EOF\n${data.template_file.k8sop_config.rendered}EOF"
   kubectl_destroy_command = "kubectl delete -f - <<EOF\n${data.template_file.k8sop_config.rendered}EOF"
+}
 
 module "wait_for_gatekeeper" {
   source                   = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"


### PR DESCRIPTION
Creating a local file `operator_cr.yaml` in an ephemeral pipeline during create results in an error during subsequent destroy if that file is not present.

This PR aims to pass the rendered yaml via stdin.