### PR TITLE
Updating the project services version for Binary Authorization

### DIFF
--- a/modules/binary-authorization/main.tf
+++ b/modules/binary-authorization/main.tf
@@ -25,7 +25,7 @@ locals {
 
 module "project-services" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "~> 8.0"
+  version = "~> 9.2.0"
 
   project_id    = var.project_id
   activate_apis = local.required_enabled_apis


### PR DESCRIPTION
Updated the Project Services module version to 9.2.0 so the Binary Authorization module supports Terraform 0.13