### PR TITLE
fix: multiple cluster wait-for-cluster.sh

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -539,9 +539,9 @@ module "gcloud_wait_for_cluster" {
   upgrade = var.gcloud_upgrade
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
-  create_cmd_body        = "${var.project_id} ${var.name} ${var.impersonate_service_account}"
+  create_cmd_body        = "${var.project_id} ${var.name} ${local.location} ${var.impersonate_service_account}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
-  destroy_cmd_body       = "${var.project_id} ${var.name} ${var.impersonate_service_account}"
+  destroy_cmd_body       = "${var.project_id} ${var.name} ${local.location} ${var.impersonate_service_account}"
 
   module_depends_on = concat(
     [google_container_cluster.primary.master_version],

--- a/autogen/main/scripts/wait-for-cluster.sh
+++ b/autogen/main/scripts/wait-for-cluster.sh
@@ -22,12 +22,17 @@ fi
 
 PROJECT=$1
 CLUSTER_NAME=$2
-IMPERSONATE_SERVICE_ACCOUNT=$3
+CLUSTER_LOCATION=$3
+IMPERSONATE_SERVICE_ACCOUNT=$4
 
-echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
+echo "Waiting for cluster $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME to reconcile..."
 
 while
-  current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  if [ -z "${current_status}" ]; then
+    echo "Unable to get status for $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME"
+    exit 1
+  fi
   [[ "${current_status}" != "RUNNING" ]]
 do printf ".";sleep 5; done
 

--- a/cluster.tf
+++ b/cluster.tf
@@ -323,9 +323,9 @@ module "gcloud_wait_for_cluster" {
   upgrade = var.gcloud_upgrade
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
-  create_cmd_body        = "${var.project_id} ${var.name} ${var.impersonate_service_account}"
+  create_cmd_body        = "${var.project_id} ${var.name} ${local.location} ${var.impersonate_service_account}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
-  destroy_cmd_body       = "${var.project_id} ${var.name} ${var.impersonate_service_account}"
+  destroy_cmd_body       = "${var.project_id} ${var.name} ${local.location} ${var.impersonate_service_account}"
 
   module_depends_on = concat(
     [google_container_cluster.primary.master_version],

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -497,9 +497,9 @@ module "gcloud_wait_for_cluster" {
   upgrade = var.gcloud_upgrade
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
-  create_cmd_body        = "${var.project_id} ${var.name} ${var.impersonate_service_account}"
+  create_cmd_body        = "${var.project_id} ${var.name} ${local.location} ${var.impersonate_service_account}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
-  destroy_cmd_body       = "${var.project_id} ${var.name} ${var.impersonate_service_account}"
+  destroy_cmd_body       = "${var.project_id} ${var.name} ${local.location} ${var.impersonate_service_account}"
 
   module_depends_on = concat(
     [google_container_cluster.primary.master_version],

--- a/modules/beta-private-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/beta-private-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -22,12 +22,17 @@ fi
 
 PROJECT=$1
 CLUSTER_NAME=$2
-IMPERSONATE_SERVICE_ACCOUNT=$3
+CLUSTER_LOCATION=$3
+IMPERSONATE_SERVICE_ACCOUNT=$4
 
-echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
+echo "Waiting for cluster $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME to reconcile..."
 
 while
-  current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  if [ -z "${current_status}" ]; then
+    echo "Unable to get status for $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME"
+    exit 1
+  fi
   [[ "${current_status}" != "RUNNING" ]]
 do printf ".";sleep 5; done
 

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -424,9 +424,9 @@ module "gcloud_wait_for_cluster" {
   upgrade = var.gcloud_upgrade
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
-  create_cmd_body        = "${var.project_id} ${var.name} ${var.impersonate_service_account}"
+  create_cmd_body        = "${var.project_id} ${var.name} ${local.location} ${var.impersonate_service_account}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
-  destroy_cmd_body       = "${var.project_id} ${var.name} ${var.impersonate_service_account}"
+  destroy_cmd_body       = "${var.project_id} ${var.name} ${local.location} ${var.impersonate_service_account}"
 
   module_depends_on = concat(
     [google_container_cluster.primary.master_version],

--- a/modules/beta-private-cluster/scripts/wait-for-cluster.sh
+++ b/modules/beta-private-cluster/scripts/wait-for-cluster.sh
@@ -22,12 +22,17 @@ fi
 
 PROJECT=$1
 CLUSTER_NAME=$2
-IMPERSONATE_SERVICE_ACCOUNT=$3
+CLUSTER_LOCATION=$3
+IMPERSONATE_SERVICE_ACCOUNT=$4
 
-echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
+echo "Waiting for cluster $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME to reconcile..."
 
 while
-  current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  if [ -z "${current_status}" ]; then
+    echo "Unable to get status for $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME"
+    exit 1
+  fi
   [[ "${current_status}" != "RUNNING" ]]
 do printf ".";sleep 5; done
 

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -478,9 +478,9 @@ module "gcloud_wait_for_cluster" {
   upgrade = var.gcloud_upgrade
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
-  create_cmd_body        = "${var.project_id} ${var.name} ${var.impersonate_service_account}"
+  create_cmd_body        = "${var.project_id} ${var.name} ${local.location} ${var.impersonate_service_account}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
-  destroy_cmd_body       = "${var.project_id} ${var.name} ${var.impersonate_service_account}"
+  destroy_cmd_body       = "${var.project_id} ${var.name} ${local.location} ${var.impersonate_service_account}"
 
   module_depends_on = concat(
     [google_container_cluster.primary.master_version],

--- a/modules/beta-public-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/beta-public-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -22,12 +22,17 @@ fi
 
 PROJECT=$1
 CLUSTER_NAME=$2
-IMPERSONATE_SERVICE_ACCOUNT=$3
+CLUSTER_LOCATION=$3
+IMPERSONATE_SERVICE_ACCOUNT=$4
 
-echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
+echo "Waiting for cluster $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME to reconcile..."
 
 while
-  current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  if [ -z "${current_status}" ]; then
+    echo "Unable to get status for $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME"
+    exit 1
+  fi
   [[ "${current_status}" != "RUNNING" ]]
 do printf ".";sleep 5; done
 

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -405,9 +405,9 @@ module "gcloud_wait_for_cluster" {
   upgrade = var.gcloud_upgrade
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
-  create_cmd_body        = "${var.project_id} ${var.name} ${var.impersonate_service_account}"
+  create_cmd_body        = "${var.project_id} ${var.name} ${local.location} ${var.impersonate_service_account}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
-  destroy_cmd_body       = "${var.project_id} ${var.name} ${var.impersonate_service_account}"
+  destroy_cmd_body       = "${var.project_id} ${var.name} ${local.location} ${var.impersonate_service_account}"
 
   module_depends_on = concat(
     [google_container_cluster.primary.master_version],

--- a/modules/beta-public-cluster/scripts/wait-for-cluster.sh
+++ b/modules/beta-public-cluster/scripts/wait-for-cluster.sh
@@ -22,12 +22,17 @@ fi
 
 PROJECT=$1
 CLUSTER_NAME=$2
-IMPERSONATE_SERVICE_ACCOUNT=$3
+CLUSTER_LOCATION=$3
+IMPERSONATE_SERVICE_ACCOUNT=$4
 
-echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
+echo "Waiting for cluster $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME to reconcile..."
 
 while
-  current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  if [ -z "${current_status}" ]; then
+    echo "Unable to get status for $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME"
+    exit 1
+  fi
   [[ "${current_status}" != "RUNNING" ]]
 do printf ".";sleep 5; done
 

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -409,9 +409,9 @@ module "gcloud_wait_for_cluster" {
   upgrade = var.gcloud_upgrade
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
-  create_cmd_body        = "${var.project_id} ${var.name} ${var.impersonate_service_account}"
+  create_cmd_body        = "${var.project_id} ${var.name} ${local.location} ${var.impersonate_service_account}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
-  destroy_cmd_body       = "${var.project_id} ${var.name} ${var.impersonate_service_account}"
+  destroy_cmd_body       = "${var.project_id} ${var.name} ${local.location} ${var.impersonate_service_account}"
 
   module_depends_on = concat(
     [google_container_cluster.primary.master_version],

--- a/modules/private-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/private-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -22,12 +22,17 @@ fi
 
 PROJECT=$1
 CLUSTER_NAME=$2
-IMPERSONATE_SERVICE_ACCOUNT=$3
+CLUSTER_LOCATION=$3
+IMPERSONATE_SERVICE_ACCOUNT=$4
 
-echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
+echo "Waiting for cluster $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME to reconcile..."
 
 while
-  current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  if [ -z "${current_status}" ]; then
+    echo "Unable to get status for $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME"
+    exit 1
+  fi
   [[ "${current_status}" != "RUNNING" ]]
 do printf ".";sleep 5; done
 

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -336,9 +336,9 @@ module "gcloud_wait_for_cluster" {
   upgrade = var.gcloud_upgrade
 
   create_cmd_entrypoint  = "${path.module}/scripts/wait-for-cluster.sh"
-  create_cmd_body        = "${var.project_id} ${var.name} ${var.impersonate_service_account}"
+  create_cmd_body        = "${var.project_id} ${var.name} ${local.location} ${var.impersonate_service_account}"
   destroy_cmd_entrypoint = "${path.module}/scripts/wait-for-cluster.sh"
-  destroy_cmd_body       = "${var.project_id} ${var.name} ${var.impersonate_service_account}"
+  destroy_cmd_body       = "${var.project_id} ${var.name} ${local.location} ${var.impersonate_service_account}"
 
   module_depends_on = concat(
     [google_container_cluster.primary.master_version],

--- a/modules/private-cluster/scripts/wait-for-cluster.sh
+++ b/modules/private-cluster/scripts/wait-for-cluster.sh
@@ -22,12 +22,17 @@ fi
 
 PROJECT=$1
 CLUSTER_NAME=$2
-IMPERSONATE_SERVICE_ACCOUNT=$3
+CLUSTER_LOCATION=$3
+IMPERSONATE_SERVICE_ACCOUNT=$4
 
-echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
+echo "Waiting for cluster $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME to reconcile..."
 
 while
-  current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  if [ -z "${current_status}" ]; then
+    echo "Unable to get status for $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME"
+    exit 1
+  fi
   [[ "${current_status}" != "RUNNING" ]]
 do printf ".";sleep 5; done
 

--- a/scripts/wait-for-cluster.sh
+++ b/scripts/wait-for-cluster.sh
@@ -22,12 +22,17 @@ fi
 
 PROJECT=$1
 CLUSTER_NAME=$2
-IMPERSONATE_SERVICE_ACCOUNT=$3
+CLUSTER_LOCATION=$3
+IMPERSONATE_SERVICE_ACCOUNT=$4
 
-echo "Waiting for cluster $CLUSTER_NAME in project $PROJECT to reconcile..."
+echo "Waiting for cluster $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME to reconcile..."
 
 while
-  current_status=$(gcloud container clusters list --project="$PROJECT" --filter=name:"$CLUSTER_NAME" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  if [ -z "${current_status}" ]; then
+    echo "Unable to get status for $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME"
+    exit 1
+  fi
   [[ "${current_status}" != "RUNNING" ]]
 do printf ".";sleep 5; done
 


### PR DESCRIPTION
fixes: #733 
Changes:
- match on equality `key=value`  instead of pattern `key:pattern` using both cluster name and location
- if  `current_status` is empty, i.e filter did not match any cluster, exit with error