### PR TITLE
fix: wait-for-cluster fallback filter to name if location is not set

### DIFF
--- a/autogen/main/scripts/wait-for-cluster.sh
+++ b/autogen/main/scripts/wait-for-cluster.sh
@@ -28,7 +28,12 @@ IMPERSONATE_SERVICE_ACCOUNT=$4
 echo "Waiting for cluster $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME to reconcile..."
 
 while
-  current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+    # if cluster location is set, use it in filter
+  if [ -z "${CLUSTER_LOCATION}" ]; then
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  else
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  fi
   if [ -z "${current_status}" ]; then
     echo "Unable to get status for $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME"
     exit 1

--- a/modules/beta-private-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/beta-private-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -28,7 +28,12 @@ IMPERSONATE_SERVICE_ACCOUNT=$4
 echo "Waiting for cluster $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME to reconcile..."
 
 while
-  current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+    # if cluster location is set, use it in filter
+  if [ -z "${CLUSTER_LOCATION}" ]; then
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  else
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  fi
   if [ -z "${current_status}" ]; then
     echo "Unable to get status for $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME"
     exit 1

--- a/modules/beta-private-cluster/scripts/wait-for-cluster.sh
+++ b/modules/beta-private-cluster/scripts/wait-for-cluster.sh
@@ -28,7 +28,12 @@ IMPERSONATE_SERVICE_ACCOUNT=$4
 echo "Waiting for cluster $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME to reconcile..."
 
 while
-  current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+    # if cluster location is set, use it in filter
+  if [ -z "${CLUSTER_LOCATION}" ]; then
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  else
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  fi
   if [ -z "${current_status}" ]; then
     echo "Unable to get status for $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME"
     exit 1

--- a/modules/beta-public-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/beta-public-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -28,7 +28,12 @@ IMPERSONATE_SERVICE_ACCOUNT=$4
 echo "Waiting for cluster $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME to reconcile..."
 
 while
-  current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+    # if cluster location is set, use it in filter
+  if [ -z "${CLUSTER_LOCATION}" ]; then
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  else
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  fi
   if [ -z "${current_status}" ]; then
     echo "Unable to get status for $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME"
     exit 1

--- a/modules/beta-public-cluster/scripts/wait-for-cluster.sh
+++ b/modules/beta-public-cluster/scripts/wait-for-cluster.sh
@@ -28,7 +28,12 @@ IMPERSONATE_SERVICE_ACCOUNT=$4
 echo "Waiting for cluster $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME to reconcile..."
 
 while
-  current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+    # if cluster location is set, use it in filter
+  if [ -z "${CLUSTER_LOCATION}" ]; then
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  else
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  fi
   if [ -z "${current_status}" ]; then
     echo "Unable to get status for $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME"
     exit 1

--- a/modules/private-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/private-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -28,7 +28,12 @@ IMPERSONATE_SERVICE_ACCOUNT=$4
 echo "Waiting for cluster $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME to reconcile..."
 
 while
-  current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+    # if cluster location is set, use it in filter
+  if [ -z "${CLUSTER_LOCATION}" ]; then
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  else
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  fi
   if [ -z "${current_status}" ]; then
     echo "Unable to get status for $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME"
     exit 1

--- a/modules/private-cluster/scripts/wait-for-cluster.sh
+++ b/modules/private-cluster/scripts/wait-for-cluster.sh
@@ -28,7 +28,12 @@ IMPERSONATE_SERVICE_ACCOUNT=$4
 echo "Waiting for cluster $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME to reconcile..."
 
 while
-  current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+    # if cluster location is set, use it in filter
+  if [ -z "${CLUSTER_LOCATION}" ]; then
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  else
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  fi
   if [ -z "${current_status}" ]; then
     echo "Unable to get status for $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME"
     exit 1

--- a/scripts/wait-for-cluster.sh
+++ b/scripts/wait-for-cluster.sh
@@ -28,7 +28,12 @@ IMPERSONATE_SERVICE_ACCOUNT=$4
 echo "Waiting for cluster $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME to reconcile..."
 
 while
-  current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+    # if cluster location is set, use it in filter
+  if [ -z "${CLUSTER_LOCATION}" ]; then
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  else
+    current_status=$(gcloud container clusters list --project="$PROJECT" --filter="name=$CLUSTER_NAME AND location=$CLUSTER_LOCATION" --format="value(status)" --impersonate-service-account="$IMPERSONATE_SERVICE_ACCOUNT")
+  fi
   if [ -z "${current_status}" ]; then
     echo "Unable to get status for $PROJECT/$CLUSTER_LOCATION/$CLUSTER_NAME"
     exit 1


### PR DESCRIPTION
fixes #735 

- fallback to just using name in the filter if location is not set for destroy hook