### PR TITLE
Make bash scripts more portable

### DIFF
--- a/autogen/main/scripts/delete-default-resource.sh
+++ b/autogen/main/scripts/delete-default-resource.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/autogen/main/scripts/kubectl_wrapper.sh
+++ b/autogen/main/scripts/kubectl_wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/autogen/main/scripts/wait-for-cluster.sh
+++ b/autogen/main/scripts/wait-for-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/node_pool/data/shutdown-script.sh
+++ b/examples/node_pool/data/shutdown-script.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Copyright 2018 Google LLC
 #

--- a/examples/node_pool_update_variant/data/shutdown-script.sh
+++ b/examples/node_pool_update_variant/data/shutdown-script.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Copyright 2018 Google LLC
 #

--- a/examples/node_pool_update_variant_beta/data/shutdown-script.sh
+++ b/examples/node_pool_update_variant_beta/data/shutdown-script.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # Copyright 2018 Google LLC
 #

--- a/modules/asm/scripts/install_asm.sh
+++ b/modules/asm/scripts/install_asm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/beta-private-cluster-update-variant/scripts/delete-default-resource.sh
+++ b/modules/beta-private-cluster-update-variant/scripts/delete-default-resource.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/beta-private-cluster-update-variant/scripts/kubectl_wrapper.sh
+++ b/modules/beta-private-cluster-update-variant/scripts/kubectl_wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/beta-private-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/beta-private-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/beta-private-cluster/scripts/delete-default-resource.sh
+++ b/modules/beta-private-cluster/scripts/delete-default-resource.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/beta-private-cluster/scripts/kubectl_wrapper.sh
+++ b/modules/beta-private-cluster/scripts/kubectl_wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/beta-private-cluster/scripts/wait-for-cluster.sh
+++ b/modules/beta-private-cluster/scripts/wait-for-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/beta-public-cluster-update-variant/scripts/delete-default-resource.sh
+++ b/modules/beta-public-cluster-update-variant/scripts/delete-default-resource.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/beta-public-cluster-update-variant/scripts/kubectl_wrapper.sh
+++ b/modules/beta-public-cluster-update-variant/scripts/kubectl_wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/beta-public-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/beta-public-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/beta-public-cluster/scripts/delete-default-resource.sh
+++ b/modules/beta-public-cluster/scripts/delete-default-resource.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/beta-public-cluster/scripts/kubectl_wrapper.sh
+++ b/modules/beta-public-cluster/scripts/kubectl_wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/beta-public-cluster/scripts/wait-for-cluster.sh
+++ b/modules/beta-public-cluster/scripts/wait-for-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/hub/scripts/gke_hub_registration.sh
+++ b/modules/hub/scripts/gke_hub_registration.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/k8s-operator-crd-support/scripts/kubectl_wrapper.sh
+++ b/modules/k8s-operator-crd-support/scripts/kubectl_wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/k8s-operator-crd-support/scripts/wait_for_gatekeeper.sh
+++ b/modules/k8s-operator-crd-support/scripts/wait_for_gatekeeper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/private-cluster-update-variant/scripts/delete-default-resource.sh
+++ b/modules/private-cluster-update-variant/scripts/delete-default-resource.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/private-cluster-update-variant/scripts/kubectl_wrapper.sh
+++ b/modules/private-cluster-update-variant/scripts/kubectl_wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/private-cluster-update-variant/scripts/wait-for-cluster.sh
+++ b/modules/private-cluster-update-variant/scripts/wait-for-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/private-cluster/scripts/delete-default-resource.sh
+++ b/modules/private-cluster/scripts/delete-default-resource.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/private-cluster/scripts/kubectl_wrapper.sh
+++ b/modules/private-cluster/scripts/kubectl_wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/private-cluster/scripts/wait-for-cluster.sh
+++ b/modules/private-cluster/scripts/wait-for-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/delete-default-resource.sh
+++ b/scripts/delete-default-resource.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/kubectl_wrapper.sh
+++ b/scripts/kubectl_wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/wait-for-cluster.sh
+++ b/scripts/wait-for-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
On my distro these scripts won't work since there is no `/bin/bash`, if instead we use `/usr/bin/env bash` for shebang these would work in more places.

Thanks for a great tf module!