### PR TITLE
remove version constraint

### DIFF
--- a/autogen/main/versions.tf.tmpl
+++ b/autogen/main/versions.tf.tmpl
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 
   required_providers {
 {% if beta_cluster %}

--- a/autogen/safer-cluster/versions.tf.tmpl
+++ b/autogen/safer-cluster/versions.tf.tmpl
@@ -17,5 +17,5 @@
 {{ autogeneration_note }}
 
 terraform {
-  required_version = ">=0.12, <0.14"
+  required_version = ">=0.12"
 }

--- a/examples/safer_cluster/versions.tf
+++ b/examples/safer_cluster/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12, <0.14"
+  required_version = ">=0.12"
 }

--- a/examples/simple_regional_beta/versions.tf
+++ b/examples/simple_regional_beta/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12, <0.14"
+  required_version = ">=0.12"
 }

--- a/examples/simple_regional_private_beta/versions.tf
+++ b/examples/simple_regional_private_beta/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12, <0.14"
+  required_version = ">=0.12"
 }

--- a/examples/simple_zonal_with_asm/versions.tf
+++ b/examples/simple_zonal_with_asm/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12, <0.14"
+  required_version = ">=0.12"
 }

--- a/examples/stub_domains_upstream_nameservers/versions.tf
+++ b/examples/stub_domains_upstream_nameservers/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12, <0.14"
+  required_version = ">=0.12"
 }

--- a/examples/upstream_nameservers/versions.tf
+++ b/examples/upstream_nameservers/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12, <0.14"
+  required_version = ">=0.12"
 }

--- a/examples/workload_metadata_config/versions.tf
+++ b/examples/workload_metadata_config/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12, <0.14"
+  required_version = ">=0.12"
 }

--- a/modules/beta-private-cluster-update-variant/versions.tf
+++ b/modules/beta-private-cluster-update-variant/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 
   required_providers {
     google-beta = ">= 3.32.0, <4.0.0"

--- a/modules/beta-private-cluster/versions.tf
+++ b/modules/beta-private-cluster/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 
   required_providers {
     google-beta = ">= 3.32.0, <4.0.0"

--- a/modules/beta-public-cluster-update-variant/versions.tf
+++ b/modules/beta-public-cluster-update-variant/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 
   required_providers {
     google-beta = ">= 3.32.0, <4.0.0"

--- a/modules/beta-public-cluster/versions.tf
+++ b/modules/beta-public-cluster/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 
   required_providers {
     google-beta = ">= 3.32.0, <4.0.0"

--- a/modules/private-cluster-update-variant/versions.tf
+++ b/modules/private-cluster-update-variant/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 
   required_providers {
     google = ">= 3.39.0, <4.0.0"

--- a/modules/private-cluster/versions.tf
+++ b/modules/private-cluster/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 
   required_providers {
     google = ">= 3.39.0, <4.0.0"

--- a/modules/safer-cluster-update-variant/versions.tf
+++ b/modules/safer-cluster-update-variant/versions.tf
@@ -17,5 +17,5 @@
 // This file was automatically generated from a template in ./autogen/safer-cluster
 
 terraform {
-  required_version = ">=0.12, <0.14"
+  required_version = ">=0.12"
 }

--- a/modules/safer-cluster/versions.tf
+++ b/modules/safer-cluster/versions.tf
@@ -17,5 +17,5 @@
 // This file was automatically generated from a template in ./autogen/safer-cluster
 
 terraform {
-  required_version = ">=0.12, <0.14"
+  required_version = ">=0.12"
 }

--- a/test/fixtures/stub_domains_upstream_nameservers/versions.tf
+++ b/test/fixtures/stub_domains_upstream_nameservers/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12, <0.14"
+  required_version = ">=0.12"
 }

--- a/test/fixtures/upstream_nameservers/versions.tf
+++ b/test/fixtures/upstream_nameservers/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12, <0.14"
+  required_version = ">=0.12"
 }

--- a/test/fixtures/workload_metadata_config/versions.tf
+++ b/test/fixtures/workload_metadata_config/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12, <0.14"
+  required_version = ">=0.12"
 }

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12, <0.14"
+  required_version = ">=0.12"
 }
 
 provider "google" {

--- a/versions.tf
+++ b/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 
   required_providers {
     google = ">= 3.39.0, <4.0.0"


### PR DESCRIPTION
This PR adds support for terraform 0.14. similar to [terraform-google-project-factory/pull/505](https://github.com/terraform-google-modules/terraform-google-project-factory/pull/505) as mentioned in [issues/754](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/754)

