### PR TITLE
no beta usage in safer-cluster module

### DIFF
--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -19,7 +19,7 @@
 // The safer-cluster module is based on a private cluster, with a several
 // settings set to recommended values by default.
 module "gke" {
-  source             = "../beta-private-cluster/"
+  source             = "../private-cluster/"
   project_id         = var.project_id
   name               = var.name
   regional           = var.regional


### PR DESCRIPTION
As this is the `safer-cluster` module in contrast to the existing `beta-safer-cluster` module, I assume the `beta` is not needed or even not supposed to be here.

If the `beta` usage is intended here, feel free to close this PR without further comment.

Btw, there might be other places where this applies.