### PR TITLE
Move version constraint to required_providers block

### DIFF
--- a/auth.tf
+++ b/auth.tf
@@ -27,7 +27,6 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10, != 1.11.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/autogen/main/auth.tf.tmpl
+++ b/autogen/main/auth.tf.tmpl
@@ -31,7 +31,6 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10, != 1.11.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/autogen/main/versions.tf.tmpl
+++ b/autogen/main/versions.tf.tmpl
@@ -20,9 +20,10 @@ terraform {
   required_providers {
 {% if beta_cluster %}
     google-beta = ">= 3.42.0, <4.0.0"
+    kubernetes  = "~> 1.10, != 1.11.0"
 {% else %}
     google     = ">= 3.39.0, <4.0.0"
-{% endif %}
     kubernetes = "~> 1.10, != 1.11.0"
+{% endif %}
   }
 }

--- a/autogen/main/versions.tf.tmpl
+++ b/autogen/main/versions.tf.tmpl
@@ -21,7 +21,8 @@ terraform {
 {% if beta_cluster %}
     google-beta = ">= 3.42.0, <4.0.0"
 {% else %}
-    google = ">= 3.39.0, <4.0.0"
+    google     = ">= 3.39.0, <4.0.0"
 {% endif %}
+    kubernetes = "~> 1.10, != 1.11.0"
   }
 }

--- a/examples/workload_identity/main.tf
+++ b/examples/workload_identity/main.tf
@@ -24,7 +24,6 @@ provider "google" {
 }
 
 provider "kubernetes" {
-  version                = "~> 1.10, != 1.11.0"
   host                   = module.gke.endpoint
   token                  = data.google_client_config.default.access_token
   cluster_ca_certificate = base64decode(module.gke.ca_certificate)

--- a/modules/beta-private-cluster-update-variant/auth.tf
+++ b/modules/beta-private-cluster-update-variant/auth.tf
@@ -27,7 +27,6 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10, != 1.11.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/beta-private-cluster-update-variant/versions.tf
+++ b/modules/beta-private-cluster-update-variant/versions.tf
@@ -19,6 +19,6 @@ terraform {
 
   required_providers {
     google-beta = ">= 3.42.0, <4.0.0"
-    kubernetes = "~> 1.10, != 1.11.0"
+    kubernetes  = "~> 1.10, != 1.11.0"
   }
 }

--- a/modules/beta-private-cluster-update-variant/versions.tf
+++ b/modules/beta-private-cluster-update-variant/versions.tf
@@ -19,5 +19,6 @@ terraform {
 
   required_providers {
     google-beta = ">= 3.42.0, <4.0.0"
+    kubernetes = "~> 1.10, != 1.11.0"
   }
 }

--- a/modules/beta-private-cluster/auth.tf
+++ b/modules/beta-private-cluster/auth.tf
@@ -27,7 +27,6 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10, != 1.11.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/beta-private-cluster/versions.tf
+++ b/modules/beta-private-cluster/versions.tf
@@ -19,6 +19,6 @@ terraform {
 
   required_providers {
     google-beta = ">= 3.42.0, <4.0.0"
-    kubernetes = "~> 1.10, != 1.11.0"
+    kubernetes  = "~> 1.10, != 1.11.0"
   }
 }

--- a/modules/beta-private-cluster/versions.tf
+++ b/modules/beta-private-cluster/versions.tf
@@ -19,5 +19,6 @@ terraform {
 
   required_providers {
     google-beta = ">= 3.42.0, <4.0.0"
+    kubernetes = "~> 1.10, != 1.11.0"
   }
 }

--- a/modules/beta-public-cluster-update-variant/auth.tf
+++ b/modules/beta-public-cluster-update-variant/auth.tf
@@ -27,7 +27,6 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10, != 1.11.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/beta-public-cluster-update-variant/versions.tf
+++ b/modules/beta-public-cluster-update-variant/versions.tf
@@ -19,6 +19,6 @@ terraform {
 
   required_providers {
     google-beta = ">= 3.42.0, <4.0.0"
-    kubernetes = "~> 1.10, != 1.11.0"
+    kubernetes  = "~> 1.10, != 1.11.0"
   }
 }

--- a/modules/beta-public-cluster-update-variant/versions.tf
+++ b/modules/beta-public-cluster-update-variant/versions.tf
@@ -19,5 +19,6 @@ terraform {
 
   required_providers {
     google-beta = ">= 3.42.0, <4.0.0"
+    kubernetes = "~> 1.10, != 1.11.0"
   }
 }

--- a/modules/beta-public-cluster/auth.tf
+++ b/modules/beta-public-cluster/auth.tf
@@ -27,7 +27,6 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10, != 1.11.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/beta-public-cluster/versions.tf
+++ b/modules/beta-public-cluster/versions.tf
@@ -19,6 +19,6 @@ terraform {
 
   required_providers {
     google-beta = ">= 3.42.0, <4.0.0"
-    kubernetes = "~> 1.10, != 1.11.0"
+    kubernetes  = "~> 1.10, != 1.11.0"
   }
 }

--- a/modules/beta-public-cluster/versions.tf
+++ b/modules/beta-public-cluster/versions.tf
@@ -19,5 +19,6 @@ terraform {
 
   required_providers {
     google-beta = ">= 3.42.0, <4.0.0"
+    kubernetes = "~> 1.10, != 1.11.0"
   }
 }

--- a/modules/private-cluster-update-variant/auth.tf
+++ b/modules/private-cluster-update-variant/auth.tf
@@ -27,7 +27,6 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10, != 1.11.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/private-cluster-update-variant/versions.tf
+++ b/modules/private-cluster-update-variant/versions.tf
@@ -18,6 +18,7 @@ terraform {
   required_version = ">=0.12.6"
 
   required_providers {
-    google = ">= 3.39.0, <4.0.0"
+    google     = ">= 3.39.0, <4.0.0"
+    kubernetes = "~> 1.10, != 1.11.0"
   }
 }

--- a/modules/private-cluster/auth.tf
+++ b/modules/private-cluster/auth.tf
@@ -27,7 +27,6 @@ data "google_client_config" "default" {
   Configure provider
  *****************************************/
 provider "kubernetes" {
-  version                = "~> 1.10, != 1.11.0"
   load_config_file       = false
   host                   = "https://${local.cluster_endpoint}"
   token                  = data.google_client_config.default.access_token

--- a/modules/private-cluster/versions.tf
+++ b/modules/private-cluster/versions.tf
@@ -18,6 +18,7 @@ terraform {
   required_version = ">=0.12.6"
 
   required_providers {
-    google = ">= 3.39.0, <4.0.0"
+    google     = ">= 3.39.0, <4.0.0"
+    kubernetes = "~> 1.10, != 1.11.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -18,6 +18,7 @@ terraform {
   required_version = ">=0.12.6"
 
   required_providers {
-    google = ">= 3.39.0, <4.0.0"
+    google     = ">= 3.39.0, <4.0.0"
+    kubernetes = "~> 1.10, != 1.11.0"
   }
 }


### PR DESCRIPTION
Terraform 0.14 shows warnings of the following kind asking to move the provider version constraint to required_providers block.
<img width="1010" alt="Screenshot 2020-12-30 at 17 16 38" src="https://user-images.githubusercontent.com/6253803/103350655-aa88bc80-4ac6-11eb-8f5a-066af8acb3fa.png">
