### PR TITLE
Add the option to disable Kubernetes SA annotation in workload-identity.

### DIFF
--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -69,6 +69,7 @@ module "my-app-workload-identity" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| annotate\_k8s\_sa | Annotate the kubernetes service account with 'iam.gke.io/gcp-service-account' annotation. Valid in cases when an existing SA is used. | `bool` | `true` | no |
 | automount\_service\_account\_token | Enable automatic mounting of the service account token | `bool` | `false` | no |
 | cluster\_name | Cluster name. Required if using existing KSA. | `string` | `""` | no |
 | k8s\_sa\_name | Name for the existing Kubernetes service account | `string` | `null` | no |

--- a/modules/workload-identity/main.tf
+++ b/modules/workload-identity/main.tf
@@ -49,7 +49,7 @@ module "annotate-sa" {
   source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
   version = "~> 2.0.2"
 
-  enabled          = var.use_existing_k8s_sa
+  enabled          = var.use_existing_k8s_sa && var.annotate_k8s_sa
   skip_download    = true
   cluster_name     = var.cluster_name
   cluster_location = var.location

--- a/modules/workload-identity/variables.tf
+++ b/modules/workload-identity/variables.tf
@@ -54,6 +54,12 @@ variable "use_existing_k8s_sa" {
   type        = bool
 }
 
+variable "annotate_k8s_sa" {
+  description = "Annotate the kubernetes service account with 'iam.gke.io/gcp-service-account' annotation. Valid in cases when an existing SA is used."
+  default     = true
+  type        = bool
+}
+
 variable "automount_service_account_token" {
   description = "Enable automatic mounting of the service account token"
   default     = false


### PR DESCRIPTION
This PR adds the option to disable Kubernetes SA annotation in the workload-identity module. This is useful in cases where an operator managing IAM doesn't have access to GKE or environments where GKE is managed in a declarative manner through GitOps, for example.