### PR TITLE
Fix: Change default value of network_policy variable to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ module "gke" {
   ip_range_services          = "us-central1-01-gke-01-services"
   http_load_balancing        = false
   horizontal_pod_autoscaling = true
-  network_policy             = true
+  network_policy             = false
 
   node_pools = [
     {

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Then perform the following commands on the root folder:
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |
 | name | The name of the cluster (required) | `string` | n/a | yes |
 | network | The VPC network to host the cluster in (required) | `string` | n/a | yes |
-| network\_policy | Enable network policy addon | `bool` | `true` | no |
+| network\_policy | Enable network policy addon | `bool` | `false` | no |
 | network\_policy\_provider | The network policy provider. | `string` | `"CALICO"` | no |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
 | node\_metadata | Specifies how node metadata is exposed to the workload running on the node | `string` | `"GKE_METADATA_SERVER"` | no |

--- a/autogen/main/README.md
+++ b/autogen/main/README.md
@@ -73,7 +73,7 @@ module "gke" {
   ip_range_services          = "us-central1-01-gke-01-services"
   http_load_balancing        = false
   horizontal_pod_autoscaling = true
-  network_policy             = true
+  network_policy             = false
   {% if private_cluster %}
   enable_private_endpoint    = true
   enable_private_nodes       = true

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -99,7 +99,7 @@ variable "http_load_balancing" {
 variable "network_policy" {
   type        = bool
   description = "Enable network policy addon"
-  default     = true
+  default     = false
 }
 
 variable "network_policy_provider" {

--- a/docs/upgrading_to_v14.0.md
+++ b/docs/upgrading_to_v14.0.md
@@ -17,6 +17,16 @@ The `registry_project_id` variable has been replaced with a `registry_project_id
 }
 ```
 
+### network_policy disabled by default
+The `network_policy` variable is now `false` by default (instead of `true`). 
+If you want to keep using the network policy addon for your cluster, make 
+sure that the `network_policy` variable is set to `true`:
+```
+module "gke" {
+   network_policy = true
+}
+```
+
 ### ASM default version changed to 1.8
 
 [ASM submodule](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/tree/master/modules/asm) has been changed to use ASM v1.8 as default.

--- a/docs/upgrading_to_v14.0.md
+++ b/docs/upgrading_to_v14.0.md
@@ -18,8 +18,8 @@ The `registry_project_id` variable has been replaced with a `registry_project_id
 ```
 
 ### network_policy disabled by default
-The `network_policy` variable is now `false` by default (instead of `true`). 
-If you want to keep using the network policy addon for your cluster, make 
+The `network_policy` variable is now `false` by default (instead of `true`).
+If you want to keep using the network policy addon for your cluster, make
 sure that the `network_policy` variable is set to `true`:
 ```diff
 module "gke" {

--- a/docs/upgrading_to_v14.0.md
+++ b/docs/upgrading_to_v14.0.md
@@ -21,9 +21,13 @@ The `registry_project_id` variable has been replaced with a `registry_project_id
 The `network_policy` variable is now `false` by default (instead of `true`). 
 If you want to keep using the network policy addon for your cluster, make 
 sure that the `network_policy` variable is set to `true`:
-```
+```diff
 module "gke" {
-   network_policy = true
+   source                  = "terraform-google-modules/kubernetes-engine/google"
+-  version                 = "~> 13.0"
++  version                 = "~> 14.0"
+
++  network_policy = true
 }
 ```
 

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -68,7 +68,7 @@ module "gke" {
   ip_range_services          = "us-central1-01-gke-01-services"
   http_load_balancing        = false
   horizontal_pod_autoscaling = true
-  network_policy             = true
+  network_policy             = false
   enable_private_endpoint    = true
   enable_private_nodes       = true
   master_ipv4_cidr_block     = "10.0.0.0/28"

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -214,7 +214,7 @@ Then perform the following commands on the root folder:
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |
 | name | The name of the cluster (required) | `string` | n/a | yes |
 | network | The VPC network to host the cluster in (required) | `string` | n/a | yes |
-| network\_policy | Enable network policy addon | `bool` | `true` | no |
+| network\_policy | Enable network policy addon | `bool` | `false` | no |
 | network\_policy\_provider | The network policy provider. | `string` | `"CALICO"` | no |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
 | node\_metadata | Specifies how node metadata is exposed to the workload running on the node | `string` | `"GKE_METADATA_SERVER"` | no |

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -99,7 +99,7 @@ variable "http_load_balancing" {
 variable "network_policy" {
   type        = bool
   description = "Enable network policy addon"
-  default     = true
+  default     = false
 }
 
 variable "network_policy_provider" {

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -46,7 +46,7 @@ module "gke" {
   ip_range_services          = "us-central1-01-gke-01-services"
   http_load_balancing        = false
   horizontal_pod_autoscaling = true
-  network_policy             = true
+  network_policy             = false
   enable_private_endpoint    = true
   enable_private_nodes       = true
   master_ipv4_cidr_block     = "10.0.0.0/28"

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -192,7 +192,7 @@ Then perform the following commands on the root folder:
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |
 | name | The name of the cluster (required) | `string` | n/a | yes |
 | network | The VPC network to host the cluster in (required) | `string` | n/a | yes |
-| network\_policy | Enable network policy addon | `bool` | `true` | no |
+| network\_policy | Enable network policy addon | `bool` | `false` | no |
 | network\_policy\_provider | The network policy provider. | `string` | `"CALICO"` | no |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
 | node\_metadata | Specifies how node metadata is exposed to the workload running on the node | `string` | `"GKE_METADATA_SERVER"` | no |

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -99,7 +99,7 @@ variable "http_load_balancing" {
 variable "network_policy" {
   type        = bool
   description = "Enable network policy addon"
-  default     = true
+  default     = false
 }
 
 variable "network_policy_provider" {

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -65,7 +65,7 @@ module "gke" {
   ip_range_services          = "us-central1-01-gke-01-services"
   http_load_balancing        = false
   horizontal_pod_autoscaling = true
-  network_policy             = true
+  network_policy             = false
   istio = true
   cloudrun = true
   dns_cache = false

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -203,7 +203,7 @@ Then perform the following commands on the root folder:
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |
 | name | The name of the cluster (required) | `string` | n/a | yes |
 | network | The VPC network to host the cluster in (required) | `string` | n/a | yes |
-| network\_policy | Enable network policy addon | `bool` | `true` | no |
+| network\_policy | Enable network policy addon | `bool` | `false` | no |
 | network\_policy\_provider | The network policy provider. | `string` | `"CALICO"` | no |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
 | node\_metadata | Specifies how node metadata is exposed to the workload running on the node | `string` | `"GKE_METADATA_SERVER"` | no |

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -99,7 +99,7 @@ variable "http_load_balancing" {
 variable "network_policy" {
   type        = bool
   description = "Enable network policy addon"
-  default     = true
+  default     = false
 }
 
 variable "network_policy_provider" {

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -181,7 +181,7 @@ Then perform the following commands on the root folder:
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |
 | name | The name of the cluster (required) | `string` | n/a | yes |
 | network | The VPC network to host the cluster in (required) | `string` | n/a | yes |
-| network\_policy | Enable network policy addon | `bool` | `true` | no |
+| network\_policy | Enable network policy addon | `bool` | `false` | no |
 | network\_policy\_provider | The network policy provider. | `string` | `"CALICO"` | no |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
 | node\_metadata | Specifies how node metadata is exposed to the workload running on the node | `string` | `"GKE_METADATA_SERVER"` | no |

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -43,7 +43,7 @@ module "gke" {
   ip_range_services          = "us-central1-01-gke-01-services"
   http_load_balancing        = false
   horizontal_pod_autoscaling = true
-  network_policy             = true
+  network_policy             = false
   istio = true
   cloudrun = true
   dns_cache = false

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -99,7 +99,7 @@ variable "http_load_balancing" {
 variable "network_policy" {
   type        = bool
   description = "Enable network policy addon"
-  default     = true
+  default     = false
 }
 
 variable "network_policy_provider" {

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -194,7 +194,7 @@ Then perform the following commands on the root folder:
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |
 | name | The name of the cluster (required) | `string` | n/a | yes |
 | network | The VPC network to host the cluster in (required) | `string` | n/a | yes |
-| network\_policy | Enable network policy addon | `bool` | `true` | no |
+| network\_policy | Enable network policy addon | `bool` | `false` | no |
 | network\_policy\_provider | The network policy provider. | `string` | `"CALICO"` | no |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
 | node\_metadata | Specifies how node metadata is exposed to the workload running on the node | `string` | `"GKE_METADATA_SERVER"` | no |

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -68,7 +68,7 @@ module "gke" {
   ip_range_services          = "us-central1-01-gke-01-services"
   http_load_balancing        = false
   horizontal_pod_autoscaling = true
-  network_policy             = true
+  network_policy             = false
   enable_private_endpoint    = true
   enable_private_nodes       = true
   master_ipv4_cidr_block     = "10.0.0.0/28"

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -99,7 +99,7 @@ variable "http_load_balancing" {
 variable "network_policy" {
   type        = bool
   description = "Enable network policy addon"
-  default     = true
+  default     = false
 }
 
 variable "network_policy_provider" {

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -172,7 +172,7 @@ Then perform the following commands on the root folder:
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |
 | name | The name of the cluster (required) | `string` | n/a | yes |
 | network | The VPC network to host the cluster in (required) | `string` | n/a | yes |
-| network\_policy | Enable network policy addon | `bool` | `true` | no |
+| network\_policy | Enable network policy addon | `bool` | `false` | no |
 | network\_policy\_provider | The network policy provider. | `string` | `"CALICO"` | no |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
 | node\_metadata | Specifies how node metadata is exposed to the workload running on the node | `string` | `"GKE_METADATA_SERVER"` | no |

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -46,7 +46,7 @@ module "gke" {
   ip_range_services          = "us-central1-01-gke-01-services"
   http_load_balancing        = false
   horizontal_pod_autoscaling = true
-  network_policy             = true
+  network_policy             = false
   enable_private_endpoint    = true
   enable_private_nodes       = true
   master_ipv4_cidr_block     = "10.0.0.0/28"

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -99,7 +99,7 @@ variable "http_load_balancing" {
 variable "network_policy" {
   type        = bool
   description = "Enable network policy addon"
-  default     = true
+  default     = false
 }
 
 variable "network_policy_provider" {

--- a/test/integration/beta_cluster/controls/gcloud.rb
+++ b/test/integration/beta_cluster/controls/gcloud.rb
@@ -57,7 +57,9 @@ control "gcloud" do
           },
           "kalmConfig" => {},
           "configConnectorConfig" => {},
-          "networkPolicyConfig" => {},
+          "networkPolicyConfig" => {
+            "disabled" => true,
+          },
           "istioConfig" => {"auth"=>"AUTH_MUTUAL_TLS"},
           "cloudRunConfig" => including(
               "loadBalancerType" => "LOAD_BALANCER_TYPE_EXTERNAL",

--- a/test/integration/private_zonal_with_networking/controls/gcloud.rb
+++ b/test/integration/private_zonal_with_networking/controls/gcloud.rb
@@ -63,7 +63,9 @@ control "gcloud" do
           "kubernetesDashboard" => {
             "disabled" => true,
           },
-          "networkPolicyConfig" => {},
+          "networkPolicyConfig" => {
+            "disabled" => true,
+          },
         )
       end
     end

--- a/test/integration/sandbox_enabled/controls/gcloud.rb
+++ b/test/integration/sandbox_enabled/controls/gcloud.rb
@@ -50,7 +50,9 @@ control "gcloud" do
           "kubernetesDashboard" => {
             "disabled" => true,
           },
-          "networkPolicyConfig" => {},
+          "networkPolicyConfig" => {
+            "disabled" => true,
+          },
         )
       end
     end

--- a/test/integration/simple_regional/controls/gcloud.rb
+++ b/test/integration/simple_regional/controls/gcloud.rb
@@ -50,7 +50,9 @@ control "gcloud" do
           "kubernetesDashboard" => {
             "disabled" => true,
           },
-          "networkPolicyConfig" => {},
+          "networkPolicyConfig" => {
+            "disabled" => true,
+          },
         )
       end
 

--- a/test/integration/simple_regional_private/controls/gcloud.rb
+++ b/test/integration/simple_regional_private/controls/gcloud.rb
@@ -58,7 +58,9 @@ control "gcloud" do
           "kubernetesDashboard" => {
             "disabled" => true,
           },
-          "networkPolicyConfig" => {},
+          "networkPolicyConfig" => {
+            "disabled" => true,
+          },
         )
       end
     end

--- a/test/integration/simple_regional_with_kubeconfig/controls/gcloud.rb
+++ b/test/integration/simple_regional_with_kubeconfig/controls/gcloud.rb
@@ -50,7 +50,9 @@ control "gcloud" do
           "kubernetesDashboard" => {
             "disabled" => true,
           },
-          "networkPolicyConfig" => {},
+          "networkPolicyConfig" => {
+            "disabled" => true,
+          },
         )
       end
     end

--- a/test/integration/simple_regional_with_networking/controls/gcloud.rb
+++ b/test/integration/simple_regional_with_networking/controls/gcloud.rb
@@ -50,7 +50,9 @@ control "gcloud" do
           "kubernetesDashboard" => {
             "disabled" => true,
           },
-          "networkPolicyConfig" => {},
+          "networkPolicyConfig" => {
+            "disabled" => true,
+          },
         )
       end
     end

--- a/test/integration/simple_zonal/controls/gcloud.rb
+++ b/test/integration/simple_zonal/controls/gcloud.rb
@@ -55,7 +55,9 @@ control "gcloud" do
           "kubernetesDashboard" => {
             "disabled" => true,
           },
-          "networkPolicyConfig" => {},
+          "networkPolicyConfig" => {
+            "disabled" => true,
+          },
         )
       end
     end

--- a/test/integration/simple_zonal_private/controls/gcloud.rb
+++ b/test/integration/simple_zonal_private/controls/gcloud.rb
@@ -58,7 +58,9 @@ control "gcloud" do
           "kubernetesDashboard" => {
             "disabled" => true,
           },
-          "networkPolicyConfig" => {},
+          "networkPolicyConfig" => {
+            "disabled" => true,
+          },
         )
       end
     end

--- a/test/integration/stub_domains/controls/gcloud.rb
+++ b/test/integration/stub_domains/controls/gcloud.rb
@@ -42,7 +42,9 @@ control "gcloud" do
           "kubernetesDashboard" => {
             "disabled" => true,
           },
-          "networkPolicyConfig" => {},
+          "networkPolicyConfig" => {
+            "disabled" => true,
+          },
         )
       end
     end

--- a/test/integration/stub_domains_private/controls/gcloud.rb
+++ b/test/integration/stub_domains_private/controls/gcloud.rb
@@ -49,7 +49,9 @@ control "gcloud" do
           "kubernetesDashboard" => {
             "disabled" => true,
           },
-          "networkPolicyConfig" => {},
+          "networkPolicyConfig" => {
+            "disabled" => true,
+          },
         )
       end
     end

--- a/test/integration/stub_domains_upstream_nameservers/controls/gcloud.rb
+++ b/test/integration/stub_domains_upstream_nameservers/controls/gcloud.rb
@@ -42,7 +42,9 @@ control "gcloud" do
           "kubernetesDashboard" => {
             "disabled" => true,
           },
-          "networkPolicyConfig" => {},
+          "networkPolicyConfig" => {
+            "disabled" => true,
+          },
         )
       end
     end

--- a/test/integration/upstream_nameservers/controls/gcloud.rb
+++ b/test/integration/upstream_nameservers/controls/gcloud.rb
@@ -42,7 +42,9 @@ control "gcloud" do
           "kubernetesDashboard" => {
             "disabled" => true,
           },
-          "networkPolicyConfig" => {},
+          "networkPolicyConfig" => {
+            "disabled" => true,
+          },
         )
       end
     end

--- a/variables.tf
+++ b/variables.tf
@@ -99,7 +99,7 @@ variable "http_load_balancing" {
 variable "network_policy" {
   type        = bool
   description = "Enable network policy addon"
-  default     = true
+  default     = false
 }
 
 variable "network_policy_provider" {


### PR DESCRIPTION
This PR fixes #804.

The only thing I'm not sure about is whether or not the `network_policy` checks are necessary in the `stub` integration tests (`stub_domains`, `stub_domains_private`, `stub_domains_upstream_nameservers`).