### PR TITLE
Feat: Control logging access

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Then perform the following commands on the root folder:
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | gcloud\_upgrade | Whether to upgrade gcloud at runtime | `bool` | `false` | no |
+| grant\_logging\_access | Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles. | `bool` | `true` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |

--- a/autogen/main/sa.tf.tmpl
+++ b/autogen/main/sa.tf.tmpl
@@ -42,28 +42,28 @@ resource "google_service_account" "cluster_service_account" {
 }
 
 resource "google_project_iam_member" "cluster_service_account-log_writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/logging.logWriter"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-metric_writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-log_writer[0].project
   role    = "roles/monitoring.metricWriter"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-metric_writer[0].project
   role    = "roles/monitoring.viewer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
   role    = "roles/stackdriver.resourceMetadata.writer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -352,6 +352,12 @@ variable "create_service_account" {
   default     = true
 }
 
+variable "grant_logging_access" {
+  type        = bool
+  description = "Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles."
+  default     = true
+}
+
 variable "grant_registry_access" {
   type        = bool
   description = "Grants created cluster-specific service account storage.objectViewer role."

--- a/autogen/safer-cluster/variables.tf.tmpl
+++ b/autogen/safer-cluster/variables.tf.tmpl
@@ -202,6 +202,12 @@ variable "monitoring_service" {
   default     = "monitoring.googleapis.com/kubernetes"
 }
 
+variable "grant_logging_access" {
+  type        = bool
+  description = "Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles."
+  default     = true
+}
+
 variable "grant_registry_access" {
   type        = bool
   description = "Grants created cluster-specific service account storage.objectViewer role."

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -189,6 +189,7 @@ Then perform the following commands on the root folder:
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | `bool` | `false` | no |
 | gcloud\_upgrade | Whether to upgrade gcloud at runtime | `bool` | `false` | no |
+| grant\_logging\_access | Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles. | `bool` | `true` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |

--- a/modules/beta-private-cluster-update-variant/sa.tf
+++ b/modules/beta-private-cluster-update-variant/sa.tf
@@ -42,28 +42,28 @@ resource "google_service_account" "cluster_service_account" {
 }
 
 resource "google_project_iam_member" "cluster_service_account-log_writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/logging.logWriter"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-metric_writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-log_writer[0].project
   role    = "roles/monitoring.metricWriter"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-metric_writer[0].project
   role    = "roles/monitoring.viewer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
   role    = "roles/stackdriver.resourceMetadata.writer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -340,6 +340,12 @@ variable "create_service_account" {
   default     = true
 }
 
+variable "grant_logging_access" {
+  type        = bool
+  description = "Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles."
+  default     = true
+}
+
 variable "grant_registry_access" {
   type        = bool
   description = "Grants created cluster-specific service account storage.objectViewer role."

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -167,6 +167,7 @@ Then perform the following commands on the root folder:
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | `bool` | `false` | no |
 | gcloud\_upgrade | Whether to upgrade gcloud at runtime | `bool` | `false` | no |
+| grant\_logging\_access | Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles. | `bool` | `true` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |

--- a/modules/beta-private-cluster/sa.tf
+++ b/modules/beta-private-cluster/sa.tf
@@ -42,28 +42,28 @@ resource "google_service_account" "cluster_service_account" {
 }
 
 resource "google_project_iam_member" "cluster_service_account-log_writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/logging.logWriter"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-metric_writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-log_writer[0].project
   role    = "roles/monitoring.metricWriter"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-metric_writer[0].project
   role    = "roles/monitoring.viewer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
   role    = "roles/stackdriver.resourceMetadata.writer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -340,6 +340,12 @@ variable "create_service_account" {
   default     = true
 }
 
+variable "grant_logging_access" {
+  type        = bool
+  description = "Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles."
+  default     = true
+}
+
 variable "grant_registry_access" {
   type        = bool
   description = "Grants created cluster-specific service account storage.objectViewer role."

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -180,6 +180,7 @@ Then perform the following commands on the root folder:
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | `bool` | `false` | no |
 | gcloud\_upgrade | Whether to upgrade gcloud at runtime | `bool` | `false` | no |
+| grant\_logging\_access | Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles. | `bool` | `true` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |

--- a/modules/beta-public-cluster-update-variant/sa.tf
+++ b/modules/beta-public-cluster-update-variant/sa.tf
@@ -42,28 +42,28 @@ resource "google_service_account" "cluster_service_account" {
 }
 
 resource "google_project_iam_member" "cluster_service_account-log_writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/logging.logWriter"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-metric_writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-log_writer[0].project
   role    = "roles/monitoring.metricWriter"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-metric_writer[0].project
   role    = "roles/monitoring.viewer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
   role    = "roles/stackdriver.resourceMetadata.writer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -340,6 +340,12 @@ variable "create_service_account" {
   default     = true
 }
 
+variable "grant_logging_access" {
+  type        = bool
+  description = "Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles."
+  default     = true
+}
+
 variable "grant_registry_access" {
   type        = bool
   description = "Grants created cluster-specific service account storage.objectViewer role."

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -158,6 +158,7 @@ Then perform the following commands on the root folder:
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | `bool` | `false` | no |
 | gcloud\_upgrade | Whether to upgrade gcloud at runtime | `bool` | `false` | no |
+| grant\_logging\_access | Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles. | `bool` | `true` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |

--- a/modules/beta-public-cluster/sa.tf
+++ b/modules/beta-public-cluster/sa.tf
@@ -42,28 +42,28 @@ resource "google_service_account" "cluster_service_account" {
 }
 
 resource "google_project_iam_member" "cluster_service_account-log_writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/logging.logWriter"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-metric_writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-log_writer[0].project
   role    = "roles/monitoring.metricWriter"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-metric_writer[0].project
   role    = "roles/monitoring.viewer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
   role    = "roles/stackdriver.resourceMetadata.writer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -340,6 +340,12 @@ variable "create_service_account" {
   default     = true
 }
 
+variable "grant_logging_access" {
+  type        = bool
+  description = "Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles."
+  default     = true
+}
+
 variable "grant_registry_access" {
   type        = bool
   description = "Grants created cluster-specific service account storage.objectViewer role."

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -174,6 +174,7 @@ Then perform the following commands on the root folder:
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | gcloud\_upgrade | Whether to upgrade gcloud at runtime | `bool` | `false` | no |
+| grant\_logging\_access | Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles. | `bool` | `true` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |

--- a/modules/private-cluster-update-variant/sa.tf
+++ b/modules/private-cluster-update-variant/sa.tf
@@ -42,28 +42,28 @@ resource "google_service_account" "cluster_service_account" {
 }
 
 resource "google_project_iam_member" "cluster_service_account-log_writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/logging.logWriter"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-metric_writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-log_writer[0].project
   role    = "roles/monitoring.metricWriter"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-metric_writer[0].project
   role    = "roles/monitoring.viewer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
   role    = "roles/stackdriver.resourceMetadata.writer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -304,6 +304,12 @@ variable "create_service_account" {
   default     = true
 }
 
+variable "grant_logging_access" {
+  type        = bool
+  description = "Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles."
+  default     = true
+}
+
 variable "grant_registry_access" {
   type        = bool
   description = "Grants created cluster-specific service account storage.objectViewer role."

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -152,6 +152,7 @@ Then perform the following commands on the root folder:
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | gcloud\_upgrade | Whether to upgrade gcloud at runtime | `bool` | `false` | no |
+| grant\_logging\_access | Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles. | `bool` | `true` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |

--- a/modules/private-cluster/sa.tf
+++ b/modules/private-cluster/sa.tf
@@ -42,28 +42,28 @@ resource "google_service_account" "cluster_service_account" {
 }
 
 resource "google_project_iam_member" "cluster_service_account-log_writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/logging.logWriter"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-metric_writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-log_writer[0].project
   role    = "roles/monitoring.metricWriter"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-metric_writer[0].project
   role    = "roles/monitoring.viewer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
   role    = "roles/stackdriver.resourceMetadata.writer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -304,6 +304,12 @@ variable "create_service_account" {
   default     = true
 }
 
+variable "grant_logging_access" {
+  type        = bool
+  description = "Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles."
+  default     = true
+}
+
 variable "grant_registry_access" {
   type        = bool
   description = "Grants created cluster-specific service account storage.objectViewer role."

--- a/modules/safer-cluster-update-variant/README.md
+++ b/modules/safer-cluster-update-variant/README.md
@@ -221,6 +221,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | `bool` | `true` | no |
+| grant\_logging\_access | Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles. | `bool` | `true` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | `bool` | `true` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon. The addon allows whoever can create Ingress objects to expose an application to a public IP. Network policies or Gatekeeper policies should be used to verify that only authorized applications are exposed. | `bool` | `true` | no |

--- a/modules/safer-cluster-update-variant/variables.tf
+++ b/modules/safer-cluster-update-variant/variables.tf
@@ -202,6 +202,12 @@ variable "monitoring_service" {
   default     = "monitoring.googleapis.com/kubernetes"
 }
 
+variable "grant_logging_access" {
+  type        = bool
+  description = "Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles."
+  default     = true
+}
+
 variable "grant_registry_access" {
   type        = bool
   description = "Grants created cluster-specific service account storage.objectViewer role."

--- a/modules/safer-cluster/README.md
+++ b/modules/safer-cluster/README.md
@@ -221,6 +221,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | `bool` | `true` | no |
+| grant\_logging\_access | Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles. | `bool` | `true` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | `bool` | `true` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon. The addon allows whoever can create Ingress objects to expose an application to a public IP. Network policies or Gatekeeper policies should be used to verify that only authorized applications are exposed. | `bool` | `true` | no |

--- a/modules/safer-cluster/variables.tf
+++ b/modules/safer-cluster/variables.tf
@@ -202,6 +202,12 @@ variable "monitoring_service" {
   default     = "monitoring.googleapis.com/kubernetes"
 }
 
+variable "grant_logging_access" {
+  type        = bool
+  description = "Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles."
+  default     = true
+}
+
 variable "grant_registry_access" {
   type        = bool
   description = "Grants created cluster-specific service account storage.objectViewer role."

--- a/sa.tf
+++ b/sa.tf
@@ -42,28 +42,28 @@ resource "google_service_account" "cluster_service_account" {
 }
 
 resource "google_project_iam_member" "cluster_service_account-log_writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/logging.logWriter"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-metric_writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-log_writer[0].project
   role    = "roles/monitoring.metricWriter"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-metric_writer[0].project
   role    = "roles/monitoring.viewer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
-  count   = var.create_service_account ? 1 : 0
+  count   = var.create_service_account && var.grant_logging_access ? 1 : 0
   project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
   role    = "roles/stackdriver.resourceMetadata.writer"
   member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"

--- a/variables.tf
+++ b/variables.tf
@@ -304,6 +304,12 @@ variable "create_service_account" {
   default     = true
 }
 
+variable "grant_logging_access" {
+  type        = bool
+  description = "Grants created cluster-specific service account logging.logWriter, monitoring.metricWriter, monitoring.viewer, and stackdriver.resourceMetadata.writer roles."
+  default     = true
+}
+
 variable "grant_registry_access" {
   type        = bool
   description = "Grants created cluster-specific service account storage.objectViewer role."


### PR DESCRIPTION
When using this module in a project that maintains control over project-level IAM with a `google_project_iam_policy` resource, adding IAM roles through `google_project_iam_member` resources becomes a bit problematic as the resources will fight. This PR adds a flag to control whether the service account is automatically granted access to the `logging.logWriter`, `monitoring.metricWriter`, `monitoring.viewer`, and `stackdriver.resourceMetadata.writer` roles or not.

While this could already be accomplished by setting your own service account, a user may wish to have the module still create the service account but at the same time have IAM roles managed elsewhere.