### PR TITLE
Feat: Multiple registry projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
+| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
+| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Project holding the Google Container Registry. If empty, we use the cluster project. If grant\_registry\_access is true, storage.objectViewer role is assigned on this project. | `string` | `""` | no |
+| registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |
 | resource\_usage\_export\_dataset\_id | The ID of a BigQuery Dataset for using BigQuery as the destination of resource usage export. | `string` | `""` | no |
@@ -280,7 +280,7 @@ following project roles:
 - roles/iam.serviceAccountUser
 - roles/resourcemanager.projectIamAdmin (only required if `service_account` is set to `create`)
 
-Additionally, if `service_account` is set to `create` and `grant_registry_access` is requested, the service account requires the following role on the `registry_project_id` project:
+Additionally, if `service_account` is set to `create` and `grant_registry_access` is requested, the service account requires the following role on the `registry_project_ids` projects:
 - roles/resourcemanager.projectIamAdmin
 
 ### Enable APIs

--- a/autogen/main/README.md
+++ b/autogen/main/README.md
@@ -241,7 +241,7 @@ following project roles:
 - roles/iam.serviceAccountUser
 - roles/resourcemanager.projectIamAdmin (only required if `service_account` is set to `create`)
 
-Additionally, if `service_account` is set to `create` and `grant_registry_access` is requested, the service account requires the following role on the `registry_project_id` project:
+Additionally, if `service_account` is set to `create` and `grant_registry_access` is requested, the service account requires the following role on the `registry_project_ids` projects:
 - roles/resourcemanager.projectIamAdmin
 
 ### Enable APIs

--- a/autogen/main/sa.tf.tmpl
+++ b/autogen/main/sa.tf.tmpl
@@ -28,8 +28,8 @@ locals {
 
   registry_projects_list = compact(
     length(var.registry_project_ids) == 0 && var.registry_project_id == ""
-      ? [var.project_id]
-      : concat([var.registry_project_id], var.registry_project_ids)
+    ? [var.project_id]
+    : concat([var.registry_project_id], var.registry_project_ids)
   )
 }
 

--- a/autogen/main/sa.tf.tmpl
+++ b/autogen/main/sa.tf.tmpl
@@ -26,7 +26,11 @@ locals {
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 
-  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
+  registry_projects_list = compact(
+    length(var.registry_project_ids) == 0 && var.registry_project_id == ""
+      ? [var.project_id]
+      : concat([var.registry_project_id], var.registry_project_ids)
+  )
 }
 
 resource "random_string" "cluster_service_account_suffix" {

--- a/autogen/main/sa.tf.tmpl
+++ b/autogen/main/sa.tf.tmpl
@@ -25,6 +25,8 @@ locals {
   )
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
+
+  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
 }
 
 resource "random_string" "cluster_service_account_suffix" {
@@ -70,15 +72,15 @@ resource "google_project_iam_member" "cluster_service_account-resourceMetadata-w
 }
 
 resource "google_project_iam_member" "cluster_service_account-gcr" {
-  count   = var.create_service_account && var.grant_registry_access ? 1 : 0
-  project = var.registry_project_id == "" ? var.project_id : var.registry_project_id
-  role    = "roles/storage.objectViewer"
-  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+  for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/storage.objectViewer"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
-  count   = var.create_service_account && var.grant_registry_access ? 1 : 0
-  project = var.registry_project_id == "" ? var.project_id : var.registry_project_id
-  role    = "roles/artifactregistry.reader"
-  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+  for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -358,6 +358,12 @@ variable "grant_registry_access" {
   default     = false
 }
 
+variable "registry_project_id" {
+  type        = string
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
+  default     = ""
+}
+
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -358,10 +358,10 @@ variable "grant_registry_access" {
   default     = false
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Project holding the Google Container Registry. If empty, we use the cluster project. If grant_registry_access is true, storage.objectViewer role is assigned on this project."
-  default     = ""
+variable "registry_project_ids" {
+  type        = list(string)
+  description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."
+  default     = []
 }
 
 variable "service_account" {

--- a/autogen/safer-cluster/README.md
+++ b/autogen/safer-cluster/README.md
@@ -53,7 +53,8 @@ developers, which mostly just want to deploy and debug applications.
     own projects, so that they can be administered independently (e.g., dev cluster;
     production clusters; staging clusters should go in different projects.)
 
--   *A shared GCR project (`registry_project_ids`):* all clusters can share the same GCR project.
+-   *Shared GCR projects (`registry_project_ids`):* all clusters can share the same
+    GCR projects.
 
     -   Easier to share images between environments. The same image could be
         progressively rolled-out in dev, staging, and then production.

--- a/autogen/safer-cluster/README.md
+++ b/autogen/safer-cluster/README.md
@@ -53,7 +53,7 @@ developers, which mostly just want to deploy and debug applications.
     own projects, so that they can be administered independently (e.g., dev cluster;
     production clusters; staging clusters should go in different projects.)
 
--   *A shared GCR project (`registry_project_id`):* all clusters can share the same GCR project.
+-   *A shared GCR project (`registry_project_ids`):* all clusters can share the same GCR project.
 
     -   Easier to share images between environments. The same image could be
         progressively rolled-out in dev, staging, and then production.
@@ -93,7 +93,7 @@ The Safer Cluster setup relies on several service accounts:
 
 ```
 create_service_account = true
-registry_project_id = <the project id for your GCR project>
+registry_project_ids = [<the project id for your GCR project>]
 grant_registry_access = true
 ```
 

--- a/autogen/safer-cluster/main.tf.tmpl
+++ b/autogen/safer-cluster/main.tf.tmpl
@@ -100,6 +100,7 @@ module "gke" {
   //   wants to maintain control of their service accounts.
   create_service_account = var.compute_engine_service_account == "" ? true : false
   service_account        = var.compute_engine_service_account
+  registry_project_id    = var.registry_project_id
   registry_project_ids   = var.registry_project_ids
   grant_registry_access  = var.grant_registry_access
 

--- a/autogen/safer-cluster/main.tf.tmpl
+++ b/autogen/safer-cluster/main.tf.tmpl
@@ -100,7 +100,7 @@ module "gke" {
   //   wants to maintain control of their service accounts.
   create_service_account = var.compute_engine_service_account == "" ? true : false
   service_account        = var.compute_engine_service_account
-  registry_project_id    = var.registry_project_id
+  registry_project_ids   = var.registry_project_ids
   grant_registry_access  = var.grant_registry_access
 
   // Basic Auth disabled

--- a/autogen/safer-cluster/variables.tf.tmpl
+++ b/autogen/safer-cluster/variables.tf.tmpl
@@ -208,6 +208,12 @@ variable "grant_registry_access" {
   default     = true
 }
 
+variable "registry_project_id" {
+  type        = string
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
+  default     = ""
+}
+
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/autogen/safer-cluster/variables.tf.tmpl
+++ b/autogen/safer-cluster/variables.tf.tmpl
@@ -208,10 +208,10 @@ variable "grant_registry_access" {
   default     = true
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Project holding the Google Container Registry. If empty, we use the cluster project. If grant_registry_access is true, storage.objectViewer role is assigned on this project."
-  default     = ""
+variable "registry_project_ids" {
+  type        = list(string)
+  description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."
+  default     = []
 }
 
 variable "cluster_resource_labels" {

--- a/examples/workload_metadata_config/main.tf
+++ b/examples/workload_metadata_config/main.tf
@@ -51,7 +51,7 @@ module "gke" {
   ip_range_services       = var.ip_range_services
   create_service_account  = true
   grant_registry_access   = true
-  registry_project_id     = var.registry_project_id
+  registry_project_ids    = var.registry_project_ids
   enable_private_endpoint = true
   enable_private_nodes    = true
   master_ipv4_cidr_block  = "172.16.0.0/28"

--- a/examples/workload_metadata_config/main.tf
+++ b/examples/workload_metadata_config/main.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {}
 
 provider "kubernetes" {
   load_config_file       = false
-  host                   = module.gke.endpoint
+  host                   = "https://${module.gke.endpoint}"
   token                  = data.google_client_config.default.access_token
   cluster_ca_certificate = base64decode(module.gke.ca_certificate)
 }
@@ -53,14 +53,14 @@ module "gke" {
   grant_registry_access   = true
   registry_project_ids    = var.registry_project_ids
   enable_private_endpoint = true
-  enable_private_nodes    = false
-  master_ipv4_cidr_block  = "172.19.0.0/28"
+  enable_private_nodes    = true
+  master_ipv4_cidr_block  = "172.16.0.0/28"
   node_metadata           = "SECURE"
 
-  #  master_authorized_networks = [
-  #    {
-  #      cidr_block   = data.google_compute_subnetwork.subnetwork.ip_cidr_range
-  #      display_name = "VPC"
-  #    },
-  #  ]
+  master_authorized_networks = [
+    {
+      cidr_block   = data.google_compute_subnetwork.subnetwork.ip_cidr_range
+      display_name = "VPC"
+    },
+  ]
 }

--- a/examples/workload_metadata_config/main.tf
+++ b/examples/workload_metadata_config/main.tf
@@ -27,7 +27,7 @@ data "google_client_config" "default" {}
 
 provider "kubernetes" {
   load_config_file       = false
-  host                   = "https://${module.gke.endpoint}"
+  host                   = module.gke.endpoint
   token                  = data.google_client_config.default.access_token
   cluster_ca_certificate = base64decode(module.gke.ca_certificate)
 }
@@ -53,14 +53,14 @@ module "gke" {
   grant_registry_access   = true
   registry_project_ids    = var.registry_project_ids
   enable_private_endpoint = true
-  enable_private_nodes    = true
-  master_ipv4_cidr_block  = "172.16.0.0/28"
+  enable_private_nodes    = false
+  master_ipv4_cidr_block  = "172.19.0.0/28"
   node_metadata           = "SECURE"
 
-  master_authorized_networks = [
-    {
-      cidr_block   = data.google_compute_subnetwork.subnetwork.ip_cidr_range
-      display_name = "VPC"
-    },
-  ]
+  #  master_authorized_networks = [
+  #    {
+  #      cidr_block   = data.google_compute_subnetwork.subnetwork.ip_cidr_range
+  #      display_name = "VPC"
+  #    },
+  #  ]
 }

--- a/examples/workload_metadata_config/outputs.tf
+++ b/examples/workload_metadata_config/outputs.tf
@@ -25,7 +25,8 @@ output "client_token" {
 }
 
 output "ca_certificate" {
-  value = module.gke.ca_certificate
+  sensitive = true
+  value     = module.gke.ca_certificate
 }
 
 output "service_account" {

--- a/examples/workload_metadata_config/variables.tf
+++ b/examples/workload_metadata_config/variables.tf
@@ -48,6 +48,7 @@ variable "ip_range_services" {
   description = "The secondary ip range to use for services"
 }
 
-variable "registry_project_id" {
-  description = "Project name for the GCR registry"
+variable "registry_project_ids" {
+  description = "Project names for GCR registries"
+  type        = list(string)
 }

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -231,7 +231,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Project holding the Google Container Registry. If empty, we use the cluster project. If grant\_registry\_access is true, storage.objectViewer role is assigned on this project. | `string` | `""` | no |
+| registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |
 | resource\_usage\_export\_dataset\_id | The ID of a BigQuery Dataset for using BigQuery as the destination of resource usage export. | `string` | `""` | no |
@@ -350,7 +350,7 @@ following project roles:
 - roles/iam.serviceAccountUser
 - roles/resourcemanager.projectIamAdmin (only required if `service_account` is set to `create`)
 
-Additionally, if `service_account` is set to `create` and `grant_registry_access` is requested, the service account requires the following role on the `registry_project_id` project:
+Additionally, if `service_account` is set to `create` and `grant_registry_access` is requested, the service account requires the following role on the `registry_project_ids` projects:
 - roles/resourcemanager.projectIamAdmin
 
 ### Enable APIs

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -231,6 +231,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
+| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -231,7 +231,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
+| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/modules/beta-private-cluster-update-variant/sa.tf
+++ b/modules/beta-private-cluster-update-variant/sa.tf
@@ -28,8 +28,8 @@ locals {
 
   registry_projects_list = compact(
     length(var.registry_project_ids) == 0 && var.registry_project_id == ""
-      ? [var.project_id]
-      : concat([var.registry_project_id], var.registry_project_ids)
+    ? [var.project_id]
+    : concat([var.registry_project_id], var.registry_project_ids)
   )
 }
 

--- a/modules/beta-private-cluster-update-variant/sa.tf
+++ b/modules/beta-private-cluster-update-variant/sa.tf
@@ -26,7 +26,11 @@ locals {
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 
-  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
+  registry_projects_list = compact(
+    length(var.registry_project_ids) == 0 && var.registry_project_id == ""
+      ? [var.project_id]
+      : concat([var.registry_project_id], var.registry_project_ids)
+  )
 }
 
 resource "random_string" "cluster_service_account_suffix" {

--- a/modules/beta-private-cluster-update-variant/sa.tf
+++ b/modules/beta-private-cluster-update-variant/sa.tf
@@ -25,6 +25,8 @@ locals {
   )
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
+
+  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
 }
 
 resource "random_string" "cluster_service_account_suffix" {
@@ -70,15 +72,15 @@ resource "google_project_iam_member" "cluster_service_account-resourceMetadata-w
 }
 
 resource "google_project_iam_member" "cluster_service_account-gcr" {
-  count   = var.create_service_account && var.grant_registry_access ? 1 : 0
-  project = var.registry_project_id == "" ? var.project_id : var.registry_project_id
-  role    = "roles/storage.objectViewer"
-  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+  for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/storage.objectViewer"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
-  count   = var.create_service_account && var.grant_registry_access ? 1 : 0
-  project = var.registry_project_id == "" ? var.project_id : var.registry_project_id
-  role    = "roles/artifactregistry.reader"
-  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+  for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -346,6 +346,12 @@ variable "grant_registry_access" {
   default     = false
 }
 
+variable "registry_project_id" {
+  type        = string
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version."
+  default     = ""
+}
+
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -348,7 +348,7 @@ variable "grant_registry_access" {
 
 variable "registry_project_id" {
   type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version."
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
   default     = ""
 }
 

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -346,10 +346,10 @@ variable "grant_registry_access" {
   default     = false
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Project holding the Google Container Registry. If empty, we use the cluster project. If grant_registry_access is true, storage.objectViewer role is assigned on this project."
-  default     = ""
+variable "registry_project_ids" {
+  type        = list(string)
+  description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."
+  default     = []
 }
 
 variable "service_account" {

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -209,7 +209,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Project holding the Google Container Registry. If empty, we use the cluster project. If grant\_registry\_access is true, storage.objectViewer role is assigned on this project. | `string` | `""` | no |
+| registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |
 | resource\_usage\_export\_dataset\_id | The ID of a BigQuery Dataset for using BigQuery as the destination of resource usage export. | `string` | `""` | no |
@@ -328,7 +328,7 @@ following project roles:
 - roles/iam.serviceAccountUser
 - roles/resourcemanager.projectIamAdmin (only required if `service_account` is set to `create`)
 
-Additionally, if `service_account` is set to `create` and `grant_registry_access` is requested, the service account requires the following role on the `registry_project_id` project:
+Additionally, if `service_account` is set to `create` and `grant_registry_access` is requested, the service account requires the following role on the `registry_project_ids` projects:
 - roles/resourcemanager.projectIamAdmin
 
 ### Enable APIs

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -209,7 +209,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
+| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -209,6 +209,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
+| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/modules/beta-private-cluster/sa.tf
+++ b/modules/beta-private-cluster/sa.tf
@@ -28,8 +28,8 @@ locals {
 
   registry_projects_list = compact(
     length(var.registry_project_ids) == 0 && var.registry_project_id == ""
-      ? [var.project_id]
-      : concat([var.registry_project_id], var.registry_project_ids)
+    ? [var.project_id]
+    : concat([var.registry_project_id], var.registry_project_ids)
   )
 }
 

--- a/modules/beta-private-cluster/sa.tf
+++ b/modules/beta-private-cluster/sa.tf
@@ -26,7 +26,11 @@ locals {
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 
-  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
+  registry_projects_list = compact(
+    length(var.registry_project_ids) == 0 && var.registry_project_id == ""
+      ? [var.project_id]
+      : concat([var.registry_project_id], var.registry_project_ids)
+  )
 }
 
 resource "random_string" "cluster_service_account_suffix" {

--- a/modules/beta-private-cluster/sa.tf
+++ b/modules/beta-private-cluster/sa.tf
@@ -25,6 +25,8 @@ locals {
   )
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
+
+  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
 }
 
 resource "random_string" "cluster_service_account_suffix" {
@@ -70,15 +72,15 @@ resource "google_project_iam_member" "cluster_service_account-resourceMetadata-w
 }
 
 resource "google_project_iam_member" "cluster_service_account-gcr" {
-  count   = var.create_service_account && var.grant_registry_access ? 1 : 0
-  project = var.registry_project_id == "" ? var.project_id : var.registry_project_id
-  role    = "roles/storage.objectViewer"
-  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+  for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/storage.objectViewer"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
-  count   = var.create_service_account && var.grant_registry_access ? 1 : 0
-  project = var.registry_project_id == "" ? var.project_id : var.registry_project_id
-  role    = "roles/artifactregistry.reader"
-  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+  for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -346,6 +346,12 @@ variable "grant_registry_access" {
   default     = false
 }
 
+variable "registry_project_id" {
+  type        = string
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version."
+  default     = ""
+}
+
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -348,7 +348,7 @@ variable "grant_registry_access" {
 
 variable "registry_project_id" {
   type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version."
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
   default     = ""
 }
 

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -346,10 +346,10 @@ variable "grant_registry_access" {
   default     = false
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Project holding the Google Container Registry. If empty, we use the cluster project. If grant_registry_access is true, storage.objectViewer role is assigned on this project."
-  default     = ""
+variable "registry_project_ids" {
+  type        = list(string)
+  description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."
+  default     = []
 }
 
 variable "service_account" {

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -220,7 +220,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Project holding the Google Container Registry. If empty, we use the cluster project. If grant\_registry\_access is true, storage.objectViewer role is assigned on this project. | `string` | `""` | no |
+| registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |
 | resource\_usage\_export\_dataset\_id | The ID of a BigQuery Dataset for using BigQuery as the destination of resource usage export. | `string` | `""` | no |
@@ -337,7 +337,7 @@ following project roles:
 - roles/iam.serviceAccountUser
 - roles/resourcemanager.projectIamAdmin (only required if `service_account` is set to `create`)
 
-Additionally, if `service_account` is set to `create` and `grant_registry_access` is requested, the service account requires the following role on the `registry_project_id` project:
+Additionally, if `service_account` is set to `create` and `grant_registry_access` is requested, the service account requires the following role on the `registry_project_ids` projects:
 - roles/resourcemanager.projectIamAdmin
 
 ### Enable APIs

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -220,6 +220,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
+| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -220,7 +220,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
+| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/modules/beta-public-cluster-update-variant/sa.tf
+++ b/modules/beta-public-cluster-update-variant/sa.tf
@@ -28,8 +28,8 @@ locals {
 
   registry_projects_list = compact(
     length(var.registry_project_ids) == 0 && var.registry_project_id == ""
-      ? [var.project_id]
-      : concat([var.registry_project_id], var.registry_project_ids)
+    ? [var.project_id]
+    : concat([var.registry_project_id], var.registry_project_ids)
   )
 }
 

--- a/modules/beta-public-cluster-update-variant/sa.tf
+++ b/modules/beta-public-cluster-update-variant/sa.tf
@@ -26,7 +26,11 @@ locals {
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 
-  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
+  registry_projects_list = compact(
+    length(var.registry_project_ids) == 0 && var.registry_project_id == ""
+      ? [var.project_id]
+      : concat([var.registry_project_id], var.registry_project_ids)
+  )
 }
 
 resource "random_string" "cluster_service_account_suffix" {

--- a/modules/beta-public-cluster-update-variant/sa.tf
+++ b/modules/beta-public-cluster-update-variant/sa.tf
@@ -25,6 +25,8 @@ locals {
   )
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
+
+  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
 }
 
 resource "random_string" "cluster_service_account_suffix" {
@@ -70,15 +72,15 @@ resource "google_project_iam_member" "cluster_service_account-resourceMetadata-w
 }
 
 resource "google_project_iam_member" "cluster_service_account-gcr" {
-  count   = var.create_service_account && var.grant_registry_access ? 1 : 0
-  project = var.registry_project_id == "" ? var.project_id : var.registry_project_id
-  role    = "roles/storage.objectViewer"
-  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+  for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/storage.objectViewer"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
-  count   = var.create_service_account && var.grant_registry_access ? 1 : 0
-  project = var.registry_project_id == "" ? var.project_id : var.registry_project_id
-  role    = "roles/artifactregistry.reader"
-  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+  for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -346,6 +346,12 @@ variable "grant_registry_access" {
   default     = false
 }
 
+variable "registry_project_id" {
+  type        = string
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version."
+  default     = ""
+}
+
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -348,7 +348,7 @@ variable "grant_registry_access" {
 
 variable "registry_project_id" {
   type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version."
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
   default     = ""
 }
 

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -346,10 +346,10 @@ variable "grant_registry_access" {
   default     = false
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Project holding the Google Container Registry. If empty, we use the cluster project. If grant_registry_access is true, storage.objectViewer role is assigned on this project."
-  default     = ""
+variable "registry_project_ids" {
+  type        = list(string)
+  description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."
+  default     = []
 }
 
 variable "service_account" {

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -198,7 +198,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Project holding the Google Container Registry. If empty, we use the cluster project. If grant\_registry\_access is true, storage.objectViewer role is assigned on this project. | `string` | `""` | no |
+| registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |
 | resource\_usage\_export\_dataset\_id | The ID of a BigQuery Dataset for using BigQuery as the destination of resource usage export. | `string` | `""` | no |
@@ -315,7 +315,7 @@ following project roles:
 - roles/iam.serviceAccountUser
 - roles/resourcemanager.projectIamAdmin (only required if `service_account` is set to `create`)
 
-Additionally, if `service_account` is set to `create` and `grant_registry_access` is requested, the service account requires the following role on the `registry_project_id` project:
+Additionally, if `service_account` is set to `create` and `grant_registry_access` is requested, the service account requires the following role on the `registry_project_ids` projects:
 - roles/resourcemanager.projectIamAdmin
 
 ### Enable APIs

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -198,6 +198,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
+| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -198,7 +198,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
+| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/modules/beta-public-cluster/sa.tf
+++ b/modules/beta-public-cluster/sa.tf
@@ -28,8 +28,8 @@ locals {
 
   registry_projects_list = compact(
     length(var.registry_project_ids) == 0 && var.registry_project_id == ""
-      ? [var.project_id]
-      : concat([var.registry_project_id], var.registry_project_ids)
+    ? [var.project_id]
+    : concat([var.registry_project_id], var.registry_project_ids)
   )
 }
 

--- a/modules/beta-public-cluster/sa.tf
+++ b/modules/beta-public-cluster/sa.tf
@@ -26,7 +26,11 @@ locals {
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 
-  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
+  registry_projects_list = compact(
+    length(var.registry_project_ids) == 0 && var.registry_project_id == ""
+      ? [var.project_id]
+      : concat([var.registry_project_id], var.registry_project_ids)
+  )
 }
 
 resource "random_string" "cluster_service_account_suffix" {

--- a/modules/beta-public-cluster/sa.tf
+++ b/modules/beta-public-cluster/sa.tf
@@ -25,6 +25,8 @@ locals {
   )
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
+
+  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
 }
 
 resource "random_string" "cluster_service_account_suffix" {
@@ -70,15 +72,15 @@ resource "google_project_iam_member" "cluster_service_account-resourceMetadata-w
 }
 
 resource "google_project_iam_member" "cluster_service_account-gcr" {
-  count   = var.create_service_account && var.grant_registry_access ? 1 : 0
-  project = var.registry_project_id == "" ? var.project_id : var.registry_project_id
-  role    = "roles/storage.objectViewer"
-  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+  for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/storage.objectViewer"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
-  count   = var.create_service_account && var.grant_registry_access ? 1 : 0
-  project = var.registry_project_id == "" ? var.project_id : var.registry_project_id
-  role    = "roles/artifactregistry.reader"
-  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+  for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -346,6 +346,12 @@ variable "grant_registry_access" {
   default     = false
 }
 
+variable "registry_project_id" {
+  type        = string
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version."
+  default     = ""
+}
+
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -348,7 +348,7 @@ variable "grant_registry_access" {
 
 variable "registry_project_id" {
   type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version."
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
   default     = ""
 }
 

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -346,10 +346,10 @@ variable "grant_registry_access" {
   default     = false
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Project holding the Google Container Registry. If empty, we use the cluster project. If grant_registry_access is true, storage.objectViewer role is assigned on this project."
-  default     = ""
+variable "registry_project_ids" {
+  type        = list(string)
+  description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."
+  default     = []
 }
 
 variable "service_account" {

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -208,7 +208,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Project holding the Google Container Registry. If empty, we use the cluster project. If grant\_registry\_access is true, storage.objectViewer role is assigned on this project. | `string` | `""` | no |
+| registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |
 | resource\_usage\_export\_dataset\_id | The ID of a BigQuery Dataset for using BigQuery as the destination of resource usage export. | `string` | `""` | no |
@@ -314,7 +314,7 @@ following project roles:
 - roles/iam.serviceAccountUser
 - roles/resourcemanager.projectIamAdmin (only required if `service_account` is set to `create`)
 
-Additionally, if `service_account` is set to `create` and `grant_registry_access` is requested, the service account requires the following role on the `registry_project_id` project:
+Additionally, if `service_account` is set to `create` and `grant_registry_access` is requested, the service account requires the following role on the `registry_project_ids` projects:
 - roles/resourcemanager.projectIamAdmin
 
 ### Enable APIs

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -208,7 +208,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
+| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -208,6 +208,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
+| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/modules/private-cluster-update-variant/sa.tf
+++ b/modules/private-cluster-update-variant/sa.tf
@@ -28,8 +28,8 @@ locals {
 
   registry_projects_list = compact(
     length(var.registry_project_ids) == 0 && var.registry_project_id == ""
-      ? [var.project_id]
-      : concat([var.registry_project_id], var.registry_project_ids)
+    ? [var.project_id]
+    : concat([var.registry_project_id], var.registry_project_ids)
   )
 }
 

--- a/modules/private-cluster-update-variant/sa.tf
+++ b/modules/private-cluster-update-variant/sa.tf
@@ -26,7 +26,11 @@ locals {
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 
-  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
+  registry_projects_list = compact(
+    length(var.registry_project_ids) == 0 && var.registry_project_id == ""
+      ? [var.project_id]
+      : concat([var.registry_project_id], var.registry_project_ids)
+  )
 }
 
 resource "random_string" "cluster_service_account_suffix" {

--- a/modules/private-cluster-update-variant/sa.tf
+++ b/modules/private-cluster-update-variant/sa.tf
@@ -25,6 +25,8 @@ locals {
   )
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
+
+  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
 }
 
 resource "random_string" "cluster_service_account_suffix" {
@@ -70,15 +72,15 @@ resource "google_project_iam_member" "cluster_service_account-resourceMetadata-w
 }
 
 resource "google_project_iam_member" "cluster_service_account-gcr" {
-  count   = var.create_service_account && var.grant_registry_access ? 1 : 0
-  project = var.registry_project_id == "" ? var.project_id : var.registry_project_id
-  role    = "roles/storage.objectViewer"
-  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+  for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/storage.objectViewer"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
-  count   = var.create_service_account && var.grant_registry_access ? 1 : 0
-  project = var.registry_project_id == "" ? var.project_id : var.registry_project_id
-  role    = "roles/artifactregistry.reader"
-  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+  for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -312,7 +312,7 @@ variable "grant_registry_access" {
 
 variable "registry_project_id" {
   type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version."
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
   default     = ""
 }
 

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -310,6 +310,12 @@ variable "grant_registry_access" {
   default     = false
 }
 
+variable "registry_project_id" {
+  type        = string
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version."
+  default     = ""
+}
+
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -310,10 +310,10 @@ variable "grant_registry_access" {
   default     = false
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Project holding the Google Container Registry. If empty, we use the cluster project. If grant_registry_access is true, storage.objectViewer role is assigned on this project."
-  default     = ""
+variable "registry_project_ids" {
+  type        = list(string)
+  description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."
+  default     = []
 }
 
 variable "service_account" {

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -186,7 +186,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
+| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -186,7 +186,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Project holding the Google Container Registry. If empty, we use the cluster project. If grant\_registry\_access is true, storage.objectViewer role is assigned on this project. | `string` | `""` | no |
+| registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |
 | resource\_usage\_export\_dataset\_id | The ID of a BigQuery Dataset for using BigQuery as the destination of resource usage export. | `string` | `""` | no |
@@ -292,7 +292,7 @@ following project roles:
 - roles/iam.serviceAccountUser
 - roles/resourcemanager.projectIamAdmin (only required if `service_account` is set to `create`)
 
-Additionally, if `service_account` is set to `create` and `grant_registry_access` is requested, the service account requires the following role on the `registry_project_id` project:
+Additionally, if `service_account` is set to `create` and `grant_registry_access` is requested, the service account requires the following role on the `registry_project_ids` projects:
 - roles/resourcemanager.projectIamAdmin
 
 ### Enable APIs

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -186,6 +186,7 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
+| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/modules/private-cluster/sa.tf
+++ b/modules/private-cluster/sa.tf
@@ -28,8 +28,8 @@ locals {
 
   registry_projects_list = compact(
     length(var.registry_project_ids) == 0 && var.registry_project_id == ""
-      ? [var.project_id]
-      : concat([var.registry_project_id], var.registry_project_ids)
+    ? [var.project_id]
+    : concat([var.registry_project_id], var.registry_project_ids)
   )
 }
 

--- a/modules/private-cluster/sa.tf
+++ b/modules/private-cluster/sa.tf
@@ -26,7 +26,11 @@ locals {
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 
-  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
+  registry_projects_list = compact(
+    length(var.registry_project_ids) == 0 && var.registry_project_id == ""
+      ? [var.project_id]
+      : concat([var.registry_project_id], var.registry_project_ids)
+  )
 }
 
 resource "random_string" "cluster_service_account_suffix" {

--- a/modules/private-cluster/sa.tf
+++ b/modules/private-cluster/sa.tf
@@ -25,6 +25,8 @@ locals {
   )
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
+
+  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
 }
 
 resource "random_string" "cluster_service_account_suffix" {
@@ -70,15 +72,15 @@ resource "google_project_iam_member" "cluster_service_account-resourceMetadata-w
 }
 
 resource "google_project_iam_member" "cluster_service_account-gcr" {
-  count   = var.create_service_account && var.grant_registry_access ? 1 : 0
-  project = var.registry_project_id == "" ? var.project_id : var.registry_project_id
-  role    = "roles/storage.objectViewer"
-  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+  for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/storage.objectViewer"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
-  count   = var.create_service_account && var.grant_registry_access ? 1 : 0
-  project = var.registry_project_id == "" ? var.project_id : var.registry_project_id
-  role    = "roles/artifactregistry.reader"
-  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+  for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -312,7 +312,7 @@ variable "grant_registry_access" {
 
 variable "registry_project_id" {
   type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version."
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
   default     = ""
 }
 

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -310,6 +310,12 @@ variable "grant_registry_access" {
   default     = false
 }
 
+variable "registry_project_id" {
+  type        = string
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version."
+  default     = ""
+}
+
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -310,10 +310,10 @@ variable "grant_registry_access" {
   default     = false
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Project holding the Google Container Registry. If empty, we use the cluster project. If grant_registry_access is true, storage.objectViewer role is assigned on this project."
-  default     = ""
+variable "registry_project_ids" {
+  type        = list(string)
+  description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."
+  default     = []
 }
 
 variable "service_account" {

--- a/modules/safer-cluster-update-variant/README.md
+++ b/modules/safer-cluster-update-variant/README.md
@@ -249,7 +249,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | project\_id | The project ID to host the cluster in | `string` | n/a | yes |
 | region | The region to host the cluster in | `string` | n/a | yes |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
+| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | (Beta) The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`. | `string` | `"REGULAR"` | no |
 | resource\_usage\_export\_dataset\_id | The dataset id for which network egress metering for this cluster will be enabled. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `string` | `""` | no |

--- a/modules/safer-cluster-update-variant/README.md
+++ b/modules/safer-cluster-update-variant/README.md
@@ -53,7 +53,7 @@ developers, which mostly just want to deploy and debug applications.
     own projects, so that they can be administered independently (e.g., dev cluster;
     production clusters; staging clusters should go in different projects.)
 
--   *A shared GCR project (`registry_project_id`):* all clusters can share the same GCR project.
+-   *A shared GCR project (`registry_project_ids`):* all clusters can share the same GCR project.
 
     -   Easier to share images between environments. The same image could be
         progressively rolled-out in dev, staging, and then production.
@@ -93,7 +93,7 @@ The Safer Cluster setup relies on several service accounts:
 
 ```
 create_service_account = true
-registry_project_id = <the project id for your GCR project>
+registry_project_ids = [<the project id for your GCR project>]
 grant_registry_access = true
 ```
 
@@ -248,7 +248,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | project\_id | The project ID to host the cluster in | `string` | n/a | yes |
 | region | The region to host the cluster in | `string` | n/a | yes |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Project holding the Google Container Registry. If empty, we use the cluster project. If grant\_registry\_access is true, storage.objectViewer role is assigned on this project. | `string` | `""` | no |
+| registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | (Beta) The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`. | `string` | `"REGULAR"` | no |
 | resource\_usage\_export\_dataset\_id | The dataset id for which network egress metering for this cluster will be enabled. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `string` | `""` | no |
 | sandbox\_enabled | (Beta) Enable GKE Sandbox (Do not forget to set `image_type` = `COS_CONTAINERD` to use it). | `bool` | `false` | no |

--- a/modules/safer-cluster-update-variant/README.md
+++ b/modules/safer-cluster-update-variant/README.md
@@ -53,7 +53,8 @@ developers, which mostly just want to deploy and debug applications.
     own projects, so that they can be administered independently (e.g., dev cluster;
     production clusters; staging clusters should go in different projects.)
 
--   *A shared GCR project (`registry_project_ids`):* all clusters can share the same GCR project.
+-   *Shared GCR projects (`registry_project_ids`):* all clusters can share the same
+    GCR projects.
 
     -   Easier to share images between environments. The same image could be
         progressively rolled-out in dev, staging, and then production.
@@ -248,6 +249,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | project\_id | The project ID to host the cluster in | `string` | n/a | yes |
 | region | The region to host the cluster in | `string` | n/a | yes |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
+| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | (Beta) The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`. | `string` | `"REGULAR"` | no |
 | resource\_usage\_export\_dataset\_id | The dataset id for which network egress metering for this cluster will be enabled. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `string` | `""` | no |

--- a/modules/safer-cluster-update-variant/main.tf
+++ b/modules/safer-cluster-update-variant/main.tf
@@ -96,7 +96,7 @@ module "gke" {
   //   wants to maintain control of their service accounts.
   create_service_account = var.compute_engine_service_account == "" ? true : false
   service_account        = var.compute_engine_service_account
-  registry_project_id    = var.registry_project_id
+  registry_project_ids   = var.registry_project_ids
   grant_registry_access  = var.grant_registry_access
 
   // Basic Auth disabled

--- a/modules/safer-cluster-update-variant/main.tf
+++ b/modules/safer-cluster-update-variant/main.tf
@@ -96,6 +96,7 @@ module "gke" {
   //   wants to maintain control of their service accounts.
   create_service_account = var.compute_engine_service_account == "" ? true : false
   service_account        = var.compute_engine_service_account
+  registry_project_id    = var.registry_project_id
   registry_project_ids   = var.registry_project_ids
   grant_registry_access  = var.grant_registry_access
 

--- a/modules/safer-cluster-update-variant/variables.tf
+++ b/modules/safer-cluster-update-variant/variables.tf
@@ -210,7 +210,7 @@ variable "grant_registry_access" {
 
 variable "registry_project_id" {
   type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version."
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
   default     = ""
 }
 

--- a/modules/safer-cluster-update-variant/variables.tf
+++ b/modules/safer-cluster-update-variant/variables.tf
@@ -208,6 +208,12 @@ variable "grant_registry_access" {
   default     = true
 }
 
+variable "registry_project_id" {
+  type        = string
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version."
+  default     = ""
+}
+
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/modules/safer-cluster-update-variant/variables.tf
+++ b/modules/safer-cluster-update-variant/variables.tf
@@ -208,10 +208,10 @@ variable "grant_registry_access" {
   default     = true
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Project holding the Google Container Registry. If empty, we use the cluster project. If grant_registry_access is true, storage.objectViewer role is assigned on this project."
-  default     = ""
+variable "registry_project_ids" {
+  type        = list(string)
+  description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."
+  default     = []
 }
 
 variable "cluster_resource_labels" {

--- a/modules/safer-cluster/README.md
+++ b/modules/safer-cluster/README.md
@@ -249,7 +249,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | project\_id | The project ID to host the cluster in | `string` | n/a | yes |
 | region | The region to host the cluster in | `string` | n/a | yes |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
+| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | (Beta) The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`. | `string` | `"REGULAR"` | no |
 | resource\_usage\_export\_dataset\_id | The dataset id for which network egress metering for this cluster will be enabled. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `string` | `""` | no |

--- a/modules/safer-cluster/README.md
+++ b/modules/safer-cluster/README.md
@@ -53,7 +53,7 @@ developers, which mostly just want to deploy and debug applications.
     own projects, so that they can be administered independently (e.g., dev cluster;
     production clusters; staging clusters should go in different projects.)
 
--   *A shared GCR project (`registry_project_id`):* all clusters can share the same GCR project.
+-   *A shared GCR project (`registry_project_ids`):* all clusters can share the same GCR project.
 
     -   Easier to share images between environments. The same image could be
         progressively rolled-out in dev, staging, and then production.
@@ -93,7 +93,7 @@ The Safer Cluster setup relies on several service accounts:
 
 ```
 create_service_account = true
-registry_project_id = <the project id for your GCR project>
+registry_project_ids = [<the project id for your GCR project>]
 grant_registry_access = true
 ```
 
@@ -248,7 +248,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | project\_id | The project ID to host the cluster in | `string` | n/a | yes |
 | region | The region to host the cluster in | `string` | n/a | yes |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Project holding the Google Container Registry. If empty, we use the cluster project. If grant\_registry\_access is true, storage.objectViewer role is assigned on this project. | `string` | `""` | no |
+| registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | (Beta) The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`. | `string` | `"REGULAR"` | no |
 | resource\_usage\_export\_dataset\_id | The dataset id for which network egress metering for this cluster will be enabled. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `string` | `""` | no |
 | sandbox\_enabled | (Beta) Enable GKE Sandbox (Do not forget to set `image_type` = `COS_CONTAINERD` to use it). | `bool` | `false` | no |

--- a/modules/safer-cluster/README.md
+++ b/modules/safer-cluster/README.md
@@ -53,7 +53,8 @@ developers, which mostly just want to deploy and debug applications.
     own projects, so that they can be administered independently (e.g., dev cluster;
     production clusters; staging clusters should go in different projects.)
 
--   *A shared GCR project (`registry_project_ids`):* all clusters can share the same GCR project.
+-   *Shared GCR projects (`registry_project_ids`):* all clusters can share the same
+    GCR projects.
 
     -   Easier to share images between environments. The same image could be
         progressively rolled-out in dev, staging, and then production.
@@ -248,6 +249,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | project\_id | The project ID to host the cluster in | `string` | n/a | yes |
 | region | The region to host the cluster in | `string` | n/a | yes |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
+| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | (Beta) The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`. | `string` | `"REGULAR"` | no |
 | resource\_usage\_export\_dataset\_id | The dataset id for which network egress metering for this cluster will be enabled. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `string` | `""` | no |

--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -96,7 +96,7 @@ module "gke" {
   //   wants to maintain control of their service accounts.
   create_service_account = var.compute_engine_service_account == "" ? true : false
   service_account        = var.compute_engine_service_account
-  registry_project_id    = var.registry_project_id
+  registry_project_ids   = var.registry_project_ids
   grant_registry_access  = var.grant_registry_access
 
   // Basic Auth disabled

--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -96,6 +96,7 @@ module "gke" {
   //   wants to maintain control of their service accounts.
   create_service_account = var.compute_engine_service_account == "" ? true : false
   service_account        = var.compute_engine_service_account
+  registry_project_id    = var.registry_project_id
   registry_project_ids   = var.registry_project_ids
   grant_registry_access  = var.grant_registry_access
 

--- a/modules/safer-cluster/variables.tf
+++ b/modules/safer-cluster/variables.tf
@@ -210,7 +210,7 @@ variable "grant_registry_access" {
 
 variable "registry_project_id" {
   type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version."
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
   default     = ""
 }
 

--- a/modules/safer-cluster/variables.tf
+++ b/modules/safer-cluster/variables.tf
@@ -208,6 +208,12 @@ variable "grant_registry_access" {
   default     = true
 }
 
+variable "registry_project_id" {
+  type        = string
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version."
+  default     = ""
+}
+
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/modules/safer-cluster/variables.tf
+++ b/modules/safer-cluster/variables.tf
@@ -208,10 +208,10 @@ variable "grant_registry_access" {
   default     = true
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Project holding the Google Container Registry. If empty, we use the cluster project. If grant_registry_access is true, storage.objectViewer role is assigned on this project."
-  default     = ""
+variable "registry_project_ids" {
+  type        = list(string)
+  description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."
+  default     = []
 }
 
 variable "cluster_resource_labels" {

--- a/sa.tf
+++ b/sa.tf
@@ -28,8 +28,8 @@ locals {
 
   registry_projects_list = compact(
     length(var.registry_project_ids) == 0 && var.registry_project_id == ""
-      ? [var.project_id]
-      : concat([var.registry_project_id], var.registry_project_ids)
+    ? [var.project_id]
+    : concat([var.registry_project_id], var.registry_project_ids)
   )
 }
 

--- a/sa.tf
+++ b/sa.tf
@@ -26,7 +26,11 @@ locals {
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 
-  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
+  registry_projects_list = compact(
+    length(var.registry_project_ids) == 0 && var.registry_project_id == ""
+      ? [var.project_id]
+      : concat([var.registry_project_id], var.registry_project_ids)
+  )
 }
 
 resource "random_string" "cluster_service_account_suffix" {

--- a/sa.tf
+++ b/sa.tf
@@ -25,6 +25,8 @@ locals {
   )
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
+
+  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
 }
 
 resource "random_string" "cluster_service_account_suffix" {
@@ -70,15 +72,15 @@ resource "google_project_iam_member" "cluster_service_account-resourceMetadata-w
 }
 
 resource "google_project_iam_member" "cluster_service_account-gcr" {
-  count   = var.create_service_account && var.grant_registry_access ? 1 : 0
-  project = var.registry_project_id == "" ? var.project_id : var.registry_project_id
-  role    = "roles/storage.objectViewer"
-  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+  for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/storage.objectViewer"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
 resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
-  count   = var.create_service_account && var.grant_registry_access ? 1 : 0
-  project = var.registry_project_id == "" ? var.project_id : var.registry_project_id
-  role    = "roles/artifactregistry.reader"
-  member  = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+  for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }

--- a/test/fixtures/shared/outputs.tf
+++ b/test/fixtures/shared/outputs.tf
@@ -79,6 +79,6 @@ output "service_account" {
   value       = module.example.service_account
 }
 
-output "registry_project_id" {
-  value = var.registry_project_id
+output "registry_project_ids" {
+  value = var.registry_project_ids
 }

--- a/test/fixtures/shared/variables.tf
+++ b/test/fixtures/shared/variables.tf
@@ -35,6 +35,7 @@ variable "compute_engine_service_accounts" {
   description = "The email addresses of the service account to associate with the GKE cluster"
 }
 
-variable "registry_project_id" {
-  description = "Project to use for granting access to the GCR registry, if requested"
+variable "registry_project_ids" {
+  description = "Projects to use for granting access to GCR registries, if requested"
+  type        = list(string)
 }

--- a/test/fixtures/workload_identity/outputs.tf
+++ b/test/fixtures/workload_identity/outputs.tf
@@ -65,8 +65,8 @@ output "service_account" {
   value       = module.example.service_account
 }
 
-output "registry_project_id" {
-  value = var.registry_project_id
+output "registry_project_ids" {
+  value = var.registry_project_ids
 }
 
 output "cluster_name" {

--- a/test/fixtures/workload_identity/variables.tf
+++ b/test/fixtures/workload_identity/variables.tf
@@ -35,7 +35,7 @@ variable "compute_engine_service_accounts" {
   description = "The email addresses of the service account to associate with the GKE cluster"
 }
 
-variable "registry_project_id" {
-  description = "Project to use for granting access to the GCR registry, if requested"
-  default     = ""
+variable "registry_project_ids" {
+  type        = list(string)
+  description = "Projects to use for granting access to GCR registries, if requested"
 }

--- a/test/fixtures/workload_metadata_config/example.tf
+++ b/test/fixtures/workload_metadata_config/example.tf
@@ -17,13 +17,13 @@
 module "example" {
   source = "../../../examples/workload_metadata_config"
 
-  project_id          = var.project_ids[1]
-  cluster_name_suffix = "-${random_string.suffix.result}"
-  region              = var.region
-  zones               = slice(var.zones, 0, 1)
-  network             = google_compute_network.main.name
-  subnetwork          = google_compute_subnetwork.main.name
-  ip_range_pods       = google_compute_subnetwork.main.secondary_ip_range[0].range_name
-  ip_range_services   = google_compute_subnetwork.main.secondary_ip_range[1].range_name
-  registry_project_id = var.registry_project_id
+  project_id           = var.project_ids[1]
+  cluster_name_suffix  = "-${random_string.suffix.result}"
+  region               = var.region
+  zones                = slice(var.zones, 0, 1)
+  network              = google_compute_network.main.name
+  subnetwork           = google_compute_subnetwork.main.name
+  ip_range_pods        = google_compute_subnetwork.main.secondary_ip_range[0].range_name
+  ip_range_services    = google_compute_subnetwork.main.secondary_ip_range[1].range_name
+  registry_project_ids = var.registry_project_ids
 }

--- a/test/integration/workload_metadata_config/controls/gcloud.rb
+++ b/test/integration/workload_metadata_config/controls/gcloud.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 project_id = attribute('project_id')
-registry_project_id = attribute('registry_project_id')
+registry_project_ids = attribute('registry_project_ids')
 location = attribute('location')
 cluster_name = attribute('cluster_name')
 service_account = attribute('service_account')
@@ -58,19 +58,21 @@ control "gcloud" do
     end
   end
 
-  describe command("gcloud projects get-iam-policy #{registry_project_id} --format=json") do
-    its(:exit_status) { should eq 0 }
-    its(:stderr) { should eq '' }
+  registry_project_ids.each do |registry_project_id|
+    describe command("gcloud projects get-iam-policy #{registry_project_id} --format=json") do
+      its(:exit_status) { should eq 0 }
+      its(:stderr) { should eq '' }
 
-    let!(:iam) do
-      if subject.exit_status == 0
-        JSON.parse(subject.stdout)
-      else
-        {}
+      let!(:iam) do
+        if subject.exit_status == 0
+          JSON.parse(subject.stdout)
+        else
+          {}
+        end
       end
-    end
-    it "has expected registry roles" do
-      expect(iam['bindings']).to include("members" => ["serviceAccount:#{service_account}"], "role" => "roles/storage.objectViewer")
+      it "has expected registry roles" do
+        expect(iam['bindings']).to include("members" => ["serviceAccount:#{service_account}"], "role" => "roles/storage.objectViewer")
+      end
     end
   end
 end

--- a/test/integration/workload_metadata_config/inspec.yml
+++ b/test/integration/workload_metadata_config/inspec.yml
@@ -12,6 +12,6 @@ attributes:
   - name: service_account
     required: true
     type: string
-  - name: registry_project_id
+  - name: registry_project_ids
     required: false
-    type: string
+    type: array

--- a/test/setup/outputs.tf
+++ b/test/setup/outputs.tf
@@ -31,6 +31,6 @@ output "compute_engine_service_accounts" {
   value = [google_service_account.gke_sa_1.email, google_service_account.gke_sa_2.email, google_service_account.gke_sa_asm.email]
 }
 
-output "registry_project_id" {
-  value = module.gke-project-1.project_id
+output "registry_project_ids" {
+  value = [module.gke-project-1.project_id]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -312,7 +312,7 @@ variable "grant_registry_access" {
 
 variable "registry_project_id" {
   type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version."
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
   default     = ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -310,6 +310,12 @@ variable "grant_registry_access" {
   default     = false
 }
 
+variable "registry_project_id" {
+  type        = string
+  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purpose of backwards compatibility, but will be removed in a future version."
+  default     = ""
+}
+
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/variables.tf
+++ b/variables.tf
@@ -310,10 +310,10 @@ variable "grant_registry_access" {
   default     = false
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Project holding the Google Container Registry. If empty, we use the cluster project. If grant_registry_access is true, storage.objectViewer role is assigned on this project."
-  default     = ""
+variable "registry_project_ids" {
+  type        = list(string)
+  description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."
+  default     = []
 }
 
 variable "service_account" {


### PR DESCRIPTION
In our organization, we have a few projects that we put container images into depending on the team, and sometimes a cluster needs access to more than one of them. Right now we use a custom module that _isn't_ a wrapper for this one, but I'd like to change that. This PR would allow that to happen, but it does mean a breaking change for those who utilize the variable as it is currently defined.

I've also updated the tests to handle the change of the variable name from `registry_project_id` to `registry_project_ids` and the type now being `list(string)`. The `workload-metadata-config-local` integration test (the only test to reference the former `registry_project_id` variable) passes locally as well. That being said, I've not used InSpec before and am not 100% sure everything's correct regarding my changes, so if it's decided that this PR merits inclusion, I'd appreciate a closer look at that part of the PR just to make sure nothing's broken. 