### PR TITLE
Initial changes to asm module to support installing asm ver 1.8.

### DIFF
--- a/modules/asm/scripts/install_asm.sh
+++ b/modules/asm/scripts/install_asm.sh
@@ -15,7 +15,7 @@
 
 set -e
 
-if [ "$#" -lt 6 ]; then
+if [ "$#" -lt 4 ]; then
     >&2 echo "Not all expected arguments set."
     exit 1
 fi
@@ -23,51 +23,21 @@ fi
 PROJECT_ID=$1
 CLUSTER_NAME=$2
 CLUSTER_LOCATION=$3
-ASM_RESOURCES=$4
-ASM_VERSION=$5
-PROJECT_NUM=$6
+ASM_VERSION=$4
+MODE="install"
 BASE_DIR="asm-base-dir"
-# check for needed binaries
-# kustomize is a requirement for installing ASM and is not available via gcloud. Safely exit if not available.
-if [[ -z $(command -v kustomize) ]]; then
-  echo "kustomize is unavailable. Skipping ASM installation. Please install kustomize, add to PATH and rerun terraform apply."
-  exit 1
-fi
-# # check docker which is optionally used for validating asm yaml using gcr.io/kustomize-functions/validate-asm:v0.1.0
-# if [[ $(command -v docker) ]]; then
-#   echo "Docker is available. ASM yaml validation will be performed."
-# else
-#   echo "ASM yaml validation will be skipped as Docker is unavailable"
-#   SKIP_ASM_VALIDATION=true
-# fi
-mkdir -p "${ASM_RESOURCES}"
-pushd "${ASM_RESOURCES}"
-gcloud config set project "${PROJECT_ID}"
-if [[ -d ./asm-patch ]]; then
-    echo "ASM patch directory exists. Skipping download..."
+
+if [[ -d "${BASE_DIR}" ]]; then
+    echo "working directory exists. Skipping creating it"
 else
-    echo "Downloading ASM patch"
-    kpt pkg get https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages.git/asm-patch@"${ASM_VERSION}" .
+    echo "creating working directory ${BASE_DIR}"
+  # make working directory
+  mkdir -p "${BASE_DIR}"
 fi
-gcloud beta anthos export "${CLUSTER_NAME}" --output-directory ${BASE_DIR} --project "${PROJECT_ID}" --location "${CLUSTER_LOCATION}"
-kpt cfg set asm-patch/ base-dir ../${BASE_DIR}
-kpt cfg set asm-patch/ gcloud.core.project "${PROJECT_ID}"
-kpt cfg set asm-patch/ gcloud.container.cluster "${CLUSTER_NAME}"
-kpt cfg set asm-patch/ gcloud.compute.location "${CLUSTER_LOCATION}"
-kpt cfg set asm-patch/ gcloud.project.environProjectNumber "${PROJECT_NUM}"
-kpt cfg list-setters asm-patch/
-pushd ${BASE_DIR}
-kustomize create --autodetect --namespace "${PROJECT_ID}"
-popd
-pushd asm-patch
-kustomize build -o ../${BASE_DIR}/all.yaml
-popd
-# # skip validate as we should investigate if we can check this without having to resort to dind
-# if [[ ${SKIP_ASM_VALIDATION} ]]; then
-#  echo "Skipping ASM validation..."
-# else
-#  echo "Running ASM validation..."
-#  kpt fn source ${BASE_DIR} | kpt fn run --image gcr.io/kustomize-functions/validate-asm:v0.1.0
-# fi
-gcloud beta anthos apply ${BASE_DIR}
-kubectl wait --for=condition=available --timeout=600s deployment --all -n istio-system
+
+#download the correct version of the install_asm script
+curl https://storage.googleapis.com/csm-artifacts/asm/install_asm_"${ASM_VERSION}" > install_asm
+chmod u+x install_asm
+
+#run the script with appropriate flags
+./install_asm --verbose --project_id ${PROJECT_ID} --cluster_name ${CLUSTER_NAME} --cluster_location ${CLUSTER_LOCATION} --mode ${MODE} --output_dir ${BASE_DIR} --enable_cluster_labels --enable_cluster_roles

--- a/modules/asm/variables.tf
+++ b/modules/asm/variables.tf
@@ -49,11 +49,10 @@ variable "asm_dir" {
 variable "asm_version" {
   description = "ASM version to deploy. Available versions are documented in https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages"
   type        = string
-  default     = "release-1.6-asm"
+  default     = "1.8"
 }
 
 variable "service_account_key_file" {
   description = "Path to service account key file to auth as for running `gcloud container clusters get-credentials`."
   default     = ""
 }
-

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -35,14 +35,19 @@ locals {
     "roles/iap.admin",
     "roles/gkehub.admin",
   ]
-  # roles as documented https://cloud.google.com/service-mesh/docs/gke-install-new-cluster#setting_up_your_project
+  # roles as documented https://cloud.google.com/service-mesh/docs/installation-permissions
   int_asm_required_roles = [
     "roles/editor",
+    "roles/compute.admin",
     "roles/container.admin",
     "roles/resourcemanager.projectIamAdmin",
+    "roles/servicemanagement.admin",
+    "roles/serviceusage.serviceUsageAdmin",
     "roles/iam.serviceAccountAdmin",
     "roles/iam.serviceAccountKeyAdmin",
     "roles/gkehub.admin",
+    "roles/meshconfig.admin",
+    "roles/privateca.admin",
   ]
 }
 

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -75,7 +75,7 @@ module "gke-project-2" {
   ]
 }
 
-# apis as documented https://cloud.google.com/service-mesh/docs/gke-install-new-cluster#setting_up_your_project
+# apis as documented https://cloud.google.com/service-mesh/docs/scripted-install/reference#setting_up_your_project
 module "gke-project-asm" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 9.1.0"
@@ -94,5 +94,13 @@ module "gke-project-asm" {
     "meshconfig.googleapis.com",
     "anthos.googleapis.com",
     "cloudresourcemanager.googleapis.com",
+    "monitoring.googleapis.com",
+    "stackdriver.googleapis.com",
+    "cloudtrace.googleapis.com",
+    "meshca.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "gkeconnect.googleapis.com",
+    "gkehub.googleapis.com",
+    "privateca.googleapis.com",
   ]
 }


### PR DESCRIPTION
Modified default value for asm_version to 1.8
Added additional IAM bindings and API enablement to the test scripts
Modified install_asm.sh wrapper script to call the new install_asm script with the updated flags.
- Need to remove the --enable_cluster_labels flag in the wrapper script once the install_asm script makes that flag optional. It is currently required.