### PR TITLE
Fix description of release_channel variable

### DIFF
--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -541,7 +541,7 @@ variable "identity_namespace" {
 
 variable "release_channel" {
   type        = string
-  description = "The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`."
+  description = "The release channel of this cluster. Accepted values are null, `\"RAPID\"`, `\"REGULAR\"` and `\"STABLE\"`. Defaults to `null`."
   default     = null
 }
 


### PR DESCRIPTION
The description is outdated. Actually specifying `"UNSPECIFIED"` as value will create a cluster in regular release channel mode. To create a cluster with a fixed version, `null` can be specified.