### PR TITLE
fix: Fix attribution for safer cluster modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| \_parent\_module | (Internal) Parent module which should be referenced in API calls. | `string` | `""` | no |
 | add\_cluster\_firewall\_rules | Create additional firewall rules | `bool` | `false` | no |
 | add\_shadow\_firewall\_rules | Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled). | `bool` | `false` | no |
 | basic\_auth\_password | The password to be used with Basic Authentication. | `string` | `""` | no |

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -625,3 +625,9 @@ variable "enable_tpu" {
   default     = false
 }
 {% endif %}
+
+variable "_parent_module" {
+  type = string
+  description = "(Internal) Parent module which should be referenced in API calls."
+  default = ""
+}

--- a/autogen/main/versions.tf.tmpl
+++ b/autogen/main/versions.tf.tmpl
@@ -17,6 +17,10 @@
 {% set module_path_str =  module_path|string %}
 {% set module_registry_name = module_path_str.split('/')[-1] %}
 
+locals {
+  blueprint_name = join("/", compact([var._parent_module, "terraform-google-kubernetes-engine{% if module_registry_name %}:{{ module_registry_name }}{% endif %}/v13.0.0"]))
+}
+
 terraform {
   required_version = ">=0.13"
 
@@ -32,7 +36,7 @@ terraform {
     }
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-kubernetes-engine{% if module_registry_name %}:{{ module_registry_name }}{% endif %}/v13.0.0"
+    module_name = "blueprints/terraform/${local.blueprint_name}"
   }
 {% else %}
   required_providers {
@@ -46,7 +50,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-kubernetes-engine{% if module_registry_name %}:{{ module_registry_name }}{% endif %}/v13.0.0"
+    module_name = "blueprints/terraform/${local.blueprint_name}"
   }
 {% endif %}
 }

--- a/autogen/safer-cluster/main.tf.tmpl
+++ b/autogen/safer-cluster/main.tf.tmpl
@@ -169,4 +169,6 @@ module "gke" {
   gce_pd_csi_driver = var.gce_pd_csi_driver
 
   notification_config_topic = var.notification_config_topic
+
+  _parent_module = local.blueprint_name
 }

--- a/autogen/safer-cluster/variables.tf.tmpl
+++ b/autogen/safer-cluster/variables.tf.tmpl
@@ -381,3 +381,9 @@ variable "notification_config_topic" {
   description = "The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}."
   default     = ""
 }
+
+variable "_parent_module" {
+  type = string
+  description = "(Internal) Parent module which should be referenced in API calls."
+  default = ""
+}

--- a/autogen/safer-cluster/versions.tf.tmpl
+++ b/autogen/safer-cluster/versions.tf.tmpl
@@ -19,10 +19,14 @@
 {% set module_path_str =  module_path|string %}
 {% set module_registry_name = module_path_str.split('/')[-1] %}
 
+locals {
+  blueprint_name = join("/", compact([var._parent_module, "terraform-google-kubernetes-engine{% if module_registry_name %}:{{ module_registry_name }}{% endif %}/v13.0.0"]))
+}
+
 terraform {
   required_version = ">=0.13"
 
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-kubernetes-engine{% if module_registry_name %}:{{ module_registry_name }}{% endif %}/v13.0.0"
+    module_name = "blueprints/terraform/${local.blueprint_name}"
   }
 }

--- a/examples/safer_cluster/README.md
+++ b/examples/safer_cluster/README.md
@@ -7,7 +7,6 @@ This example illustrates how to instantiate the opinionated Safer Cluster module
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| compute\_engine\_service\_account | Service account to associate to the nodes in the cluster | `string` | n/a | yes |
 | project\_id | The project ID to host the cluster in | `string` | n/a | yes |
 | region | The region to host the cluster in | `string` | `"us-central1"` | no |
 

--- a/examples/safer_cluster/main.tf
+++ b/examples/safer_cluster/main.tf
@@ -57,7 +57,6 @@ module "gke" {
   subnetwork                     = local.subnet_names[index(module.gcp-network.subnets_names, local.subnet_name)]
   ip_range_pods                  = local.pods_range_name
   ip_range_services              = local.svc_range_name
-  compute_engine_service_account = var.compute_engine_service_account
   master_ipv4_cidr_block         = "172.16.0.0/28"
   add_cluster_firewall_rules     = true
   firewall_inbound_ports         = ["9443", "15017"]

--- a/examples/safer_cluster/main.tf
+++ b/examples/safer_cluster/main.tf
@@ -48,18 +48,18 @@ provider "kubernetes" {
 }
 
 module "gke" {
-  source                         = "../../modules/safer-cluster/"
-  project_id                     = var.project_id
-  name                           = "${local.cluster_type}-cluster-${random_string.suffix.result}"
-  regional                       = true
-  region                         = var.region
-  network                        = module.gcp-network.network_name
-  subnetwork                     = local.subnet_names[index(module.gcp-network.subnets_names, local.subnet_name)]
-  ip_range_pods                  = local.pods_range_name
-  ip_range_services              = local.svc_range_name
-  master_ipv4_cidr_block         = "172.16.0.0/28"
-  add_cluster_firewall_rules     = true
-  firewall_inbound_ports         = ["9443", "15017"]
+  source                     = "../../modules/safer-cluster/"
+  project_id                 = var.project_id
+  name                       = "${local.cluster_type}-cluster-${random_string.suffix.result}"
+  regional                   = true
+  region                     = var.region
+  network                    = module.gcp-network.network_name
+  subnetwork                 = local.subnet_names[index(module.gcp-network.subnets_names, local.subnet_name)]
+  ip_range_pods              = local.pods_range_name
+  ip_range_services          = local.svc_range_name
+  master_ipv4_cidr_block     = "172.16.0.0/28"
+  add_cluster_firewall_rules = true
+  firewall_inbound_ports     = ["9443", "15017"]
 
   master_authorized_networks = [
     {

--- a/examples/safer_cluster/variables.tf
+++ b/examples/safer_cluster/variables.tf
@@ -24,8 +24,3 @@ variable "region" {
   description = "The region to host the cluster in"
   default     = "us-central1"
 }
-
-variable "compute_engine_service_account" {
-  type        = string
-  description = "Service account to associate to the nodes in the cluster"
-}

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -154,6 +154,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| \_parent\_module | (Internal) Parent module which should be referenced in API calls. | `string` | `""` | no |
 | add\_cluster\_firewall\_rules | Create additional firewall rules | `bool` | `false` | no |
 | add\_shadow\_firewall\_rules | Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled). | `bool` | `false` | no |
 | authenticator\_security\_group | The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com | `string` | `null` | no |

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -603,3 +603,9 @@ variable "enable_tpu" {
   description = "Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive!"
   default     = false
 }
+
+variable "_parent_module" {
+  type        = string
+  description = "(Internal) Parent module which should be referenced in API calls."
+  default     = ""
+}

--- a/modules/beta-private-cluster-update-variant/versions.tf
+++ b/modules/beta-private-cluster-update-variant/versions.tf
@@ -15,6 +15,10 @@
  */
 
 
+locals {
+  blueprint_name = join("/", compact([var._parent_module, "terraform-google-kubernetes-engine:beta-private-cluster-update-variant/v13.0.0"]))
+}
+
 terraform {
   required_version = ">=0.13"
 
@@ -29,6 +33,6 @@ terraform {
     }
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:beta-private-cluster-update-variant/v13.0.0"
+    module_name = "blueprints/terraform/${local.blueprint_name}"
   }
 }

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -132,6 +132,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| \_parent\_module | (Internal) Parent module which should be referenced in API calls. | `string` | `""` | no |
 | add\_cluster\_firewall\_rules | Create additional firewall rules | `bool` | `false` | no |
 | add\_shadow\_firewall\_rules | Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled). | `bool` | `false` | no |
 | authenticator\_security\_group | The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com | `string` | `null` | no |

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -603,3 +603,9 @@ variable "enable_tpu" {
   description = "Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive!"
   default     = false
 }
+
+variable "_parent_module" {
+  type        = string
+  description = "(Internal) Parent module which should be referenced in API calls."
+  default     = ""
+}

--- a/modules/beta-private-cluster/versions.tf
+++ b/modules/beta-private-cluster/versions.tf
@@ -15,6 +15,10 @@
  */
 
 
+locals {
+  blueprint_name = join("/", compact([var._parent_module, "terraform-google-kubernetes-engine:beta-private-cluster/v13.0.0"]))
+}
+
 terraform {
   required_version = ">=0.13"
 
@@ -29,6 +33,6 @@ terraform {
     }
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:beta-private-cluster/v13.0.0"
+    module_name = "blueprints/terraform/${local.blueprint_name}"
   }
 }

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -148,6 +148,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| \_parent\_module | (Internal) Parent module which should be referenced in API calls. | `string` | `""` | no |
 | add\_cluster\_firewall\_rules | Create additional firewall rules | `bool` | `false` | no |
 | add\_shadow\_firewall\_rules | Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled). | `bool` | `false` | no |
 | authenticator\_security\_group | The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com | `string` | `null` | no |

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -572,3 +572,9 @@ variable "enable_tpu" {
   description = "Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive!"
   default     = false
 }
+
+variable "_parent_module" {
+  type        = string
+  description = "(Internal) Parent module which should be referenced in API calls."
+  default     = ""
+}

--- a/modules/beta-public-cluster-update-variant/versions.tf
+++ b/modules/beta-public-cluster-update-variant/versions.tf
@@ -15,6 +15,10 @@
  */
 
 
+locals {
+  blueprint_name = join("/", compact([var._parent_module, "terraform-google-kubernetes-engine:beta-public-cluster-update-variant/v13.0.0"]))
+}
+
 terraform {
   required_version = ">=0.13"
 
@@ -29,6 +33,6 @@ terraform {
     }
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:beta-public-cluster-update-variant/v13.0.0"
+    module_name = "blueprints/terraform/${local.blueprint_name}"
   }
 }

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -126,6 +126,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| \_parent\_module | (Internal) Parent module which should be referenced in API calls. | `string` | `""` | no |
 | add\_cluster\_firewall\_rules | Create additional firewall rules | `bool` | `false` | no |
 | add\_shadow\_firewall\_rules | Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled). | `bool` | `false` | no |
 | authenticator\_security\_group | The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com | `string` | `null` | no |

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -572,3 +572,9 @@ variable "enable_tpu" {
   description = "Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive!"
   default     = false
 }
+
+variable "_parent_module" {
+  type        = string
+  description = "(Internal) Parent module which should be referenced in API calls."
+  default     = ""
+}

--- a/modules/beta-public-cluster/versions.tf
+++ b/modules/beta-public-cluster/versions.tf
@@ -15,6 +15,10 @@
  */
 
 
+locals {
+  blueprint_name = join("/", compact([var._parent_module, "terraform-google-kubernetes-engine:beta-public-cluster/v13.0.0"]))
+}
+
 terraform {
   required_version = ">=0.13"
 
@@ -29,6 +33,6 @@ terraform {
     }
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:beta-public-cluster/v13.0.0"
+    module_name = "blueprints/terraform/${local.blueprint_name}"
   }
 }

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -151,6 +151,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| \_parent\_module | (Internal) Parent module which should be referenced in API calls. | `string` | `""` | no |
 | add\_cluster\_firewall\_rules | Create additional firewall rules | `bool` | `false` | no |
 | add\_shadow\_firewall\_rules | Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled). | `bool` | `false` | no |
 | basic\_auth\_password | The password to be used with Basic Authentication. | `string` | `""` | no |

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -474,3 +474,9 @@ variable "impersonate_service_account" {
   default     = ""
 }
 
+
+variable "_parent_module" {
+  type        = string
+  description = "(Internal) Parent module which should be referenced in API calls."
+  default     = ""
+}

--- a/modules/private-cluster-update-variant/versions.tf
+++ b/modules/private-cluster-update-variant/versions.tf
@@ -15,6 +15,10 @@
  */
 
 
+locals {
+  blueprint_name = join("/", compact([var._parent_module, "terraform-google-kubernetes-engine:private-cluster-update-variant/v13.0.0"]))
+}
+
 terraform {
   required_version = ">=0.13"
 
@@ -29,6 +33,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:private-cluster-update-variant/v13.0.0"
+    module_name = "blueprints/terraform/${local.blueprint_name}"
   }
 }

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -129,6 +129,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| \_parent\_module | (Internal) Parent module which should be referenced in API calls. | `string` | `""` | no |
 | add\_cluster\_firewall\_rules | Create additional firewall rules | `bool` | `false` | no |
 | add\_shadow\_firewall\_rules | Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled). | `bool` | `false` | no |
 | basic\_auth\_password | The password to be used with Basic Authentication. | `string` | `""` | no |

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -474,3 +474,9 @@ variable "impersonate_service_account" {
   default     = ""
 }
 
+
+variable "_parent_module" {
+  type        = string
+  description = "(Internal) Parent module which should be referenced in API calls."
+  default     = ""
+}

--- a/modules/private-cluster/versions.tf
+++ b/modules/private-cluster/versions.tf
@@ -15,6 +15,10 @@
  */
 
 
+locals {
+  blueprint_name = join("/", compact([var._parent_module, "terraform-google-kubernetes-engine:private-cluster/v13.0.0"]))
+}
+
 terraform {
   required_version = ">=0.13"
 
@@ -29,6 +33,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:private-cluster/v13.0.0"
+    module_name = "blueprints/terraform/${local.blueprint_name}"
   }
 }

--- a/modules/safer-cluster-update-variant/README.md
+++ b/modules/safer-cluster-update-variant/README.md
@@ -201,6 +201,7 @@ For simplicity, we suggest using `roles/container.admin` and
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| \_parent\_module | (Internal) Parent module which should be referenced in API calls. | `string` | `""` | no |
 | add\_cluster\_firewall\_rules | Create additional firewall rules | `bool` | `false` | no |
 | authenticator\_security\_group | The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com | `string` | `null` | no |
 | cloudrun | (Beta) Enable CloudRun addon | `bool` | `false` | no |

--- a/modules/safer-cluster-update-variant/main.tf
+++ b/modules/safer-cluster-update-variant/main.tf
@@ -165,4 +165,6 @@ module "gke" {
   gce_pd_csi_driver = var.gce_pd_csi_driver
 
   notification_config_topic = var.notification_config_topic
+
+  _parent_module = local.blueprint_name
 }

--- a/modules/safer-cluster-update-variant/variables.tf
+++ b/modules/safer-cluster-update-variant/variables.tf
@@ -381,3 +381,9 @@ variable "notification_config_topic" {
   description = "The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}."
   default     = ""
 }
+
+variable "_parent_module" {
+  type        = string
+  description = "(Internal) Parent module which should be referenced in API calls."
+  default     = ""
+}

--- a/modules/safer-cluster-update-variant/versions.tf
+++ b/modules/safer-cluster-update-variant/versions.tf
@@ -17,10 +17,14 @@
 // This file was automatically generated from a template in ./autogen/safer-cluster
 
 
+locals {
+  blueprint_name = join("/", compact([var._parent_module, "terraform-google-kubernetes-engine:safer-cluster-update-variant/v13.0.0"]))
+}
+
 terraform {
   required_version = ">=0.13"
 
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:safer-cluster-update-variant/v13.0.0"
+    module_name = "blueprints/terraform/${local.blueprint_name}"
   }
 }

--- a/modules/safer-cluster/README.md
+++ b/modules/safer-cluster/README.md
@@ -201,6 +201,7 @@ For simplicity, we suggest using `roles/container.admin` and
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| \_parent\_module | (Internal) Parent module which should be referenced in API calls. | `string` | `""` | no |
 | add\_cluster\_firewall\_rules | Create additional firewall rules | `bool` | `false` | no |
 | authenticator\_security\_group | The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com | `string` | `null` | no |
 | cloudrun | (Beta) Enable CloudRun addon | `bool` | `false` | no |

--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -165,4 +165,6 @@ module "gke" {
   gce_pd_csi_driver = var.gce_pd_csi_driver
 
   notification_config_topic = var.notification_config_topic
+
+  _parent_module = local.blueprint_name
 }

--- a/modules/safer-cluster/variables.tf
+++ b/modules/safer-cluster/variables.tf
@@ -381,3 +381,9 @@ variable "notification_config_topic" {
   description = "The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}."
   default     = ""
 }
+
+variable "_parent_module" {
+  type        = string
+  description = "(Internal) Parent module which should be referenced in API calls."
+  default     = ""
+}

--- a/modules/safer-cluster/versions.tf
+++ b/modules/safer-cluster/versions.tf
@@ -17,10 +17,14 @@
 // This file was automatically generated from a template in ./autogen/safer-cluster
 
 
+locals {
+  blueprint_name = join("/", compact([var._parent_module, "terraform-google-kubernetes-engine:safer-cluster/v13.0.0"]))
+}
+
 terraform {
   required_version = ">=0.13"
 
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:safer-cluster/v13.0.0"
+    module_name = "blueprints/terraform/${local.blueprint_name}"
   }
 }

--- a/test/fixtures/safer_cluster/example.tf
+++ b/test/fixtures/safer_cluster/example.tf
@@ -19,5 +19,4 @@ module "example" {
 
   project_id                     = var.project_ids[0]
   region                         = var.region
-  compute_engine_service_account = var.compute_engine_service_accounts[0]
 }

--- a/test/fixtures/safer_cluster/example.tf
+++ b/test/fixtures/safer_cluster/example.tf
@@ -17,6 +17,6 @@
 module "example" {
   source = "../../../examples/safer_cluster"
 
-  project_id                     = var.project_ids[0]
-  region                         = var.region
+  project_id = var.project_ids[0]
+  region     = var.region
 }

--- a/variables.tf
+++ b/variables.tf
@@ -450,3 +450,9 @@ variable "impersonate_service_account" {
   default     = ""
 }
 
+
+variable "_parent_module" {
+  type        = string
+  description = "(Internal) Parent module which should be referenced in API calls."
+  default     = ""
+}

--- a/versions.tf
+++ b/versions.tf
@@ -15,6 +15,10 @@
  */
 
 
+locals {
+  blueprint_name = join("/", compact([var._parent_module, "terraform-google-kubernetes-engine/v13.0.0"]))
+}
+
 terraform {
   required_version = ">=0.13"
 
@@ -29,6 +33,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-kubernetes-engine/v13.0.0"
+    module_name = "blueprints/terraform/${local.blueprint_name}"
   }
 }


### PR DESCRIPTION
This adds a `_parent_module` variable which can be used to pass parent module into the module attribution call, so we can track when parent modules are used and not just the base module.