### PR TITLE
Feat: Remove deprecated variable "registry_project_id"

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/autogen/main/sa.tf.tmpl
+++ b/autogen/main/sa.tf.tmpl
@@ -26,11 +26,7 @@ locals {
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 
-  registry_projects_list = compact(
-    length(var.registry_project_ids) == 0 && var.registry_project_id == ""
-    ? [var.project_id]
-    : concat([var.registry_project_id], var.registry_project_ids)
-  )
+  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
 }
 
 resource "random_string" "cluster_service_account_suffix" {

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -358,12 +358,6 @@ variable "grant_registry_access" {
   default     = false
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
-  default     = ""
-}
-
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/autogen/safer-cluster/main.tf.tmpl
+++ b/autogen/safer-cluster/main.tf.tmpl
@@ -100,7 +100,6 @@ module "gke" {
   //   wants to maintain control of their service accounts.
   create_service_account = var.compute_engine_service_account == "" ? true : false
   service_account        = var.compute_engine_service_account
-  registry_project_id    = var.registry_project_id
   registry_project_ids   = var.registry_project_ids
   grant_registry_access  = var.grant_registry_access
 

--- a/autogen/safer-cluster/variables.tf.tmpl
+++ b/autogen/safer-cluster/variables.tf.tmpl
@@ -208,12 +208,6 @@ variable "grant_registry_access" {
   default     = true
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
-  default     = ""
-}
-
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -233,7 +233,6 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/modules/beta-private-cluster-update-variant/sa.tf
+++ b/modules/beta-private-cluster-update-variant/sa.tf
@@ -26,11 +26,7 @@ locals {
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 
-  registry_projects_list = compact(
-    length(var.registry_project_ids) == 0 && var.registry_project_id == ""
-    ? [var.project_id]
-    : concat([var.registry_project_id], var.registry_project_ids)
-  )
+  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
 }
 
 resource "random_string" "cluster_service_account_suffix" {

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -346,12 +346,6 @@ variable "grant_registry_access" {
   default     = false
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
-  default     = ""
-}
-
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -211,7 +211,6 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/modules/beta-private-cluster/sa.tf
+++ b/modules/beta-private-cluster/sa.tf
@@ -26,11 +26,7 @@ locals {
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 
-  registry_projects_list = compact(
-    length(var.registry_project_ids) == 0 && var.registry_project_id == ""
-    ? [var.project_id]
-    : concat([var.registry_project_id], var.registry_project_ids)
-  )
+  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
 }
 
 resource "random_string" "cluster_service_account_suffix" {

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -346,12 +346,6 @@ variable "grant_registry_access" {
   default     = false
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
-  default     = ""
-}
-
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -222,7 +222,6 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/modules/beta-public-cluster-update-variant/sa.tf
+++ b/modules/beta-public-cluster-update-variant/sa.tf
@@ -26,11 +26,7 @@ locals {
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 
-  registry_projects_list = compact(
-    length(var.registry_project_ids) == 0 && var.registry_project_id == ""
-    ? [var.project_id]
-    : concat([var.registry_project_id], var.registry_project_ids)
-  )
+  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
 }
 
 resource "random_string" "cluster_service_account_suffix" {

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -346,12 +346,6 @@ variable "grant_registry_access" {
   default     = false
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
-  default     = ""
-}
-
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -200,7 +200,6 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/modules/beta-public-cluster/sa.tf
+++ b/modules/beta-public-cluster/sa.tf
@@ -26,11 +26,7 @@ locals {
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 
-  registry_projects_list = compact(
-    length(var.registry_project_ids) == 0 && var.registry_project_id == ""
-    ? [var.project_id]
-    : concat([var.registry_project_id], var.registry_project_ids)
-  )
+  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
 }
 
 resource "random_string" "cluster_service_account_suffix" {

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -346,12 +346,6 @@ variable "grant_registry_access" {
   default     = false
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
-  default     = ""
-}
-
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -210,7 +210,6 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/modules/private-cluster-update-variant/sa.tf
+++ b/modules/private-cluster-update-variant/sa.tf
@@ -26,11 +26,7 @@ locals {
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 
-  registry_projects_list = compact(
-    length(var.registry_project_ids) == 0 && var.registry_project_id == ""
-    ? [var.project_id]
-    : concat([var.registry_project_id], var.registry_project_ids)
-  )
+  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
 }
 
 resource "random_string" "cluster_service_account_suffix" {

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -310,12 +310,6 @@ variable "grant_registry_access" {
   default     = false
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
-  default     = ""
-}
-
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -188,7 +188,6 @@ Then perform the following commands on the root folder:
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `UNSPECIFIED`. | `string` | `null` | no |
 | remove\_default\_node\_pool | Remove default node pool while setting up the cluster | `bool` | `false` | no |

--- a/modules/private-cluster/sa.tf
+++ b/modules/private-cluster/sa.tf
@@ -26,11 +26,7 @@ locals {
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 
-  registry_projects_list = compact(
-    length(var.registry_project_ids) == 0 && var.registry_project_id == ""
-    ? [var.project_id]
-    : concat([var.registry_project_id], var.registry_project_ids)
-  )
+  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
 }
 
 resource "random_string" "cluster_service_account_suffix" {

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -310,12 +310,6 @@ variable "grant_registry_access" {
   default     = false
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
-  default     = ""
-}
-
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/modules/safer-cluster-update-variant/README.md
+++ b/modules/safer-cluster-update-variant/README.md
@@ -250,7 +250,6 @@ For simplicity, we suggest using `roles/container.admin` and
 | project\_id | The project ID to host the cluster in | `string` | n/a | yes |
 | region | The region to host the cluster in | `string` | n/a | yes |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | (Beta) The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`. | `string` | `"REGULAR"` | no |
 | resource\_usage\_export\_dataset\_id | The dataset id for which network egress metering for this cluster will be enabled. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `string` | `""` | no |

--- a/modules/safer-cluster-update-variant/main.tf
+++ b/modules/safer-cluster-update-variant/main.tf
@@ -96,7 +96,6 @@ module "gke" {
   //   wants to maintain control of their service accounts.
   create_service_account = var.compute_engine_service_account == "" ? true : false
   service_account        = var.compute_engine_service_account
-  registry_project_id    = var.registry_project_id
   registry_project_ids   = var.registry_project_ids
   grant_registry_access  = var.grant_registry_access
 

--- a/modules/safer-cluster-update-variant/variables.tf
+++ b/modules/safer-cluster-update-variant/variables.tf
@@ -208,12 +208,6 @@ variable "grant_registry_access" {
   default     = true
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
-  default     = ""
-}
-
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/modules/safer-cluster/README.md
+++ b/modules/safer-cluster/README.md
@@ -250,7 +250,6 @@ For simplicity, we suggest using `roles/container.admin` and
 | project\_id | The project ID to host the cluster in | `string` | n/a | yes |
 | region | The region to host the cluster in | `string` | n/a | yes |
 | regional | Whether is a regional cluster (zonal cluster if set false. WARNING: changing this after cluster creation is destructive!) | `bool` | `true` | no |
-| registry\_project\_id | Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version. | `string` | `""` | no |
 | registry\_project\_ids | Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects. | `list(string)` | `[]` | no |
 | release\_channel | (Beta) The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`. | `string` | `"REGULAR"` | no |
 | resource\_usage\_export\_dataset\_id | The dataset id for which network egress metering for this cluster will be enabled. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `string` | `""` | no |

--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -96,7 +96,6 @@ module "gke" {
   //   wants to maintain control of their service accounts.
   create_service_account = var.compute_engine_service_account == "" ? true : false
   service_account        = var.compute_engine_service_account
-  registry_project_id    = var.registry_project_id
   registry_project_ids   = var.registry_project_ids
   grant_registry_access  = var.grant_registry_access
 

--- a/modules/safer-cluster/variables.tf
+++ b/modules/safer-cluster/variables.tf
@@ -208,12 +208,6 @@ variable "grant_registry_access" {
   default     = true
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
-  default     = ""
-}
-
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."

--- a/sa.tf
+++ b/sa.tf
@@ -26,11 +26,7 @@ locals {
   // if user set var.service_account it will be used even if var.create_service_account==true, so service account will be created but not used
   service_account = (var.service_account == "" || var.service_account == "create") && var.create_service_account ? local.service_account_list[0] : var.service_account
 
-  registry_projects_list = compact(
-    length(var.registry_project_ids) == 0 && var.registry_project_id == ""
-    ? [var.project_id]
-    : concat([var.registry_project_id], var.registry_project_ids)
-  )
+  registry_projects_list = length(var.registry_project_ids) == 0 ? [var.project_id] : var.registry_project_ids
 }
 
 resource "random_string" "cluster_service_account_suffix" {

--- a/variables.tf
+++ b/variables.tf
@@ -310,12 +310,6 @@ variable "grant_registry_access" {
   default     = false
 }
 
-variable "registry_project_id" {
-  type        = string
-  description = "Deprecated. Replaced by `registry_project_ids`. Still works for the purposes of backwards compatibility, but will be removed in a future version."
-  default     = ""
-}
-
 variable "registry_project_ids" {
   type        = list(string)
   description = "Projects holding Google Container Registries. If empty, we use the cluster project. If a service account is created and the `grant_registry_access` variable is set to `true`, the `storage.objectViewer` role is assigned on these projects."


### PR DESCRIPTION
As of v13.1.0, the variable `registry_project_id` is deprecated. This PR removes the variable (resulting in a breaking change), so should be merged in the next major version versus a point release.