### PR TITLE
Add new property to explicitly return GKE private_endpoint

### DIFF
--- a/modules/auth/README.md
+++ b/modules/auth/README.md
@@ -9,15 +9,18 @@ This module retrieves a token for the account configured with the `google`
 provider as the Terraform runner using the provider's `credentials`,
 `access_token`, or other means of authentication.
 
+If you run a [private cluster](https://cloud.google.com/kubernetes-engine/docs/concepts/private-cluster-concept), you can set the `use_private_endpoint` property to return the GKE private_endpoint IP address.
+
 ## Usage
 
 ```tf
 module "gke_auth" {
-  source           = "terraform-google-modules/kubernetes-engine/google//modules/auth"
+  source               = "terraform-google-modules/kubernetes-engine/google//modules/auth"
 
-  project_id       = "my-project-id"
-  cluster_name     = "my-cluster-name"
-  location         = module.gke.location
+  project_id           = "my-project-id"
+  cluster_name         = "my-cluster-name"
+  location             = module.gke.location
+  use_private_endpoint = true
 }
 ```
 

--- a/modules/auth/main.tf
+++ b/modules/auth/main.tf
@@ -17,9 +17,8 @@
 locals {
   cluster_ca_certificate = data.google_container_cluster.gke_cluster.master_auth != null ? data.google_container_cluster.gke_cluster.master_auth[0].cluster_ca_certificate : ""
   private_endpoint       = try(data.google_container_cluster.gke_cluster.private_cluster_config[0].private_endpoint, "")
-  public_endpoint        = try(data.google_container_cluster.gke_cluster.private_cluster_config[0].public_endpoint, "")
   default_endpoint       = data.google_container_cluster.gke_cluster.endpoint != null ? data.google_container_cluster.gke_cluster.endpoint : ""
-  endpoint               = var.use_private_endpoint == true ? local.private_endpoint : local.public_endpoint != "" ? local.public_endpoint : local.default_endpoint
+  endpoint               = var.use_private_endpoint == true ? local.private_endpoint : local.default_endpoint
   host                   = local.endpoint != "" ? "https://${local.endpoint}" : ""
   context                = data.google_container_cluster.gke_cluster.name != null ? data.google_container_cluster.gke_cluster.name : ""
 }

--- a/modules/auth/main.tf
+++ b/modules/auth/main.tf
@@ -16,8 +16,11 @@
 
 locals {
   cluster_ca_certificate = data.google_container_cluster.gke_cluster.master_auth != null ? data.google_container_cluster.gke_cluster.master_auth[0].cluster_ca_certificate : ""
-  endpoint               = data.google_container_cluster.gke_cluster.endpoint != null ? data.google_container_cluster.gke_cluster.endpoint : ""
-  host                   = data.google_container_cluster.gke_cluster.endpoint != null ? "https://${data.google_container_cluster.gke_cluster.endpoint}" : ""
+  private_endpoint       = try(data.google_container_cluster.gke_cluster.private_cluster_config[0].private_endpoint, "")
+  public_endpoint        = try(data.google_container_cluster.gke_cluster.private_cluster_config[0].public_endpoint, "")
+  default_endpoint       = data.google_container_cluster.gke_cluster.endpoint != null ? data.google_container_cluster.gke_cluster.endpoint : ""
+  endpoint               = var.use_private_endpoint == true ? local.private_endpoint : local.public_endpoint != "" ? local.public_endpoint : local.default_endpoint
+  host                   = local.endpoint != "" ? "https://${local.endpoint}" : ""
   context                = data.google_container_cluster.gke_cluster.name != null ? data.google_container_cluster.gke_cluster.name : ""
 }
 

--- a/modules/auth/variables.tf
+++ b/modules/auth/variables.tf
@@ -28,3 +28,9 @@ variable "cluster_name" {
   description = "The name of the GKE cluster."
   type        = string
 }
+
+variable "use_private_endpoint" {
+  description = "Connect on the private GKE cluster endpoint"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This fixes #828 on the `auth` module. A new flag `use_private_endpoint` is introduced. If this flag is set to `true`, the `private_endpoint` property of the GKE cluster is looked up.

If `use_private_endpoint` is set to `false` (default), the `data.google_container_cluster.gke_cluster.private_cluster_config[0].public_endpoint` will be used if available with a fallback to the default GKE `endpoint` property.