### PR TITLE
Add step to avoid nodepool replacement due to random-id change

### DIFF
--- a/docs/upgrading_to_v13.0.md
+++ b/docs/upgrading_to_v13.0.md
@@ -73,3 +73,21 @@ This is destructive and will result in deletion and recreation of the ACM operat
 
 Plan: 0 to add, 0 to change, 3 to destroy.
 ```
+
+### NodePool Random ID Keepers Modified
+
+Reported in issue [#842](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/842)
+
+PR [#717](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/717) added the nodepool taints to the `keepers` for the `random_id` resource used in the naming of nodepools.
+
+This addition forces a replacement of the `random_id` resource, and therefore the nodepools themselves.
+
+To avoid this, it is possible to edit the remote state of the `random_id` resource to add the "missing" `keeper` attribute.
+
+1. Perform a `terraform plan` as normal, identifying the `random_id` resources changing and the new `"taints"` attribute
+1. Pull the remote state locally; `terraform state pull > default.tfstate`
+1. Backup the original remote state; `cp default.tfstate original.tfstate`
+1. Edit the `random_id` resources to add in the new `"taints"` attributes from the `terraform plan` step
+1. Bump the serial number at the top
+1. Push the modified state to the remote `terraform state push default.tfstate`
+1. Confirm the `random_id` resource no longer changes (or the corresponding `nodepool`) in a `terraform plan`

--- a/docs/upgrading_to_v13.0.md
+++ b/docs/upgrading_to_v13.0.md
@@ -74,7 +74,9 @@ This is destructive and will result in deletion and recreation of the ACM operat
 Plan: 0 to add, 0 to change, 3 to destroy.
 ```
 
-### NodePool Random ID Keepers Modified
+### Node Pool Random ID Keepers Modified
+
+Note: This change only applies to the update variant submodules.
 
 As reported in issue [#842](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/842), the v13.0 release has
 added the node pool taints to the `keepers` for the `random_id` resource used in the naming of node pools.

--- a/docs/upgrading_to_v13.0.md
+++ b/docs/upgrading_to_v13.0.md
@@ -76,17 +76,16 @@ Plan: 0 to add, 0 to change, 3 to destroy.
 
 ### NodePool Random ID Keepers Modified
 
-Reported in issue [#842](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/842)
+As reported in issue [#842](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/842), the v13.0 release has
+added the node pool taints to the `keepers` for the `random_id` resource used in the naming of node pools.
 
-PR [#717](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/717) added the nodepool taints to the `keepers` for the `random_id` resource used in the naming of nodepools.
-
-This addition forces a replacement of the `random_id` resource, and therefore the nodepools themselves.
+This addition forces a replacement of the `random_id` resource, and therefore the node pools themselves.
 
 To avoid this, it is possible to edit the remote state of the `random_id` resource to add the "missing" `keeper` attribute.
 
 1. Perform a `terraform plan` as normal, identifying the `random_id` resources changing and the new `"taints"` attribute
-1. Pull the remote state locally; `terraform state pull > default.tfstate`
-1. Backup the original remote state; `cp default.tfstate original.tfstate`
+1. Pull the remote state locally: `terraform state pull > default.tfstate`
+1. Back up the original remote state: `cp default.tfstate original.tfstate`
 1. Edit the `random_id` resources to add in the new `"taints"` attributes from the `terraform plan` step
 1. Bump the serial number at the top
 1. Push the modified state to the remote `terraform state push default.tfstate`


### PR DESCRIPTION
Add section to v13.0 upgrade doc on how to workaround `random_id` and nodepool cycling mentioned in https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/842