### PR TITLE
Fix ConfigManagement hierarchyController definition

### DIFF
--- a/modules/k8s-operator-crd-support/main.tf
+++ b/modules/k8s-operator-crd-support/main.tf
@@ -22,7 +22,7 @@ locals {
   manifest_path                                  = local.should_download_manifest ? "${path.root}/.terraform/tmp/${var.project_id}-${var.cluster_name}/config-management-operator.yaml" : var.operator_path
   sync_branch_node                               = var.sync_branch != "" ? format("syncBranch: %s", var.sync_branch) : ""
   policy_dir_node                                = var.policy_dir != "" ? format("policyDir: %s", var.policy_dir) : ""
-  hierarchy_controller_map_node                  = var.hierarchy_controller == null ? "" : format("hierarchy_controller:\n    %s", yamlencode(var.hierarchy_controller))
+  hierarchy_controller_map_node                  = var.hierarchy_controller == null ? "" : format("hierarchyController:\n    %s", indent(4, replace(yamlencode(var.hierarchy_controller), "/((?:^|\n)[\\s-]*)\"([\\w-]+)\":/", "$1$2:")))
   source_format_node                             = var.source_format != "" ? format("sourceFormat: %s", var.source_format) : ""
   append_arg_use_existing_context_for_gatekeeper = var.use_existing_context ? "USE_EXISTING_CONTEXT_ARG" : ""
 }


### PR DESCRIPTION
Hi,

currently the spec.hierarchyController definition is not working for the ConfigManagement template in the acm and config-sync modules.

The PR fixes the following things:
* hierarchy_controller is renamed to hierarchyController in the resource definition
* quotation marks added by the yamlencode function are removed
* correct indentation with more than one entry in the hiearchy_controller variable

## Example

With the hierarchy_controller variable defined as:
```
hierarchy_controller = {
    enabled                         = true
    enablePodTreeLabels             = true
    enableHierarchicalResourceQuota = true
  }
```

the output with v14.0.1 is as follows:
```
apiVersion: configmanagement.gke.io/v1
kind: ConfigManagement
metadata:
  name: config-management
spec:
  # clusterName is required and must be unique among all managed clusters
  clusterName: test
  policyController:
    # policyController definitions
  git:
    # git definitions

  hierarchy_controller:
    "enableHierarchicalResourceQuota": true
"enablePodTreeLabels": true
"enabled": true
```

output with this fix:
```
apiVersion: configmanagement.gke.io/v1
kind: ConfigManagement
metadata:
  name: config-management
spec:
  # clusterName is required and must be unique among all managed clusters
  clusterName: test
  policyController:
    # policyController definitions
  git:
    # git definitions

  hierarchyController:
    enableHierarchicalResourceQuota: true
    enablePodTreeLabels: true
    enabled: true
```