### PR TITLE
Add cluster ID to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Then perform the following commands on the root folder:
 | Name | Description |
 |------|-------------|
 | ca\_certificate | Cluster ca certificate (base64 encoded) |
+| cluster\_id | Cluster ID |
 | endpoint | Cluster endpoint |
 | horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |
 | http\_load\_balancing\_enabled | Whether http load balancing enabled |

--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -36,6 +36,9 @@ resource "random_shuffle" "available_zones" {
 }
 
 locals {
+  // ID of the cluster
+  cluster_id = google_container_cluster.primary.id
+
   // location
   location = var.regional ? var.region : var.zones[0]
   region   = var.regional ? var.region : join("-", slice(split("-", var.zones[0]), 0, 2))

--- a/autogen/main/outputs.tf.tmpl
+++ b/autogen/main/outputs.tf.tmpl
@@ -16,6 +16,11 @@
 
 {{ autogeneration_note }}
 
+output "cluster_id" {
+  description = "Cluster ID"
+  value       = local.cluster_id
+}
+
 output "name" {
   description = "Cluster name"
   value       = local.cluster_name

--- a/autogen/safer-cluster/outputs.tf.tmpl
+++ b/autogen/safer-cluster/outputs.tf.tmpl
@@ -16,6 +16,11 @@
 
 {{ autogeneration_note }}
 
+output "cluster_id" {
+  description = "Cluster ID"
+  value       = module.gke.cluster_id
+}
+
 output "name" {
   description = "Cluster name"
   value       = module.gke.name

--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,9 @@ resource "random_shuffle" "available_zones" {
 }
 
 locals {
+  // ID of the cluster
+  cluster_id = google_container_cluster.primary.id
+
   // location
   location = var.regional ? var.region : var.zones[0]
   region   = var.regional ? var.region : join("-", slice(split("-", var.zones[0]), 0, 2))

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -253,6 +253,7 @@ Then perform the following commands on the root folder:
 |------|-------------|
 | ca\_certificate | Cluster ca certificate (base64 encoded) |
 | cloudrun\_enabled | Whether CloudRun enabled |
+| cluster\_id | Cluster ID |
 | dns\_cache\_enabled | Whether DNS Cache enabled |
 | endpoint | Cluster endpoint |
 | horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -32,6 +32,9 @@ resource "random_shuffle" "available_zones" {
 }
 
 locals {
+  // ID of the cluster
+  cluster_id = google_container_cluster.primary.id
+
   // location
   location = var.regional ? var.region : var.zones[0]
   region   = var.regional ? var.region : join("-", slice(split("-", var.zones[0]), 0, 2))

--- a/modules/beta-private-cluster-update-variant/outputs.tf
+++ b/modules/beta-private-cluster-update-variant/outputs.tf
@@ -16,6 +16,11 @@
 
 // This file was automatically generated from a template in ./autogen/main
 
+output "cluster_id" {
+  description = "Cluster ID"
+  value       = local.cluster_id
+}
+
 output "name" {
   description = "Cluster name"
   value       = local.cluster_name

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -231,6 +231,7 @@ Then perform the following commands on the root folder:
 |------|-------------|
 | ca\_certificate | Cluster ca certificate (base64 encoded) |
 | cloudrun\_enabled | Whether CloudRun enabled |
+| cluster\_id | Cluster ID |
 | dns\_cache\_enabled | Whether DNS Cache enabled |
 | endpoint | Cluster endpoint |
 | horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -32,6 +32,9 @@ resource "random_shuffle" "available_zones" {
 }
 
 locals {
+  // ID of the cluster
+  cluster_id = google_container_cluster.primary.id
+
   // location
   location = var.regional ? var.region : var.zones[0]
   region   = var.regional ? var.region : join("-", slice(split("-", var.zones[0]), 0, 2))

--- a/modules/beta-private-cluster/outputs.tf
+++ b/modules/beta-private-cluster/outputs.tf
@@ -16,6 +16,11 @@
 
 // This file was automatically generated from a template in ./autogen/main
 
+output "cluster_id" {
+  description = "Cluster ID"
+  value       = local.cluster_id
+}
+
 output "name" {
   description = "Cluster name"
   value       = local.cluster_name

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -242,6 +242,7 @@ Then perform the following commands on the root folder:
 |------|-------------|
 | ca\_certificate | Cluster ca certificate (base64 encoded) |
 | cloudrun\_enabled | Whether CloudRun enabled |
+| cluster\_id | Cluster ID |
 | dns\_cache\_enabled | Whether DNS Cache enabled |
 | endpoint | Cluster endpoint |
 | horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |

--- a/modules/beta-public-cluster-update-variant/main.tf
+++ b/modules/beta-public-cluster-update-variant/main.tf
@@ -32,6 +32,9 @@ resource "random_shuffle" "available_zones" {
 }
 
 locals {
+  // ID of the cluster
+  cluster_id = google_container_cluster.primary.id
+
   // location
   location = var.regional ? var.region : var.zones[0]
   region   = var.regional ? var.region : join("-", slice(split("-", var.zones[0]), 0, 2))

--- a/modules/beta-public-cluster-update-variant/outputs.tf
+++ b/modules/beta-public-cluster-update-variant/outputs.tf
@@ -16,6 +16,11 @@
 
 // This file was automatically generated from a template in ./autogen/main
 
+output "cluster_id" {
+  description = "Cluster ID"
+  value       = local.cluster_id
+}
+
 output "name" {
   description = "Cluster name"
   value       = local.cluster_name

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -220,6 +220,7 @@ Then perform the following commands on the root folder:
 |------|-------------|
 | ca\_certificate | Cluster ca certificate (base64 encoded) |
 | cloudrun\_enabled | Whether CloudRun enabled |
+| cluster\_id | Cluster ID |
 | dns\_cache\_enabled | Whether DNS Cache enabled |
 | endpoint | Cluster endpoint |
 | horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -32,6 +32,9 @@ resource "random_shuffle" "available_zones" {
 }
 
 locals {
+  // ID of the cluster
+  cluster_id = google_container_cluster.primary.id
+
   // location
   location = var.regional ? var.region : var.zones[0]
   region   = var.regional ? var.region : join("-", slice(split("-", var.zones[0]), 0, 2))

--- a/modules/beta-public-cluster/outputs.tf
+++ b/modules/beta-public-cluster/outputs.tf
@@ -16,6 +16,11 @@
 
 // This file was automatically generated from a template in ./autogen/main
 
+output "cluster_id" {
+  description = "Cluster ID"
+  value       = local.cluster_id
+}
+
 output "name" {
   description = "Cluster name"
   value       = local.cluster_name

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -227,6 +227,7 @@ Then perform the following commands on the root folder:
 | Name | Description |
 |------|-------------|
 | ca\_certificate | Cluster ca certificate (base64 encoded) |
+| cluster\_id | Cluster ID |
 | endpoint | Cluster endpoint |
 | horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |
 | http\_load\_balancing\_enabled | Whether http load balancing enabled |

--- a/modules/private-cluster-update-variant/main.tf
+++ b/modules/private-cluster-update-variant/main.tf
@@ -32,6 +32,9 @@ resource "random_shuffle" "available_zones" {
 }
 
 locals {
+  // ID of the cluster
+  cluster_id = google_container_cluster.primary.id
+
   // location
   location = var.regional ? var.region : var.zones[0]
   region   = var.regional ? var.region : join("-", slice(split("-", var.zones[0]), 0, 2))

--- a/modules/private-cluster-update-variant/outputs.tf
+++ b/modules/private-cluster-update-variant/outputs.tf
@@ -16,6 +16,11 @@
 
 // This file was automatically generated from a template in ./autogen/main
 
+output "cluster_id" {
+  description = "Cluster ID"
+  value       = local.cluster_id
+}
+
 output "name" {
   description = "Cluster name"
   value       = local.cluster_name

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -205,6 +205,7 @@ Then perform the following commands on the root folder:
 | Name | Description |
 |------|-------------|
 | ca\_certificate | Cluster ca certificate (base64 encoded) |
+| cluster\_id | Cluster ID |
 | endpoint | Cluster endpoint |
 | horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |
 | http\_load\_balancing\_enabled | Whether http load balancing enabled |

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -32,6 +32,9 @@ resource "random_shuffle" "available_zones" {
 }
 
 locals {
+  // ID of the cluster
+  cluster_id = google_container_cluster.primary.id
+
   // location
   location = var.regional ? var.region : var.zones[0]
   region   = var.regional ? var.region : join("-", slice(split("-", var.zones[0]), 0, 2))

--- a/modules/private-cluster/outputs.tf
+++ b/modules/private-cluster/outputs.tf
@@ -16,6 +16,11 @@
 
 // This file was automatically generated from a template in ./autogen/main
 
+output "cluster_id" {
+  description = "Cluster ID"
+  value       = local.cluster_id
+}
+
 output "name" {
   description = "Cluster name"
   value       = local.cluster_name

--- a/modules/safer-cluster-update-variant/README.md
+++ b/modules/safer-cluster-update-variant/README.md
@@ -264,6 +264,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | Name | Description |
 |------|-------------|
 | ca\_certificate | Cluster ca certificate (base64 encoded) |
+| cluster\_id | Cluster ID |
 | endpoint | Cluster endpoint |
 | horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |
 | http\_load\_balancing\_enabled | Whether http load balancing enabled |

--- a/modules/safer-cluster-update-variant/outputs.tf
+++ b/modules/safer-cluster-update-variant/outputs.tf
@@ -16,6 +16,11 @@
 
 // This file was automatically generated from a template in ./autogen/safer-cluster
 
+output "cluster_id" {
+  description = "Cluster ID"
+  value       = module.gke.cluster_id
+}
+
 output "name" {
   description = "Cluster name"
   value       = module.gke.name

--- a/modules/safer-cluster/README.md
+++ b/modules/safer-cluster/README.md
@@ -264,6 +264,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | Name | Description |
 |------|-------------|
 | ca\_certificate | Cluster ca certificate (base64 encoded) |
+| cluster\_id | Cluster ID |
 | endpoint | Cluster endpoint |
 | horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |
 | http\_load\_balancing\_enabled | Whether http load balancing enabled |

--- a/modules/safer-cluster/outputs.tf
+++ b/modules/safer-cluster/outputs.tf
@@ -16,6 +16,11 @@
 
 // This file was automatically generated from a template in ./autogen/safer-cluster
 
+output "cluster_id" {
+  description = "Cluster ID"
+  value       = module.gke.cluster_id
+}
+
 output "name" {
   description = "Cluster name"
   value       = module.gke.name

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,6 +16,11 @@
 
 // This file was automatically generated from a template in ./autogen/main
 
+output "cluster_id" {
+  description = "Cluster ID"
+  value       = local.cluster_id
+}
+
 output "name" {
   description = "Cluster name"
   value       = local.cluster_name


### PR DESCRIPTION
This PR adds the [GKE Cluster id](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#id) as an output. Having the id handy saves users from having to fetch that id with a data source.

Additionally, this is likely a prerequisite for #860 

Closes #885 