### PR TITLE
[workload identity] add entire GSA in output

### DIFF
--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -84,6 +84,7 @@ module "my-app-workload-identity" {
 
 | Name | Description |
 |------|-------------|
+| gcp\_service\_account | GCP service account. |
 | gcp\_service\_account\_email | Email address of GCP service account. |
 | gcp\_service\_account\_fqn | FQN of GCP service account. |
 | gcp\_service\_account\_name | Name of GCP service account. |

--- a/modules/workload-identity/output.tf
+++ b/modules/workload-identity/output.tf
@@ -38,3 +38,8 @@ output "gcp_service_account_name" {
   description = "Name of GCP service account."
   value       = local.k8s_sa_gcp_derived_name
 }
+
+output "gcp_service_account" {
+  description = "GCP service account."
+  value       = google_service_account.cluster_service_account
+}


### PR DESCRIPTION
I wanted to access the id
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_service_account#attributes-reference
but instead of adding it individually, exporting the GSA as is offers
the most flexibility long term.

Signed-off-by: naseemkullah <naseem@transit.app>