### PR TITLE
Token-based git authentication for ACM

### DIFF
--- a/modules/acm/README.md
+++ b/modules/acm/README.md
@@ -51,6 +51,8 @@ By default, this module will attempt to download the ACM operator from Google di
 | enable\_log\_denies | Whether to enable logging of all denies and dryrun failures for ACM Policy Controller. | `bool` | `false` | no |
 | enable\_multi\_repo | Whether to use ACM Config Sync [multi-repo mode](https://cloud.google.com/kubernetes-engine/docs/add-on/config-sync/how-to/multi-repo). | `bool` | `false` | no |
 | enable\_policy\_controller | Whether to enable the ACM Policy Controller on the cluster | `bool` | `true` | no |
+| git\_token | Token for token-based git access. | `string` | `null` | no |
+| git\_username | Username for token-based git access. | `string` | `null` | no |
 | hierarchy\_controller | Configurations for Hierarchy Controller. See [Hierarchy Controller docs](https://cloud.google.com/anthos-config-management/docs/how-to/installing-hierarchy-controller) for more details | `map(any)` | `null` | no |
 | install\_template\_library | Whether to install the default Policy Controller template library | `bool` | `true` | no |
 | location | GCP location used to reach cluster. | `string` | n/a | yes |

--- a/modules/acm/main.tf
+++ b/modules/acm/main.tf
@@ -53,6 +53,8 @@ module "acm_operator" {
   enable_log_denies        = var.enable_log_denies
   service_account_key_file = var.service_account_key_file
   use_existing_context     = var.use_existing_context
+  git_token                = var.git_token
+  git_username             = var.git_username
 
   operator_latest_manifest_url  = "gs://config-management-release/released/latest/config-management-operator.yaml"
   operator_cr_template_path     = "${path.module}/templates/acm-config.yml.tpl"

--- a/modules/acm/variables.tf
+++ b/modules/acm/variables.tf
@@ -127,3 +127,17 @@ variable "use_existing_context" {
   type        = bool
   default     = false
 }
+
+variable "git_token" {
+  description = "Token for token-based git access."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "git_username" {
+  description = "Username for token-based git access."
+  type        = string
+  default     = null
+  sensitive   = true
+}

--- a/modules/acm/variables.tf
+++ b/modules/acm/variables.tf
@@ -132,12 +132,10 @@ variable "git_token" {
   description = "Token for token-based git access."
   type        = string
   default     = null
-  sensitive   = true
 }
 
 variable "git_username" {
   description = "Username for token-based git access."
   type        = string
   default     = null
-  sensitive   = true
 }

--- a/modules/k8s-operator-crd-support/variables.tf
+++ b/modules/k8s-operator-crd-support/variables.tf
@@ -168,3 +168,17 @@ variable "impersonate_service_account" {
   description = "An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials."
   default     = ""
 }
+
+variable "git_token" {
+  description = "Token for token-based git access."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "git_username" {
+  description = "Username for token-based git access."
+  type        = string
+  default     = null
+  sensitive   = true
+}

--- a/modules/k8s-operator-crd-support/variables.tf
+++ b/modules/k8s-operator-crd-support/variables.tf
@@ -173,12 +173,10 @@ variable "git_token" {
   description = "Token for token-based git access."
   type        = string
   default     = null
-  sensitive   = true
 }
 
 variable "git_username" {
   description = "Username for token-based git access."
   type        = string
   default     = null
-  sensitive   = true
 }


### PR DESCRIPTION
Updated ACM "git-creds" secret creation to support token-based authentication.  In this mode, the git-creds secret must contain both the username and token keys.
Added the ability for git-creds to be updated with new values after creation.