### PR TITLE
Fixed the ASM module's destroy command.

### DIFF
--- a/examples/simple_zonal_with_asm/outputs.tf
+++ b/examples/simple_zonal_with_asm/outputs.tf
@@ -25,7 +25,8 @@ output "client_token" {
 }
 
 output "ca_certificate" {
-  value = module.gke.ca_certificate
+  sensitive = true
+  value     = module.gke.ca_certificate
 }
 
 output "service_account" {

--- a/modules/asm/main.tf
+++ b/modules/asm/main.tf
@@ -96,5 +96,5 @@ module "asm_install" {
   impersonate_service_account = var.impersonate_service_account
 
   kubectl_create_command  = "${path.module}/scripts/install_asm.sh ${var.project_id} ${var.cluster_name} ${var.location} ${var.asm_version} ${var.mode} ${var.managed_control_plane} ${var.skip_validation} ${local.options_string} ${local.custom_overlays_string} ${var.enable_all} ${var.enable_cluster_roles} ${var.enable_cluster_labels} ${var.enable_gcp_components} ${var.enable_registration} ${var.outdir} ${var.ca} ${local.ca_cert} ${local.ca_key} ${local.root_cert} ${local.cert_chain} ${local.service_account_string} ${local.key_file_string} ${local.asm_git_tag_string}"
-  kubectl_destroy_command = "kubectl delete ns istio-system"
+  kubectl_destroy_command = "kubectl delete ns asm-system istio-system && kubectl label namespaces --all istio-injection-"
 }


### PR DESCRIPTION
Currently, the ASM module’s destroy command only removes the istio-system namespace. This pull request extends the module’s destroy command to remove any istio/asm related labels and/or namespaces.

For testing my changes, I used the "simple_zonal_with_asm" example. Unfortunately, the example didn't start due to the ca_certificate output variable not being marked as sensitive. After correcting this mistake, everything was working as expected.

Fixes #881 