### PR TITLE
Asm overlay path

### DIFF
--- a/modules/asm/scripts/install_asm.sh
+++ b/modules/asm/scripts/install_asm.sh
@@ -79,7 +79,7 @@ item="${OPTIONS[*]}";OPTIONS_COMMAND=$(echo "--option" "${item// / --option }")
 echo -e "OPTIONS_COMMAND is $OPTIONS_COMMAND"
 echo -e "CUSTOM_OVERLAYS array length is ${#CUSTOM_OVERLAYS[@]}"
 # Create custom_overlays command snippet
-item="${CUSTOM_OVERLAYS[*]}";CUSTOM_OVERLAYS_COMMAND=$(echo "--custom_overlay $(pwd)/" "${item// / --custom_overlay $(pwd)/}")
+item="${CUSTOM_OVERLAYS[*]}";CUSTOM_OVERLAYS_COMMAND=$(echo "--custom_overlay " "$(pwd)/${item// / --custom_overlay $(pwd)/}")
 echo -e "CUSTOM_OVERLAYS_COMMAND is $CUSTOM_OVERLAYS_COMMAND"
 echo -e "ENABLE_ALL is $ENABLE_ALL"
 echo -e "ENABLE_CLUSTER_ROLES is $ENABLE_CLUSTER_ROLES"

--- a/modules/asm/scripts/install_asm.sh
+++ b/modules/asm/scripts/install_asm.sh
@@ -79,7 +79,7 @@ item="${OPTIONS[*]}";OPTIONS_COMMAND=$(echo "--option" "${item// / --option }")
 echo -e "OPTIONS_COMMAND is $OPTIONS_COMMAND"
 echo -e "CUSTOM_OVERLAYS array length is ${#CUSTOM_OVERLAYS[@]}"
 # Create custom_overlays command snippet
-item="${CUSTOM_OVERLAYS[*]}";CUSTOM_OVERLAYS_COMMAND=$(echo "--custom_overlay" "$(pwd)/${item// / --custom_overlay }")
+item="${CUSTOM_OVERLAYS[*]}";CUSTOM_OVERLAYS_COMMAND=$(echo "--custom_overlay" "$(pwd)/${item// / --custom_overlay $(pwd)/}")
 echo -e "CUSTOM_OVERLAYS_COMMAND is $CUSTOM_OVERLAYS_COMMAND"
 echo -e "ENABLE_ALL is $ENABLE_ALL"
 echo -e "ENABLE_CLUSTER_ROLES is $ENABLE_CLUSTER_ROLES"

--- a/modules/asm/scripts/install_asm.sh
+++ b/modules/asm/scripts/install_asm.sh
@@ -79,7 +79,7 @@ item="${OPTIONS[*]}";OPTIONS_COMMAND=$(echo "--option" "${item// / --option }")
 echo -e "OPTIONS_COMMAND is $OPTIONS_COMMAND"
 echo -e "CUSTOM_OVERLAYS array length is ${#CUSTOM_OVERLAYS[@]}"
 # Create custom_overlays command snippet
-item="${CUSTOM_OVERLAYS[*]}";CUSTOM_OVERLAYS_COMMAND=$(echo "--custom_overlay" "$(pwd)/${item// / --custom_overlay $(pwd)/}")
+item="${CUSTOM_OVERLAYS[*]}";CUSTOM_OVERLAYS_COMMAND=$(echo "--custom_overlay $(pwd)/" "${item// / --custom_overlay $(pwd)}")
 echo -e "CUSTOM_OVERLAYS_COMMAND is $CUSTOM_OVERLAYS_COMMAND"
 echo -e "ENABLE_ALL is $ENABLE_ALL"
 echo -e "ENABLE_CLUSTER_ROLES is $ENABLE_CLUSTER_ROLES"

--- a/modules/asm/scripts/install_asm.sh
+++ b/modules/asm/scripts/install_asm.sh
@@ -79,7 +79,11 @@ item="${OPTIONS[*]}";OPTIONS_COMMAND=$(echo "--option" "${item// / --option }")
 echo -e "OPTIONS_COMMAND is $OPTIONS_COMMAND"
 echo -e "CUSTOM_OVERLAYS array length is ${#CUSTOM_OVERLAYS[@]}"
 # Create custom_overlays command snippet
-item="${CUSTOM_OVERLAYS[*]}";CUSTOM_OVERLAYS_COMMAND=$(echo "--custom_overlay" "$(pwd)/${item// / --custom_overlay $(pwd)/}")
+if [[ "${CUSTOM_OVERLAYS[*]}" == "none" ]]; then
+    CUSTOM_OVERLAYS_COMMAND="--custom_overlay none"
+else
+    item="${CUSTOM_OVERLAYS[*]}";CUSTOM_OVERLAYS_COMMAND=$(echo "--custom_overlay" "$(pwd)/${item// / --custom_overlay $(pwd)/}")
+fi
 echo -e "CUSTOM_OVERLAYS_COMMAND is $CUSTOM_OVERLAYS_COMMAND"
 echo -e "ENABLE_ALL is $ENABLE_ALL"
 echo -e "ENABLE_CLUSTER_ROLES is $ENABLE_CLUSTER_ROLES"

--- a/modules/asm/scripts/install_asm.sh
+++ b/modules/asm/scripts/install_asm.sh
@@ -79,7 +79,7 @@ item="${OPTIONS[*]}";OPTIONS_COMMAND=$(echo "--option" "${item// / --option }")
 echo -e "OPTIONS_COMMAND is $OPTIONS_COMMAND"
 echo -e "CUSTOM_OVERLAYS array length is ${#CUSTOM_OVERLAYS[@]}"
 # Create custom_overlays command snippet
-item="${CUSTOM_OVERLAYS[*]}";CUSTOM_OVERLAYS_COMMAND=$(echo "--custom_overlay" "${item// / --custom_overlay }")
+item="${CUSTOM_OVERLAYS[*]}";CUSTOM_OVERLAYS_COMMAND=$(echo "--custom_overlay" "$(pwd)/${item// / --custom_overlay }")
 echo -e "CUSTOM_OVERLAYS_COMMAND is $CUSTOM_OVERLAYS_COMMAND"
 echo -e "ENABLE_ALL is $ENABLE_ALL"
 echo -e "ENABLE_CLUSTER_ROLES is $ENABLE_CLUSTER_ROLES"

--- a/modules/asm/scripts/install_asm.sh
+++ b/modules/asm/scripts/install_asm.sh
@@ -79,7 +79,7 @@ item="${OPTIONS[*]}";OPTIONS_COMMAND=$(echo "--option" "${item// / --option }")
 echo -e "OPTIONS_COMMAND is $OPTIONS_COMMAND"
 echo -e "CUSTOM_OVERLAYS array length is ${#CUSTOM_OVERLAYS[@]}"
 # Create custom_overlays command snippet
-item="${CUSTOM_OVERLAYS[*]}";CUSTOM_OVERLAYS_COMMAND=$(echo "--custom_overlay $(pwd)/" "${item// / --custom_overlay $(pwd)}")
+item="${CUSTOM_OVERLAYS[*]}";CUSTOM_OVERLAYS_COMMAND=$(echo "--custom_overlay $(pwd)/" "${item// / --custom_overlay $(pwd)/}")
 echo -e "CUSTOM_OVERLAYS_COMMAND is $CUSTOM_OVERLAYS_COMMAND"
 echo -e "ENABLE_ALL is $ENABLE_ALL"
 echo -e "ENABLE_CLUSTER_ROLES is $ENABLE_CLUSTER_ROLES"

--- a/modules/asm/scripts/install_asm.sh
+++ b/modules/asm/scripts/install_asm.sh
@@ -79,7 +79,7 @@ item="${OPTIONS[*]}";OPTIONS_COMMAND=$(echo "--option" "${item// / --option }")
 echo -e "OPTIONS_COMMAND is $OPTIONS_COMMAND"
 echo -e "CUSTOM_OVERLAYS array length is ${#CUSTOM_OVERLAYS[@]}"
 # Create custom_overlays command snippet
-item="${CUSTOM_OVERLAYS[*]}";CUSTOM_OVERLAYS_COMMAND=$(echo "--custom_overlay " "$(pwd)/${item// / --custom_overlay $(pwd)/}")
+item="${CUSTOM_OVERLAYS[*]}";CUSTOM_OVERLAYS_COMMAND=$(echo "--custom_overlay" "$(pwd)/${item// / --custom_overlay $(pwd)/}")
 echo -e "CUSTOM_OVERLAYS_COMMAND is $CUSTOM_OVERLAYS_COMMAND"
 echo -e "ENABLE_ALL is $ENABLE_ALL"
 echo -e "ENABLE_CLUSTER_ROLES is $ENABLE_CLUSTER_ROLES"


### PR DESCRIPTION
Similar to the fix @ameer00 and I made for `KEY_FILE_COMMAND_SNIPPET` to add the full path to the service account key file, the `CUSTOM_OVERLAYS_COMMAND` also needs the full path since the script generating the command is in a different location from where it is used, so it will not resolve relative paths correctly.