### PR TITLE
fix: asm destroy

### DIFF
--- a/modules/asm/main.tf
+++ b/modules/asm/main.tf
@@ -96,5 +96,5 @@ module "asm_install" {
   impersonate_service_account = var.impersonate_service_account
 
   kubectl_create_command  = "${path.module}/scripts/install_asm.sh ${var.project_id} ${var.cluster_name} ${var.location} ${var.asm_version} ${var.mode} ${var.managed_control_plane} ${var.skip_validation} ${local.options_string} ${local.custom_overlays_string} ${var.enable_all} ${var.enable_cluster_roles} ${var.enable_cluster_labels} ${var.enable_gcp_components} ${var.enable_registration} ${var.outdir} ${var.ca} ${local.ca_cert} ${local.ca_key} ${local.root_cert} ${local.cert_chain} ${local.service_account_string} ${local.key_file_string} ${local.asm_git_tag_string}"
-  kubectl_destroy_command = "kubectl delete ns asm-system istio-system && kubectl label namespaces --all istio-injection-"
+  kubectl_destroy_command = "${path.module}/scripts/destroy_asm.sh"
 }

--- a/modules/asm/scripts/destroy_asm.sh
+++ b/modules/asm/scripts/destroy_asm.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+kubectl delete ns asm-system istio-system --ignore-not-found
+kubectl label namespaces --all istio-injection-

--- a/test/integration/node_pool/controls/gcloud.rb
+++ b/test/integration/node_pool/controls/gcloud.rb
@@ -37,6 +37,7 @@ control "gcloud" do
       it "has the expected cluster autoscaling settings" do
         expect(data['autoscaling']).to eq({
             "autoprovisioningNodePoolDefaults" => {
+                "imageType"=>"COS",
                 "oauthScopes" => %w(https://www.googleapis.com/auth/cloud-platform),
                 "serviceAccount" => "default"
             },


### PR DESCRIPTION
fixes #919 
also adds `--ignore-not-found` incase a namespace is not found. This could be useful if destroy failed midway due to any reason and only removed one of the namespaces.