### PR TITLE
fix: Remove kustomize requirement

### DIFF
--- a/modules/asm/main.tf
+++ b/modules/asm/main.tf
@@ -88,7 +88,7 @@ module "asm_install" {
 
   gcloud_sdk_version          = var.gcloud_sdk_version
   upgrade                     = true
-  additional_components       = ["kubectl", "kpt", "beta", "kustomize"]
+  additional_components       = ["kubectl", "kpt", "beta"]
   cluster_name                = var.cluster_name
   cluster_location            = var.location
   project_id                  = var.project_id


### PR DESCRIPTION
`kustomize` seems to be a historical requirement, and is not used anymore by the ASM install script - https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/master/modules/asm/scripts/install_asm.sh.

The install works fine without `kustomize` command being available on the system.