### PR TITLE
Add support for all kubelet_config fields in node pools 

### DIFF
--- a/autogen/main/README.md
+++ b/autogen/main/README.md
@@ -174,6 +174,8 @@ The node_pools variable takes the following parameters:
 | autoscaling | Configuration required by cluster autoscaler to adjust the size of the node pool to the current cluster usage | true | Optional |
 | auto_upgrade | Whether the nodes will be automatically upgraded | true (if cluster is regional) | Optional |
 {% if beta_cluster %}
+| cpu_cfs_quota | Enable CPU CFS quota enforcement for containers that specify CPU limits. | true | Optional |
+| cpu_cfs_quota_period | Set the CPU CFS quota period value 'cpu.cfs_period_us'. |  | Optional |
 | cpu_manager_policy | The CPU manager policy on the node. One of "none" or "static". | "none" | Optional |
 {% endif %}
 | disk_size_gb | Size of the disk attached to each node, specified in GB. The smallest allowed disk size is 10GB | 100 | Optional |

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -578,10 +578,16 @@ resource "google_container_node_pool" "pools" {
     boot_disk_kms_key = lookup(each.value, "boot_disk_kms_key", "")
 
     dynamic "kubelet_config" {
-      for_each = contains(keys(each.value), "cpu_manager_policy") ? [1] : []
+      for_each =  (
+        contains(keys(each.value), "cpu_cfs_quota") ||
+        contains(keys(each.value), "cpu_cfs_quota_period") ||
+        contains(keys(each.value), "cpu_manager_policy")
+        ) ? [1] : []
 
       content {
-        cpu_manager_policy = lookup(each.value, "cpu_manager_policy")
+        cpu_cfs_quota = lookup(each.value, "cpu_cfs_quota", true)
+        cpu_cfs_quota_period = lookup(each.value, "cpu_cfs_quota_period", "100ms")
+        cpu_manager_policy = lookup(each.value, "cpu_manager_policy", "none")
       }
     }
 

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -296,6 +296,8 @@ The node_pools variable takes the following parameters:
 | auto_repair | Whether the nodes will be automatically repaired | true | Optional |
 | autoscaling | Configuration required by cluster autoscaler to adjust the size of the node pool to the current cluster usage | true | Optional |
 | auto_upgrade | Whether the nodes will be automatically upgraded | true (if cluster is regional) | Optional |
+| cpu_cfs_quota | Enable CPU CFS quota enforcement for containers that specify CPU limits. | true | Optional |
+| cpu_cfs_quota_period | Set the CPU CFS quota period value 'cpu.cfs_period_us'. |  | Optional |
 | cpu_manager_policy | The CPU manager policy on the node. One of "none" or "static". | "none" | Optional |
 | disk_size_gb | Size of the disk attached to each node, specified in GB. The smallest allowed disk size is 10GB | 100 | Optional |
 | disk_type | Type of the disk attached to each node (e.g. 'pd-standard' or 'pd-ssd') | pd-standard | Optional |

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -534,7 +534,7 @@ resource "google_container_node_pool" "pools" {
 
       content {
         cpu_cfs_quota        = lookup(each.value, "cpu_cfs_quota", true)
-        cpu_cfs_quota_period = lookup(each.value, "cpu_cfs_quota_period", "")
+        cpu_cfs_quota_period = lookup(each.value, "cpu_cfs_quota_period", "100ms")
         cpu_manager_policy   = lookup(each.value, "cpu_manager_policy", "none")
       }
     }

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -526,10 +526,16 @@ resource "google_container_node_pool" "pools" {
     boot_disk_kms_key = lookup(each.value, "boot_disk_kms_key", "")
 
     dynamic "kubelet_config" {
-      for_each = contains(keys(each.value), "cpu_manager_policy") ? [1] : []
+      for_each = (
+        contains(keys(each.value), "cpu_cfs_quota") ||
+        contains(keys(each.value), "cpu_cfs_quota_period") ||
+        contains(keys(each.value), "cpu_manager_policy")
+      ) ? [1] : []
 
       content {
-        cpu_manager_policy = lookup(each.value, "cpu_manager_policy")
+        cpu_cfs_quota        = lookup(each.value, "cpu_cfs_quota", true)
+        cpu_cfs_quota_period = lookup(each.value, "cpu_cfs_quota_period", "")
+        cpu_manager_policy   = lookup(each.value, "cpu_manager_policy", "none")
       }
     }
 

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -274,6 +274,8 @@ The node_pools variable takes the following parameters:
 | auto_repair | Whether the nodes will be automatically repaired | true | Optional |
 | autoscaling | Configuration required by cluster autoscaler to adjust the size of the node pool to the current cluster usage | true | Optional |
 | auto_upgrade | Whether the nodes will be automatically upgraded | true (if cluster is regional) | Optional |
+| cpu_cfs_quota | Enable CPU CFS quota enforcement for containers that specify CPU limits. | true | Optional |
+| cpu_cfs_quota_period | Set the CPU CFS quota period value 'cpu.cfs_period_us'. |  | Optional |
 | cpu_manager_policy | The CPU manager policy on the node. One of "none" or "static". | "none" | Optional |
 | disk_size_gb | Size of the disk attached to each node, specified in GB. The smallest allowed disk size is 10GB | 100 | Optional |
 | disk_type | Type of the disk attached to each node (e.g. 'pd-standard' or 'pd-ssd') | pd-standard | Optional |

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -450,7 +450,7 @@ resource "google_container_node_pool" "pools" {
 
       content {
         cpu_cfs_quota        = lookup(each.value, "cpu_cfs_quota", true)
-        cpu_cfs_quota_period = lookup(each.value, "cpu_cfs_quota_period", "")
+        cpu_cfs_quota_period = lookup(each.value, "cpu_cfs_quota_period", "100ms")
         cpu_manager_policy   = lookup(each.value, "cpu_manager_policy", "none")
       }
     }

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -442,10 +442,16 @@ resource "google_container_node_pool" "pools" {
     boot_disk_kms_key = lookup(each.value, "boot_disk_kms_key", "")
 
     dynamic "kubelet_config" {
-      for_each = contains(keys(each.value), "cpu_manager_policy") ? [1] : []
+      for_each = (
+        contains(keys(each.value), "cpu_cfs_quota") ||
+        contains(keys(each.value), "cpu_cfs_quota_period") ||
+        contains(keys(each.value), "cpu_manager_policy")
+      ) ? [1] : []
 
       content {
-        cpu_manager_policy = lookup(each.value, "cpu_manager_policy")
+        cpu_cfs_quota        = lookup(each.value, "cpu_cfs_quota", true)
+        cpu_cfs_quota_period = lookup(each.value, "cpu_cfs_quota_period", "")
+        cpu_manager_policy   = lookup(each.value, "cpu_manager_policy", "none")
       }
     }
 

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -283,6 +283,8 @@ The node_pools variable takes the following parameters:
 | auto_repair | Whether the nodes will be automatically repaired | true | Optional |
 | autoscaling | Configuration required by cluster autoscaler to adjust the size of the node pool to the current cluster usage | true | Optional |
 | auto_upgrade | Whether the nodes will be automatically upgraded | true (if cluster is regional) | Optional |
+| cpu_cfs_quota | Enable CPU CFS quota enforcement for containers that specify CPU limits. | true | Optional |
+| cpu_cfs_quota_period | Set the CPU CFS quota period value 'cpu.cfs_period_us'. |  | Optional |
 | cpu_manager_policy | The CPU manager policy on the node. One of "none" or "static". | "none" | Optional |
 | disk_size_gb | Size of the disk attached to each node, specified in GB. The smallest allowed disk size is 10GB | 100 | Optional |
 | disk_type | Type of the disk attached to each node (e.g. 'pd-standard' or 'pd-ssd') | pd-standard | Optional |

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -507,10 +507,16 @@ resource "google_container_node_pool" "pools" {
     boot_disk_kms_key = lookup(each.value, "boot_disk_kms_key", "")
 
     dynamic "kubelet_config" {
-      for_each = contains(keys(each.value), "cpu_manager_policy") ? [1] : []
+      for_each = (
+        contains(keys(each.value), "cpu_cfs_quota") ||
+        contains(keys(each.value), "cpu_cfs_quota_period") ||
+        contains(keys(each.value), "cpu_manager_policy")
+      ) ? [1] : []
 
       content {
-        cpu_manager_policy = lookup(each.value, "cpu_manager_policy")
+        cpu_cfs_quota        = lookup(each.value, "cpu_cfs_quota", true)
+        cpu_cfs_quota_period = lookup(each.value, "cpu_cfs_quota_period", "")
+        cpu_manager_policy   = lookup(each.value, "cpu_manager_policy", "none")
       }
     }
 

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -515,7 +515,7 @@ resource "google_container_node_pool" "pools" {
 
       content {
         cpu_cfs_quota        = lookup(each.value, "cpu_cfs_quota", true)
-        cpu_cfs_quota_period = lookup(each.value, "cpu_cfs_quota_period", "")
+        cpu_cfs_quota_period = lookup(each.value, "cpu_cfs_quota_period", "100ms")
         cpu_manager_policy   = lookup(each.value, "cpu_manager_policy", "none")
       }
     }

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -261,6 +261,8 @@ The node_pools variable takes the following parameters:
 | auto_repair | Whether the nodes will be automatically repaired | true | Optional |
 | autoscaling | Configuration required by cluster autoscaler to adjust the size of the node pool to the current cluster usage | true | Optional |
 | auto_upgrade | Whether the nodes will be automatically upgraded | true (if cluster is regional) | Optional |
+| cpu_cfs_quota | Enable CPU CFS quota enforcement for containers that specify CPU limits. | true | Optional |
+| cpu_cfs_quota_period | Set the CPU CFS quota period value 'cpu.cfs_period_us'. |  | Optional |
 | cpu_manager_policy | The CPU manager policy on the node. One of "none" or "static". | "none" | Optional |
 | disk_size_gb | Size of the disk attached to each node, specified in GB. The smallest allowed disk size is 10GB | 100 | Optional |
 | disk_type | Type of the disk attached to each node (e.g. 'pd-standard' or 'pd-ssd') | pd-standard | Optional |

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -431,7 +431,7 @@ resource "google_container_node_pool" "pools" {
 
       content {
         cpu_cfs_quota        = lookup(each.value, "cpu_cfs_quota", true)
-        cpu_cfs_quota_period = lookup(each.value, "cpu_cfs_quota_period", "")
+        cpu_cfs_quota_period = lookup(each.value, "cpu_cfs_quota_period", "100ms")
         cpu_manager_policy   = lookup(each.value, "cpu_manager_policy", "none")
       }
     }

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -423,10 +423,16 @@ resource "google_container_node_pool" "pools" {
     boot_disk_kms_key = lookup(each.value, "boot_disk_kms_key", "")
 
     dynamic "kubelet_config" {
-      for_each = contains(keys(each.value), "cpu_manager_policy") ? [1] : []
+      for_each = (
+        contains(keys(each.value), "cpu_cfs_quota") ||
+        contains(keys(each.value), "cpu_cfs_quota_period") ||
+        contains(keys(each.value), "cpu_manager_policy")
+      ) ? [1] : []
 
       content {
-        cpu_manager_policy = lookup(each.value, "cpu_manager_policy")
+        cpu_cfs_quota        = lookup(each.value, "cpu_cfs_quota", true)
+        cpu_cfs_quota_period = lookup(each.value, "cpu_cfs_quota_period", "")
+        cpu_manager_policy   = lookup(each.value, "cpu_manager_policy", "none")
       }
     }
 


### PR DESCRIPTION
This adds support for the missing [`cpu_cfs_quota` and `cpu_cfs_quota_period` attributes](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#kubelet_config
) in the `kubelet_config` block of node pools configuration.

This gave me some flexibility to work around #941, although it doesn't solve the root cause of the issue (which seems to be a provider bug).
