### PR TITLE
fix: nap default image in test

### DIFF
--- a/test/integration/node_pool/controls/gcloud.rb
+++ b/test/integration/node_pool/controls/gcloud.rb
@@ -37,7 +37,7 @@ control "gcloud" do
       it "has the expected cluster autoscaling settings" do
         expect(data['autoscaling']).to eq({
             "autoprovisioningNodePoolDefaults" => {
-                "imageType"=>"COS",
+                "imageType"=>"COS_CONTAINERD",
                 "oauthScopes" => %w(https://www.googleapis.com/auth/cloud-platform),
                 "serviceAccount" => "default"
             },


### PR DESCRIPTION
[default](https://cloud.google.com/kubernetes-engine/docs/concepts/using-containerd#:~:text=starting%20with%20gke%20node%20version%201.19) is now cos_containerd