### PR TITLE
Enables an existing GSA to be used when setting up Workload Identity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,15 +59,24 @@ Six test-kitchen instances are defined:
 The test-kitchen instances in `test/fixtures/` wrap identically-named examples in the `examples/` directory.`
 
 ### Test Environment
-The easiest way to test the module is in an isolated test project. The setup for such a project is defined in [test/setup](./test/setup/) directory.
+The easiest way to test the module is in an isolated test project. The
+setup for such a project is defined in [test/setup](./test/setup/)
+directory.
 
-To use this setup, you need a service account with Project Creator access on a folder. Export the Service Account credentials to your environment like so:
+To use this setup, you need a service account with Project Creator access
+on a folder; the Billing Account User role is also required. Export the
+Service Account credentials to your environment like so:
 
 ```
 export SERVICE_ACCOUNT_JSON=$(< credentials.json)
 ```
 
+Note that `SERVICE_ACCOUNT_JSON` holds the _contents_ of the credentials
+file; if you see errors pertaining to credential type, ensure this variable
+contains valid JSON, and not, for example, a path.
+
 You will also need to set a few environment variables:
+
 ```
 export TF_VAR_org_id="your_org_id"
 export TF_VAR_folder_id="your_folder_id"
@@ -75,6 +84,7 @@ export TF_VAR_billing_account="your_billing_account_id"
 ```
 
 With these settings in place, you can prepare a test project using Docker:
+
 ```
 make docker_test_prepare
 ```

--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -87,7 +87,7 @@ module "my-app-workload-identity" {
 
 | Name | Description |
 |------|-------------|
-| gcp\_service\_account | GCP service account, if created; null if existing account was used. |
+| gcp\_service\_account | GCP service account. |
 | gcp\_service\_account\_email | Email address of GCP service account. |
 | gcp\_service\_account\_fqn | FQN of GCP service account. |
 | gcp\_service\_account\_name | Name of GCP service account. |

--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -10,7 +10,9 @@ This module creates:
 
 ## Usage
 
-The `terraform-google-workload-identity` can create a Kubernetes service account for you, or use an existing Kubernetes service account.
+The `terraform-google-workload-identity` can create service accounts for you,
+or you can use existing accounts; this applies for both the Google and
+Kubernetes accounts.
 
 ### Creating a Workload Identity
 

--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -72,20 +72,22 @@ module "my-app-workload-identity" {
 | annotate\_k8s\_sa | Annotate the kubernetes service account with 'iam.gke.io/gcp-service-account' annotation. Valid in cases when an existing SA is used. | `bool` | `true` | no |
 | automount\_service\_account\_token | Enable automatic mounting of the service account token | `bool` | `false` | no |
 | cluster\_name | Cluster name. Required if using existing KSA. | `string` | `""` | no |
+| gcp\_sa\_name | Name for the Google service account | `string` | `null` | no |
 | impersonate\_service\_account | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `""` | no |
-| k8s\_sa\_name | Name for the existing Kubernetes service account | `string` | `null` | no |
+| k8s\_sa\_name | Name for the Kubernetes service account | `string` | `null` | no |
 | location | Cluster location (region if regional cluster, zone if zonal cluster). Required if using existing KSA. | `string` | `""` | no |
 | name | Name for both service accounts. The GCP SA will be truncated to the first 30 chars if necessary. | `string` | n/a | yes |
-| namespace | Namespace for k8s service account | `string` | `"default"` | no |
+| namespace | Namespace for the Kubernetes service account | `string` | `"default"` | no |
 | project\_id | GCP project ID | `string` | n/a | yes |
-| roles | (optional) A list of roles to be added to the created Service account | `list(string)` | `[]` | no |
+| roles | A list of roles to be added to the created service account | `list(string)` | `[]` | no |
+| use\_existing\_gcp\_sa | Use an existing Google service account instead of creating one | `bool` | `false` | no |
 | use\_existing\_k8s\_sa | Use an existing kubernetes service account instead of creating one | `bool` | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| gcp\_service\_account | GCP service account. |
+| gcp\_service\_account | GCP service account, if created; null if existing account was used. |
 | gcp\_service\_account\_email | Email address of GCP service account. |
 | gcp\_service\_account\_fqn | FQN of GCP service account. |
 | gcp\_service\_account\_name | Name of GCP service account. |

--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -72,9 +72,9 @@ module "my-app-workload-identity" {
 | annotate\_k8s\_sa | Annotate the kubernetes service account with 'iam.gke.io/gcp-service-account' annotation. Valid in cases when an existing SA is used. | `bool` | `true` | no |
 | automount\_service\_account\_token | Enable automatic mounting of the service account token | `bool` | `false` | no |
 | cluster\_name | Cluster name. Required if using existing KSA. | `string` | `""` | no |
-| gcp\_sa\_name | Name for the Google service account | `string` | `null` | no |
+| gcp\_sa\_name | Name for the Google service account; overrides `var.name`. | `string` | `null` | no |
 | impersonate\_service\_account | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `""` | no |
-| k8s\_sa\_name | Name for the Kubernetes service account | `string` | `null` | no |
+| k8s\_sa\_name | Name for the Kubernetes service account; overrides `var.name`. | `string` | `null` | no |
 | location | Cluster location (region if regional cluster, zone if zonal cluster). Required if using existing KSA. | `string` | `""` | no |
 | name | Name for both service accounts. The GCP SA will be truncated to the first 30 chars if necessary. | `string` | n/a | yes |
 | namespace | Namespace for the Kubernetes service account | `string` | `"default"` | no |

--- a/modules/workload-identity/main.tf
+++ b/modules/workload-identity/main.tf
@@ -17,7 +17,7 @@
 locals {
   gcp_given_name = var.gcp_sa_name != null ? var.gcp_sa_name : var.name
   gcp_sa_name    = var.use_existing_gcp_sa ? local.gcp_given_name : google_service_account.main[0].name
-  gcp_sa_email   = var.use_existing_gcp_sa ? "${local.gcp_given_name}@${var.project_id}.iam.gserviceaccount.com" : google_service_account.main[0].email
+  gcp_sa_email   = google_service_account.cluster_service_account.email
   gcp_sa_fqn     = "serviceAccount:${local.gcp_sa_email}"
 
   k8s_sa_gcp_derived_name = "serviceAccount:${var.project_id}.svc.id.goog[${var.namespace}/${local.output_k8s_name}]"

--- a/modules/workload-identity/main.tf
+++ b/modules/workload-identity/main.tf
@@ -17,7 +17,7 @@
 locals {
   gcp_given_name = var.gcp_sa_name != null ? var.gcp_sa_name : var.name
   gcp_sa_name    = var.use_existing_gcp_sa ? local.gcp_given_name : google_service_account.main[0].name
-  gcp_sa_email   = google_service_account.cluster_service_account.email
+  gcp_sa_email   = data.google_service_account.cluster_service_account.email
   gcp_sa_fqn     = "serviceAccount:${local.gcp_sa_email}"
 
   k8s_sa_gcp_derived_name = "serviceAccount:${var.project_id}.svc.id.goog[${var.namespace}/${local.output_k8s_name}]"

--- a/modules/workload-identity/main.tf
+++ b/modules/workload-identity/main.tf
@@ -16,7 +16,7 @@
 
 locals {
   gcp_given_name = var.gcp_sa_name != null ? var.gcp_sa_name : var.name
-  gcp_sa_name    = var.use_existing_gcp_sa ? local.gcp_given_name : google_service_account.main[0].name
+  gcp_sa_name    = var.use_existing_gcp_sa ? local.gcp_given_name : google_service_account.main[0].account_id
   gcp_sa_email   = data.google_service_account.cluster_service_account.email
   gcp_sa_fqn     = "serviceAccount:${local.gcp_sa_email}"
 

--- a/modules/workload-identity/main.tf
+++ b/modules/workload-identity/main.tf
@@ -28,6 +28,11 @@ locals {
   output_k8s_namespace = var.use_existing_k8s_sa ? var.namespace : kubernetes_service_account.main[0].metadata[0].namespace
 }
 
+data "google_service_account" "cluster_service_account" {
+  account_id = local.gcp_sa_name
+  project    = var.project_id
+}
+
 resource "google_service_account" "main" {
   count = var.use_existing_gcp_sa ? 0 : 1
 

--- a/modules/workload-identity/main.tf
+++ b/modules/workload-identity/main.tf
@@ -16,8 +16,8 @@
 
 locals {
   gcp_given_name = var.gcp_sa_name != null ? var.gcp_sa_name : var.name
-  gcp_sa_name    = var.use_existing_gcp_sa ? local.gcp_given_name : google_service_account.cluster_service_account[local.gcp_given_name].name
-  gcp_sa_email   = var.use_existing_gcp_sa ? "${local.gcp_given_name}@${var.project_id}.iam.gserviceaccount.com" : google_service_account.cluster_service_account[local.gcp_given_name].email
+  gcp_sa_name    = var.use_existing_gcp_sa ? local.gcp_given_name : google_service_account.main[0].name
+  gcp_sa_email   = var.use_existing_gcp_sa ? "${local.gcp_given_name}@${var.project_id}.iam.gserviceaccount.com" : google_service_account.main[0].email
   gcp_sa_fqn     = "serviceAccount:${local.gcp_sa_email}"
 
   k8s_sa_gcp_derived_name = "serviceAccount:${var.project_id}.svc.id.goog[${var.namespace}/${local.output_k8s_name}]"
@@ -28,8 +28,8 @@ locals {
   output_k8s_namespace = var.use_existing_k8s_sa ? var.namespace : kubernetes_service_account.main[0].metadata[0].namespace
 }
 
-resource "google_service_account" "cluster_service_account" {
-  for_each = var.use_existing_gcp_sa ? [] : toset([local.gcp_given_name])
+resource "google_service_account" "main" {
+  count = var.use_existing_gcp_sa ? 0 : 1
 
   # GCP service account ids must be < 30 chars matching regex ^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$
   # KSAs do not have this naming restriction.

--- a/modules/workload-identity/main.tf
+++ b/modules/workload-identity/main.tf
@@ -21,12 +21,12 @@ locals {
   gcp_sa_email   = data.google_service_account.cluster_service_account.email
   gcp_sa_fqn     = "serviceAccount:${local.gcp_sa_email}"
 
-  k8s_sa_gcp_derived_name = "serviceAccount:${var.project_id}.svc.id.goog[${var.namespace}/${local.output_k8s_name}]"
-
   # This will cause Terraform to block returning outputs until the service account is created
   k8s_given_name       = var.k8s_sa_name != null ? var.k8s_sa_name : var.name
   output_k8s_name      = var.use_existing_k8s_sa ? local.k8s_given_name : kubernetes_service_account.main[0].metadata[0].name
   output_k8s_namespace = var.use_existing_k8s_sa ? var.namespace : kubernetes_service_account.main[0].metadata[0].namespace
+
+  k8s_sa_gcp_derived_name = "serviceAccount:${var.project_id}.svc.id.goog[${var.namespace}/${local.output_k8s_name}]"
 }
 
 data "google_service_account" "cluster_service_account" {

--- a/modules/workload-identity/main.tf
+++ b/modules/workload-identity/main.tf
@@ -38,7 +38,7 @@ resource "google_service_account" "main" {
 
   # GCP service account ids must be < 30 chars matching regex ^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$
   # KSAs do not have this naming restriction.
-  account_id   = substr(each.key, 0, 30)
+  account_id   = substr(var.name, 0, 30)
   display_name = substr("GCP SA bound to K8S SA ${local.k8s_given_name}", 0, 100)
   project      = var.project_id
 }

--- a/modules/workload-identity/output.tf
+++ b/modules/workload-identity/output.tf
@@ -40,6 +40,6 @@ output "gcp_service_account_name" {
 }
 
 output "gcp_service_account" {
-  description = "GCP service account, if created; `null` if existing account was used."
+  description = "GCP service account."
   value       = google_service_account.cluster_service_account
 }

--- a/modules/workload-identity/output.tf
+++ b/modules/workload-identity/output.tf
@@ -40,6 +40,6 @@ output "gcp_service_account_name" {
 }
 
 output "gcp_service_account" {
-  description = "GCP service account, if created; null if existing account was used."
+  description = "GCP service account, if created; `null` if existing account was used."
   value       = google_service_account.cluster_service_account
 }

--- a/modules/workload-identity/output.tf
+++ b/modules/workload-identity/output.tf
@@ -31,7 +31,7 @@ output "gcp_service_account_email" {
 
 output "gcp_service_account_fqn" {
   description = "FQN of GCP service account."
-  value       = "serviceAccount:${google_service_account.cluster_service_account.email}"
+  value       = local.gcp_sa_fqn
 }
 
 output "gcp_service_account_name" {
@@ -40,6 +40,6 @@ output "gcp_service_account_name" {
 }
 
 output "gcp_service_account" {
-  description = "GCP service account."
+  description = "GCP service account, if created; null if existing account was used."
   value       = google_service_account.cluster_service_account
 }

--- a/modules/workload-identity/output.tf
+++ b/modules/workload-identity/output.tf
@@ -41,5 +41,5 @@ output "gcp_service_account_name" {
 
 output "gcp_service_account" {
   description = "GCP service account."
-  value       = google_service_account.cluster_service_account
+  value       = data.google_service_account.cluster_service_account
 }

--- a/modules/workload-identity/variables.tf
+++ b/modules/workload-identity/variables.tf
@@ -32,8 +32,8 @@ variable "gcp_sa_name" {
 
 variable "use_existing_gcp_sa" {
   description = "Use an existing Google service account instead of creating one"
-  default     = false
   type        = bool
+  default     = false
 }
 
 variable "cluster_name" {
@@ -56,36 +56,36 @@ variable "k8s_sa_name" {
 
 variable "namespace" {
   description = "Namespace for the Kubernetes service account"
-  default     = "default"
   type        = string
+  default     = "default"
 }
 
 variable "use_existing_k8s_sa" {
   description = "Use an existing kubernetes service account instead of creating one"
-  default     = false
   type        = bool
+  default     = false
 }
 
 variable "annotate_k8s_sa" {
   description = "Annotate the kubernetes service account with 'iam.gke.io/gcp-service-account' annotation. Valid in cases when an existing SA is used."
-  default     = true
   type        = bool
+  default     = true
 }
 
 variable "automount_service_account_token" {
   description = "Enable automatic mounting of the service account token"
-  default     = false
   type        = bool
+  default     = false
 }
 
 variable "roles" {
+  description = "A list of roles to be added to the created service account"
   type        = list(string)
   default     = []
-  description = "A list of roles to be added to the created service account"
 }
 
 variable "impersonate_service_account" {
-  type        = string
   description = "An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials."
+  type        = string
   default     = ""
 }

--- a/modules/workload-identity/variables.tf
+++ b/modules/workload-identity/variables.tf
@@ -19,6 +19,23 @@ variable "name" {
   type        = string
 }
 
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "gcp_sa_name" {
+  description = "Name for the Google service account"
+  type        = string
+  default     = null
+}
+
+variable "use_existing_gcp_sa" {
+  description = "Use an existing Google service account instead of creating one"
+  default     = false
+  type        = bool
+}
+
 variable "cluster_name" {
   description = "Cluster name. Required if using existing KSA."
   type        = string
@@ -32,19 +49,14 @@ variable "location" {
 }
 
 variable "k8s_sa_name" {
-  description = "Name for the existing Kubernetes service account"
+  description = "Name for the Kubernetes service account"
   type        = string
   default     = null
 }
 
 variable "namespace" {
-  description = "Namespace for k8s service account"
+  description = "Namespace for the Kubernetes service account"
   default     = "default"
-  type        = string
-}
-
-variable "project_id" {
-  description = "GCP project ID"
   type        = string
 }
 
@@ -69,7 +81,7 @@ variable "automount_service_account_token" {
 variable "roles" {
   type        = list(string)
   default     = []
-  description = "(optional) A list of roles to be added to the created Service account"
+  description = "A list of roles to be added to the created service account"
 }
 
 variable "impersonate_service_account" {

--- a/modules/workload-identity/variables.tf
+++ b/modules/workload-identity/variables.tf
@@ -25,7 +25,7 @@ variable "project_id" {
 }
 
 variable "gcp_sa_name" {
-  description = "Name for the Google service account"
+  description = "Name for the Google service account; overrides `var.name`."
   type        = string
   default     = null
 }
@@ -49,7 +49,7 @@ variable "location" {
 }
 
 variable "k8s_sa_name" {
-  description = "Name for the Kubernetes service account"
+  description = "Name for the Kubernetes service account; overrides `var.name`."
   type        = string
   default     = null
 }


### PR DESCRIPTION
Resolves https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/956.

The workload-identity module currently allows for reusing an existing KSA, but not an existing GSA. This is a common requirement for us: typically, we will have two clusters within the same project (for example, a production cluster and a disaster recovery cluster), and want to configure KSAs in each cluster that are bound to the same GSA.

With the existing module, this isn't possible, as errors are thrown owing to the attempt to recreate an existing GSA.

This is a work-in-progress: I believe it's feature complete, but I'm still testing.