### PR TITLE
configure variable firewall_shadow_allow_master

### DIFF
--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -174,6 +174,7 @@ Then perform the following commands on the root folder:
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | `bool` | `false` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers. Either flag `add_master_webhook_firewall_rules` or `add_cluster_firewall_rules` (also adds egress rules) must be set to `true` for inbound-ports firewall rules to be applied. | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
+| firewall\_shadow\_allow\_master | Additional List of TCP ports for shadow allow master | `list(string)` | `[]` | no |
 | gcloud\_upgrade | Whether to upgrade gcloud at runtime | `bool` | `false` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |

--- a/modules/private-cluster-update-variant/firewall.tf
+++ b/modules/private-cluster-update-variant/firewall.tf
@@ -123,7 +123,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 
   allow {
     protocol = "tcp"
-    ports    = ["10250", "443"]
+    ports    = flatten([["10250", "443"], var.firewall_shadow_allow_master])
   }
 
   log_config {

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -451,6 +451,12 @@ variable "firewall_inbound_ports" {
   default     = ["8443", "9443", "15017"]
 }
 
+variable "firewall_shadow_allow_master" {
+  type        = list(string)
+  description = "Additional List of TCP ports for shadow allow master"
+  default     = []
+}
+
 variable "gcloud_upgrade" {
   type        = bool
   description = "Whether to upgrade gcloud at runtime"


### PR DESCRIPTION
this necesary for port istio v1.10.3

For private GKE clusters

An automatically created firewall rule does not open port 15017. This is needed by the Pilot discovery validation webhook.

To review this firewall rule for master access:

$ gcloud compute firewall-rules list --filter="name~gke-${CLUSTER_NAME}-[0-9a-z]*-master"

To replace the existing rule and allow master access:

$ gcloud compute firewall-rules update <firewall-rule-name> --allow tcp:10250,tcp:443,tcp:15017

https://istio.io/latest/docs/setup/platform-setup/gke/