### PR TITLE
Consider k8s service account name from evaluated local parameter

### DIFF
--- a/modules/workload-identity/main.tf
+++ b/modules/workload-identity/main.tf
@@ -48,7 +48,7 @@ resource "kubernetes_service_account" "main" {
 
   automount_service_account_token = var.automount_service_account_token
   metadata {
-    name      = var.name
+    name      = local.k8s_given_name
     namespace = var.namespace
     annotations = {
       "iam.gke.io/gcp-service-account" = local.gcp_sa_email


### PR DESCRIPTION
Module supports providing a custom name for kubernetes service account through **k8s_sa_name** variable. But internally this value is not considered for kubernetes service account resource.

**k8s_given_name** has evaluated value for service account name under locals. Using this value will respect custom input from the user.
