### PR TITLE
Ignore GKE cluster tags

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -238,7 +238,7 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
-    ignore_changes = [node_pool, initial_node_count]
+    ignore_changes = [node_pool, initial_node_count, resource_labels]
   }
 
   timeouts {

--- a/cluster.tf
+++ b/cluster.tf
@@ -124,7 +124,7 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
-    ignore_changes = [node_pool, initial_node_count]
+    ignore_changes = [node_pool, initial_node_count, resource_labels]
   }
 
   timeouts {

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -211,7 +211,7 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
-    ignore_changes = [node_pool, initial_node_count]
+    ignore_changes = [node_pool, initial_node_count, resource_labels]
   }
 
   timeouts {

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -211,7 +211,7 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
-    ignore_changes = [node_pool, initial_node_count]
+    ignore_changes = [node_pool, initial_node_count, resource_labels]
   }
 
   timeouts {

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -211,7 +211,7 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
-    ignore_changes = [node_pool, initial_node_count]
+    ignore_changes = [node_pool, initial_node_count, resource_labels]
   }
 
   timeouts {

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -211,7 +211,7 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
-    ignore_changes = [node_pool, initial_node_count]
+    ignore_changes = [node_pool, initial_node_count, resource_labels]
   }
 
   timeouts {

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -124,7 +124,7 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
-    ignore_changes = [node_pool, initial_node_count]
+    ignore_changes = [node_pool, initial_node_count, resource_labels]
   }
 
   timeouts {

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -124,7 +124,7 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
-    ignore_changes = [node_pool, initial_node_count]
+    ignore_changes = [node_pool, initial_node_count, resource_labels]
   }
 
   timeouts {


### PR DESCRIPTION
Products like Anthos Service Mesh add GKE cluster tags
and we dont want Terraform to remove `asmv` and `mesh_id`.