### PR TITLE
SR-2692: Support enabling workload identity during hub registration

### DIFF
--- a/modules/hub/README.md
+++ b/modules/hub/README.md
@@ -36,6 +36,7 @@ To deploy this config:
 | cluster\_endpoint | The GKE cluster endpoint. | `string` | n/a | yes |
 | cluster\_name | The unique name to identify the cluster in ASM. | `string` | n/a | yes |
 | enable\_gke\_hub\_registration | Enables GKE Hub Registration when set to true | `bool` | `true` | no |
+| enable\_workload\_identity | Enables workload identity when registering. | `bool` | `false` | no |
 | gcloud\_sdk\_version | The gcloud sdk version to use. Minimum required version is 293.0.0 | `string` | `"296.0.1"` | no |
 | gke\_hub\_membership\_name | Membership name that uniquely represents the cluster being registered on the Hub | `string` | `"gke-hub-membership"` | no |
 | gke\_hub\_sa\_name | Name for the GKE Hub SA stored as a secret `creds-gcp` in the `gke-connect` namespace. | `string` | `"gke-hub-sa"` | no |

--- a/modules/hub/main.tf
+++ b/modules/hub/main.tf
@@ -17,12 +17,13 @@
 locals {
   gke_hub_sa_key = var.use_existing_sa ? var.sa_private_key : google_service_account_key.gke_hub_key[0].private_key
 
-  is_gke_flag = var.use_kubeconfig ? 0 : 1
-  hub_project = var.hub_project_id == "" ? var.project_id : var.hub_project_id
+  is_gke_flag              = var.use_kubeconfig ? 0 : 1
+  hub_project              = var.hub_project_id == "" ? var.project_id : var.hub_project_id
+  enable_workload_identity = var.enable_workload_identity ? 1 : 0
 
   cluster_uri               = "https://container.googleapis.com/projects/${var.project_id}/locations/${var.location}/clusters/${var.cluster_name}"
   create_cmd_gke_entrypoint = "${path.module}/scripts/gke_hub_registration.sh"
-  create_cmd_gke_body       = "${local.is_gke_flag} ${var.gke_hub_membership_name} ${local.gke_hub_sa_key} ${local.cluster_uri} ${local.hub_project} ${var.labels}"
+  create_cmd_gke_body       = "${local.is_gke_flag} ${var.gke_hub_membership_name} ${local.gke_hub_sa_key} ${local.cluster_uri} ${local.hub_project} ${local.enable_workload_identity} ${var.labels}"
   destroy_gke_entrypoint    = "${path.module}/scripts/gke_hub_unregister.sh"
   destroy_gke_body          = "${local.is_gke_flag} ${var.gke_hub_membership_name} ${local.cluster_uri} ${local.hub_project}"
 }

--- a/modules/hub/variables.tf
+++ b/modules/hub/variables.tf
@@ -98,3 +98,9 @@ variable "labels" {
   type        = string
   default     = ""
 }
+
+variable "enable_workload_identity" {
+  description = "Enables workload identity when registering."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
In order to be able to install Anthos Service Mesh 1.9 or higher, it now requires an identity provider to be set:
https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/blob/1.9.8-asm.1+config1/scripts/asm-installer/install_asm#L2157

The solution for that is to pass the `--enable-workload-identity` flag when registering with the hub (instead of SA key).

Adding a new variable `enable_workload_identity` to the `hub` module that will pass this flag when registering.

Tested happy path in our terraform project by pulling in this module through our forked repo.