### PR TITLE
'pod_security_policy_config' block should be static

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -112,11 +112,8 @@ resource "google_container_cluster" "primary" {
   enable_kubernetes_alpha     = var.enable_kubernetes_alpha
   enable_tpu                  = var.enable_tpu
 
-  dynamic "pod_security_policy_config" {
-    for_each = var.enable_pod_security_policy ? [var.enable_pod_security_policy] : []
-    content {
-      enabled = pod_security_policy_config.value
-    }
+  pod_security_policy_config {
+    enabled = var.enable_pod_security_policy
   }
 
   enable_l4_ilb_subsetting = var.enable_l4_ilb_subsetting

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -98,11 +98,8 @@ resource "google_container_cluster" "primary" {
   enable_kubernetes_alpha     = var.enable_kubernetes_alpha
   enable_tpu                  = var.enable_tpu
 
-  dynamic "pod_security_policy_config" {
-    for_each = var.enable_pod_security_policy ? [var.enable_pod_security_policy] : []
-    content {
-      enabled = pod_security_policy_config.value
-    }
+  pod_security_policy_config {
+    enabled = var.enable_pod_security_policy
   }
 
   enable_l4_ilb_subsetting = var.enable_l4_ilb_subsetting

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -98,11 +98,8 @@ resource "google_container_cluster" "primary" {
   enable_kubernetes_alpha     = var.enable_kubernetes_alpha
   enable_tpu                  = var.enable_tpu
 
-  dynamic "pod_security_policy_config" {
-    for_each = var.enable_pod_security_policy ? [var.enable_pod_security_policy] : []
-    content {
-      enabled = pod_security_policy_config.value
-    }
+  pod_security_policy_config {
+    enabled = var.enable_pod_security_policy
   }
 
   enable_l4_ilb_subsetting = var.enable_l4_ilb_subsetting

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -98,11 +98,8 @@ resource "google_container_cluster" "primary" {
   enable_kubernetes_alpha     = var.enable_kubernetes_alpha
   enable_tpu                  = var.enable_tpu
 
-  dynamic "pod_security_policy_config" {
-    for_each = var.enable_pod_security_policy ? [var.enable_pod_security_policy] : []
-    content {
-      enabled = pod_security_policy_config.value
-    }
+  pod_security_policy_config {
+    enabled = var.enable_pod_security_policy
   }
 
   enable_l4_ilb_subsetting = var.enable_l4_ilb_subsetting

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -98,11 +98,8 @@ resource "google_container_cluster" "primary" {
   enable_kubernetes_alpha     = var.enable_kubernetes_alpha
   enable_tpu                  = var.enable_tpu
 
-  dynamic "pod_security_policy_config" {
-    for_each = var.enable_pod_security_policy ? [var.enable_pod_security_policy] : []
-    content {
-      enabled = pod_security_policy_config.value
-    }
+  pod_security_policy_config {
+    enabled = var.enable_pod_security_policy
   }
 
   enable_l4_ilb_subsetting = var.enable_l4_ilb_subsetting


### PR DESCRIPTION
## What
The `pod_security_policy_config` block should be defined in all cases and not managed dynamically

## Why
In case someone enables the policy with the `enable_pod_security_policy` variable and later on decides to flag it as `false` then the apply fails due to the reason that "can not be null"