### PR TITLE
feat: Add support for gVisor per node pool

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -577,9 +577,9 @@ resource "google_container_node_pool" "pools" {
     }
     {% if beta_cluster %}
     dynamic "sandbox_config" {
-      for_each = local.cluster_sandbox_enabled
-
+      for_each = tobool((lookup(each.value, "sandbox_enabled", var.sandbox_enabled))) ? ["gvisor"] : []
       content {
+
         sandbox_type = sandbox_config.value
       }
     }

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -495,7 +495,7 @@ resource "google_container_node_pool" "pools" {
 
   node_config {
     {% if beta_cluster %}
-    image_type   = lookup(each.value, "image_type", var.sandbox_enabled ? "COS_CONTAINERD" : "COS")
+    image_type   = lookup(each.value, "image_type", lookup(each.value, "sandbox_enabled", var.sandbox_enabled) ? "COS_CONTAINERD" : "COS")
     {% else %}
     image_type   = lookup(each.value, "image_type", "COS")
     {% endif %}
@@ -579,7 +579,6 @@ resource "google_container_node_pool" "pools" {
     dynamic "sandbox_config" {
       for_each = tobool((lookup(each.value, "sandbox_enabled", var.sandbox_enabled))) ? ["gvisor"] : []
       content {
-
         sandbox_type = sandbox_config.value
       }
     }

--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -105,8 +105,6 @@ locals {
 
   cluster_gce_pd_csi_config = var.gce_pd_csi_driver ? [{ enabled = true }] : [{ enabled = false }]
 
-  cluster_sandbox_enabled = var.sandbox_enabled ? ["gvisor"] : []
-
 {% endif %}
 
   cluster_authenticator_security_group = var.authenticator_security_group == null ? [] : [{

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -70,14 +70,15 @@ module "gke" {
     },
     {
       name            = "pool-03"
+      machine_type    = "n1-standard-2"
       node_locations  = "${var.region}-b,${var.region}-c"
       autoscaling     = false
       node_count      = 2
       disk_type       = "pd-standard"
-      image_type      = "COS"
       auto_upgrade    = true
       service_account = var.compute_engine_service_account
       pod_range       = "test"
+      sandbox_enabled = true
     },
   ]
 

--- a/examples/node_pool_update_variant/main.tf
+++ b/examples/node_pool_update_variant/main.tf
@@ -82,12 +82,22 @@ module "gke" {
       auto_repair       = false
       service_account   = var.compute_engine_service_account
     },
+    {
+      name            = "pool-03"
+      min_count       = 1
+      max_count       = 2
+      service_account = var.compute_engine_service_account
+      auto_upgrade    = true
+      sandbox_enabled = true
+      image_type      = "COS"
+    },
   ]
 
   node_pools_oauth_scopes = {
     all     = []
     pool-01 = []
     pool-02 = []
+    pool-03 = []
   }
 
   node_pools_metadata = {
@@ -96,6 +106,7 @@ module "gke" {
       shutdown-script = file("${path.module}/data/shutdown-script.sh")
     }
     pool-02 = {}
+    pool-03 = {}
   }
 
   node_pools_labels = {
@@ -106,6 +117,7 @@ module "gke" {
       pool-01-example = true
     }
     pool-02 = {}
+    pool-03 = {}
   }
 
   node_pools_tags = {
@@ -116,5 +128,6 @@ module "gke" {
       "pool-01-example",
     ]
     pool-02 = []
+    pool-03 = []
   }
 }

--- a/examples/node_pool_update_variant/main.tf
+++ b/examples/node_pool_update_variant/main.tf
@@ -82,22 +82,12 @@ module "gke" {
       auto_repair       = false
       service_account   = var.compute_engine_service_account
     },
-    {
-      name            = "pool-03"
-      min_count       = 1
-      max_count       = 2
-      service_account = var.compute_engine_service_account
-      auto_upgrade    = true
-      sandbox_enabled = true
-      image_type      = "COS"
-    },
   ]
 
   node_pools_oauth_scopes = {
     all     = []
     pool-01 = []
     pool-02 = []
-    pool-03 = []
   }
 
   node_pools_metadata = {
@@ -106,7 +96,6 @@ module "gke" {
       shutdown-script = file("${path.module}/data/shutdown-script.sh")
     }
     pool-02 = {}
-    pool-03 = {}
   }
 
   node_pools_labels = {
@@ -117,7 +106,6 @@ module "gke" {
       pool-01-example = true
     }
     pool-02 = {}
-    pool-03 = {}
   }
 
   node_pools_tags = {
@@ -128,6 +116,5 @@ module "gke" {
       "pool-01-example",
     ]
     pool-02 = []
-    pool-03 = []
   }
 }

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -523,9 +523,9 @@ resource "google_container_node_pool" "pools" {
       }
     }
     dynamic "sandbox_config" {
-      for_each = local.cluster_sandbox_enabled
-
+      for_each = tobool((lookup(each.value, "sandbox_enabled", var.sandbox_enabled))) ? ["gvisor"] : []
       content {
+
         sandbox_type = sandbox_config.value
       }
     }

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -447,7 +447,7 @@ resource "google_container_node_pool" "pools" {
   }
 
   node_config {
-    image_type   = lookup(each.value, "image_type", var.sandbox_enabled ? "COS_CONTAINERD" : "COS")
+    image_type   = lookup(each.value, "image_type", lookup(each.value, "sandbox_enabled", var.sandbox_enabled) ? "COS_CONTAINERD" : "COS")
     machine_type = lookup(each.value, "machine_type", "e2-medium")
     labels = merge(
       lookup(lookup(local.node_pools_labels, "default_values", {}), "cluster_name", true) ? { "cluster_name" = var.name } : {},
@@ -525,7 +525,6 @@ resource "google_container_node_pool" "pools" {
     dynamic "sandbox_config" {
       for_each = tobool((lookup(each.value, "sandbox_enabled", var.sandbox_enabled))) ? ["gvisor"] : []
       content {
-
         sandbox_type = sandbox_config.value
       }
     }

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -96,8 +96,6 @@ locals {
 
   cluster_gce_pd_csi_config = var.gce_pd_csi_driver ? [{ enabled = true }] : [{ enabled = false }]
 
-  cluster_sandbox_enabled = var.sandbox_enabled ? ["gvisor"] : []
-
 
   cluster_authenticator_security_group = var.authenticator_security_group == null ? [] : [{
     security_group = var.authenticator_security_group

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -439,9 +439,9 @@ resource "google_container_node_pool" "pools" {
       }
     }
     dynamic "sandbox_config" {
-      for_each = local.cluster_sandbox_enabled
-
+      for_each = tobool((lookup(each.value, "sandbox_enabled", var.sandbox_enabled))) ? ["gvisor"] : []
       content {
+
         sandbox_type = sandbox_config.value
       }
     }

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -363,7 +363,7 @@ resource "google_container_node_pool" "pools" {
   }
 
   node_config {
-    image_type   = lookup(each.value, "image_type", var.sandbox_enabled ? "COS_CONTAINERD" : "COS")
+    image_type   = lookup(each.value, "image_type", lookup(each.value, "sandbox_enabled", var.sandbox_enabled) ? "COS_CONTAINERD" : "COS")
     machine_type = lookup(each.value, "machine_type", "e2-medium")
     labels = merge(
       lookup(lookup(local.node_pools_labels, "default_values", {}), "cluster_name", true) ? { "cluster_name" = var.name } : {},
@@ -441,7 +441,6 @@ resource "google_container_node_pool" "pools" {
     dynamic "sandbox_config" {
       for_each = tobool((lookup(each.value, "sandbox_enabled", var.sandbox_enabled))) ? ["gvisor"] : []
       content {
-
         sandbox_type = sandbox_config.value
       }
     }

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -96,8 +96,6 @@ locals {
 
   cluster_gce_pd_csi_config = var.gce_pd_csi_driver ? [{ enabled = true }] : [{ enabled = false }]
 
-  cluster_sandbox_enabled = var.sandbox_enabled ? ["gvisor"] : []
-
 
   cluster_authenticator_security_group = var.authenticator_security_group == null ? [] : [{
     security_group = var.authenticator_security_group

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -504,9 +504,9 @@ resource "google_container_node_pool" "pools" {
       }
     }
     dynamic "sandbox_config" {
-      for_each = local.cluster_sandbox_enabled
-
+      for_each = tobool((lookup(each.value, "sandbox_enabled", var.sandbox_enabled))) ? ["gvisor"] : []
       content {
+
         sandbox_type = sandbox_config.value
       }
     }

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -428,7 +428,7 @@ resource "google_container_node_pool" "pools" {
   }
 
   node_config {
-    image_type   = lookup(each.value, "image_type", var.sandbox_enabled ? "COS_CONTAINERD" : "COS")
+    image_type   = lookup(each.value, "image_type", lookup(each.value, "sandbox_enabled", var.sandbox_enabled) ? "COS_CONTAINERD" : "COS")
     machine_type = lookup(each.value, "machine_type", "e2-medium")
     labels = merge(
       lookup(lookup(local.node_pools_labels, "default_values", {}), "cluster_name", true) ? { "cluster_name" = var.name } : {},
@@ -506,7 +506,6 @@ resource "google_container_node_pool" "pools" {
     dynamic "sandbox_config" {
       for_each = tobool((lookup(each.value, "sandbox_enabled", var.sandbox_enabled))) ? ["gvisor"] : []
       content {
-
         sandbox_type = sandbox_config.value
       }
     }

--- a/modules/beta-public-cluster-update-variant/main.tf
+++ b/modules/beta-public-cluster-update-variant/main.tf
@@ -96,8 +96,6 @@ locals {
 
   cluster_gce_pd_csi_config = var.gce_pd_csi_driver ? [{ enabled = true }] : [{ enabled = false }]
 
-  cluster_sandbox_enabled = var.sandbox_enabled ? ["gvisor"] : []
-
 
   cluster_authenticator_security_group = var.authenticator_security_group == null ? [] : [{
     security_group = var.authenticator_security_group

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -344,7 +344,7 @@ resource "google_container_node_pool" "pools" {
   }
 
   node_config {
-    image_type   = lookup(each.value, "image_type", var.sandbox_enabled ? "COS_CONTAINERD" : "COS")
+    image_type   = lookup(each.value, "image_type", lookup(each.value, "sandbox_enabled", var.sandbox_enabled) ? "COS_CONTAINERD" : "COS")
     machine_type = lookup(each.value, "machine_type", "e2-medium")
     labels = merge(
       lookup(lookup(local.node_pools_labels, "default_values", {}), "cluster_name", true) ? { "cluster_name" = var.name } : {},
@@ -422,7 +422,6 @@ resource "google_container_node_pool" "pools" {
     dynamic "sandbox_config" {
       for_each = tobool((lookup(each.value, "sandbox_enabled", var.sandbox_enabled))) ? ["gvisor"] : []
       content {
-
         sandbox_type = sandbox_config.value
       }
     }

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -420,9 +420,9 @@ resource "google_container_node_pool" "pools" {
       }
     }
     dynamic "sandbox_config" {
-      for_each = local.cluster_sandbox_enabled
-
+      for_each = tobool((lookup(each.value, "sandbox_enabled", var.sandbox_enabled))) ? ["gvisor"] : []
       content {
+
         sandbox_type = sandbox_config.value
       }
     }

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -96,8 +96,6 @@ locals {
 
   cluster_gce_pd_csi_config = var.gce_pd_csi_driver ? [{ enabled = true }] : [{ enabled = false }]
 
-  cluster_sandbox_enabled = var.sandbox_enabled ? ["gvisor"] : []
-
 
   cluster_authenticator_security_group = var.authenticator_security_group == null ? [] : [{
     security_group = var.authenticator_security_group

--- a/test/integration/node_pool/controls/gcloud.rb
+++ b/test/integration/node_pool/controls/gcloud.rb
@@ -351,7 +351,7 @@ control "gcloud" do
             including(
               "name" => "pool-03",
               "config" => including(
-                "machineType" => "e2-medium",
+                "machineType" => "n1-standard-2",
               ),
             )
           )
@@ -408,6 +408,7 @@ control "gcloud" do
                   "all-pools-example" => "true",
                   "cluster_name" => cluster_name,
                   "node_pool" => "pool-03",
+                  "sandbox.gke.io/runtime"=>"gvisor"
                 },
               ),
             )
@@ -437,6 +438,17 @@ control "gcloud" do
                 "podIpv4CidrBlock" => "172.16.0.0/18",
                 "podRange" => "test"
               )
+            )
+          )
+        end
+
+        it "has the expected image" do
+          expect(data['nodePools']).to include(
+            including(
+              "name" => "pool-03",
+              "config" => including(
+                "imageType" => "COS_CONTAINERD",
+              ),
             )
           )
         end


### PR DESCRIPTION
Issue [https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/240](url) was resolved but now all node pools needs to be with gVisor or non of them.

With this PR you are able to define `sandbox_enabled` variable per node pool, code is backward compatible.