### PR TITLE
fix: Use provided gcp_given_name for workload identity

### DIFF
--- a/modules/workload-identity/main.tf
+++ b/modules/workload-identity/main.tf
@@ -32,7 +32,7 @@ locals {
 data "google_service_account" "cluster_service_account" {
   count = var.use_existing_gcp_sa ? 1 : 0
 
-  account_id = var.name
+  account_id = local.gcp_given_name
   project    = var.project_id
 }
 


### PR DESCRIPTION
Fixes #1002