### PR TITLE
chore: fix test .netrc permissions, nodepool pod range fixture

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -19,7 +19,7 @@ steps:
   args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && download_acm']
 - id: prepare
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && prepare_environment && sleep 120']
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && prepare_environment && chmod 600 /builder/home/.netrc && sleep 120']
   env:
   - 'TF_VAR_org_id=$_ORG_ID'
   - 'TF_VAR_folder_id=$_FOLDER_ID'

--- a/test/fixtures/node_pool/network.tf
+++ b/test/fixtures/node_pool/network.tf
@@ -44,5 +44,9 @@ resource "google_compute_subnetwork" "main" {
     range_name    = "cft-gke-test-services-${random_string.suffix.result}"
     ip_cidr_range = "192.168.64.0/18"
   }
-}
 
+  secondary_ip_range {
+    range_name    = "test"
+    ip_cidr_range = "172.16.0.0/18"
+  }
+}

--- a/test/integration/node_pool/controls/gcloud.rb
+++ b/test/integration/node_pool/controls/gcloud.rb
@@ -429,6 +429,18 @@ control "gcloud" do
           )
         end
 
+        it "has the expected pod range" do
+          expect(data['nodePools']).to include(
+            including(
+              "name" => "pool-03",
+              "networkConfig" => including(
+                "podIpv4CidrBlock" => "172.16.0.0/18",
+                "podRange" => "test"
+              )
+            )
+          )
+        end
+
         it "has the expected linux node config sysctls" do
           expect(data['nodePools']).to include(
             including(


### PR DESCRIPTION
Tests using the ruby k8s client seem to be failing with `Permission bits for '/builder/home/.netrc' should be 0600, but are 644`. 