### PR TITLE
fix: adds metadata to the default node pool

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -262,10 +262,7 @@ resource "google_container_cluster" "primary" {
         }
       }
 
-      metadata = merge(        
-        local.node_pools_metadata["all"],
-        local.node_pools_metadata["default-node-pool"],        
-      )
+      metadata = local.node_pools_metadata["all"]
     }
   }
 

--- a/cluster.tf
+++ b/cluster.tf
@@ -148,10 +148,7 @@ resource "google_container_cluster" "primary" {
         }
       }
 
-      metadata = merge(
-        local.node_pools_metadata["all"],
-        local.node_pools_metadata["default-node-pool"],
-      )
+      metadata = local.node_pools_metadata["all"]
     }
   }
 

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -235,10 +235,7 @@ resource "google_container_cluster" "primary" {
         }
       }
 
-      metadata = merge(
-        local.node_pools_metadata["all"],
-        local.node_pools_metadata["default-node-pool"],
-      )
+      metadata = local.node_pools_metadata["all"]
     }
   }
 

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -235,10 +235,7 @@ resource "google_container_cluster" "primary" {
         }
       }
 
-      metadata = merge(
-        local.node_pools_metadata["all"],
-        local.node_pools_metadata["default-node-pool"],
-      )
+      metadata = local.node_pools_metadata["all"]
     }
   }
 

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -235,10 +235,7 @@ resource "google_container_cluster" "primary" {
         }
       }
 
-      metadata = merge(
-        local.node_pools_metadata["all"],
-        local.node_pools_metadata["default-node-pool"],
-      )
+      metadata = local.node_pools_metadata["all"]
     }
   }
 

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -235,10 +235,7 @@ resource "google_container_cluster" "primary" {
         }
       }
 
-      metadata = merge(
-        local.node_pools_metadata["all"],
-        local.node_pools_metadata["default-node-pool"],
-      )
+      metadata = local.node_pools_metadata["all"]
     }
   }
 

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -148,10 +148,7 @@ resource "google_container_cluster" "primary" {
         }
       }
 
-      metadata = merge(
-        local.node_pools_metadata["all"],
-        local.node_pools_metadata["default-node-pool"],
-      )
+      metadata = local.node_pools_metadata["all"]
     }
   }
 

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -148,10 +148,7 @@ resource "google_container_cluster" "primary" {
         }
       }
 
-      metadata = merge(
-        local.node_pools_metadata["all"],
-        local.node_pools_metadata["default-node-pool"],
-      )
+      metadata = local.node_pools_metadata["all"]
     }
   }
 


### PR DESCRIPTION
This is a fix for #1000 where the default node pool doesn't accept the metadata provided as part of the module calling it. Now metadata included in "all" as well as "default-node-pool" will be applied to the default node pool preventing it from crashing in case of a specific policy constraint.