### PR TITLE
fix: add missing required_providers on workload identity module

### DIFF
--- a/modules/workload-identity/versions.tf
+++ b/modules/workload-identity/versions.tf
@@ -18,6 +18,17 @@
 terraform {
   required_version = ">= 0.13.0"
 
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.39.0, <4.0.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+
   provider_meta "google" {
     module_name = "blueprints/terraform/terraform-google-kubernetes-engine:workload-identity/v17.0.0"
   }


### PR DESCRIPTION
Fixes https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/979