### PR TITLE
Remove deprecation warning about identity_namespace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ Note: The correct sequence to update the repo using autogen functionality is to 
 generate the Terraform documentation using `terraform-docs`.
 
 ### Autogeneration of documentation from .tf files
+
 To generate new Inputs and Outputs tables run
 ```
 make docker_generate_docs
@@ -56,9 +57,10 @@ Six test-kitchen instances are defined:
 - `simple-zonal`
 - `stub-domains`
 
-The test-kitchen instances in `test/fixtures/` wrap identically-named examples in the `examples/` directory.`
+The test-kitchen instances in `test/fixtures/` wrap identically-named examples in the `examples/` directory.
 
 ### Test Environment
+
 The easiest way to test the module is in an isolated test project. The
 setup for such a project is defined in [test/setup](./test/setup/)
 directory.

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -352,7 +352,7 @@ resource "google_container_cluster" "primary" {
     for_each = local.cluster_workload_identity_config
 
     content {
-      identity_namespace = workload_identity_config.value.identity_namespace
+      workload_pool = workload_identity_config.value.identity_namespace
     }
   }
 

--- a/autogen/main/versions.tf.tmpl
+++ b/autogen/main/versions.tf.tmpl
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.90.0, <4.0.0"
+      version = ">= 3.90.1, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.90.0, <4.0.0"
+      version = ">= 3.90.1, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/autogen/main/versions.tf.tmpl
+++ b/autogen/main/versions.tf.tmpl
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.79.0, <4.0.0"
+      version = ">= 4.0.0, <5.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.39.0, <4.0.0"
+      version = ">= 4.0.0, <5.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/autogen/main/versions.tf.tmpl
+++ b/autogen/main/versions.tf.tmpl
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.0.0, <5.0.0"
+      version = ">= 3.90.0, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.0.0, <5.0.0"
+      version = ">= 3.90.0, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/cluster.tf
+++ b/cluster.tf
@@ -193,7 +193,7 @@ resource "google_container_cluster" "primary" {
     for_each = local.cluster_workload_identity_config
 
     content {
-      identity_namespace = workload_identity_config.value.identity_namespace
+      workload_pool = workload_identity_config.value.identity_namespace
     }
   }
 

--- a/examples/acm-terraform-blog-part1/terraform/providers.tf
+++ b/examples/acm-terraform-blog-part1/terraform/providers.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "3.73.0"
+      version = "3.90.1"
     }
   }
 }

--- a/examples/acm-terraform-blog-part2/terraform/providers.tf
+++ b/examples/acm-terraform-blog-part2/terraform/providers.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "3.73.0"
+      version = "3.90.1"
     }
   }
 }

--- a/examples/acm-terraform-blog-part3/terraform/providers.tf
+++ b/examples/acm-terraform-blog-part3/terraform/providers.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "3.73.0"
+      version = "3.90.1"
     }
   }
 }

--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/disable_client_cert/main.tf
+++ b/examples/disable_client_cert/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/disable_client_cert/main.tf
+++ b/examples/disable_client_cert/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.79.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/node_pool_update_variant/main.tf
+++ b/examples/node_pool_update_variant/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/node_pool_update_variant/main.tf
+++ b/examples/node_pool_update_variant/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/node_pool_update_variant_beta/main.tf
+++ b/examples/node_pool_update_variant_beta/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version     = "~> 3.90.0"
+  version     = "~> 3.90.1"
   credentials = file(var.credentials_path)
   region      = var.region
 }

--- a/examples/node_pool_update_variant_beta/main.tf
+++ b/examples/node_pool_update_variant_beta/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version     = "~> 3.79.0"
+  version     = "~> 3.90.0"
   credentials = file(var.credentials_path)
   region      = var.region
 }

--- a/examples/node_pool_update_variant_public_beta/main.tf
+++ b/examples/node_pool_update_variant_public_beta/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version     = "~> 3.90.0"
+  version     = "~> 3.90.1"
   credentials = file(var.credentials_path)
   region      = var.region
 }

--- a/examples/node_pool_update_variant_public_beta/main.tf
+++ b/examples/node_pool_update_variant_public_beta/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version     = "~> 3.79.0"
+  version     = "~> 3.90.0"
   credentials = file(var.credentials_path)
   region      = var.region
 }

--- a/examples/regional_private_node_pool_oauth_scopes/provider.tf
+++ b/examples/regional_private_node_pool_oauth_scopes/provider.tf
@@ -15,11 +15,11 @@
  */
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
 }
 
 provider "google-beta" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
 }
 
 data "google_client_config" "default" {}

--- a/examples/regional_private_node_pool_oauth_scopes/provider.tf
+++ b/examples/regional_private_node_pool_oauth_scopes/provider.tf
@@ -15,11 +15,11 @@
  */
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
 }
 
 provider "google-beta" {
-  version = "~> 3.79.0"
+  version = "~> 3.90.0"
 }
 
 data "google_client_config" "default" {}

--- a/examples/safer_cluster/main.tf
+++ b/examples/safer_cluster/main.tf
@@ -31,11 +31,11 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
 }
 
 provider "google-beta" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
 }
 
 data "google_client_config" "default" {}

--- a/examples/safer_cluster/main.tf
+++ b/examples/safer_cluster/main.tf
@@ -31,11 +31,11 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
 }
 
 provider "google-beta" {
-  version = "~> 3.79.0"
+  version = "~> 3.90.0"
 }
 
 data "google_client_config" "default" {}

--- a/examples/safer_cluster_iap_bastion/provider.tf
+++ b/examples/safer_cluster_iap_bastion/provider.tf
@@ -19,7 +19,7 @@ provider "google" {
 }
 
 provider "google-beta" {
-  version = "~> 3.79.0"
+  version = "~> 3.90.0"
 }
 
 data "google_client_config" "default" {}

--- a/examples/safer_cluster_iap_bastion/provider.tf
+++ b/examples/safer_cluster_iap_bastion/provider.tf
@@ -15,11 +15,11 @@
  */
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
 }
 
 provider "google-beta" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
 }
 
 data "google_client_config" "default" {}

--- a/examples/safer_cluster_iap_bastion/provider.tf
+++ b/examples/safer_cluster_iap_bastion/provider.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.52.0"
+  version = "~> 3.90.0"
 }
 
 provider "google-beta" {

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/simple_regional/main.tf
+++ b/examples/simple_regional/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/simple_regional/main.tf
+++ b/examples/simple_regional/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_beta/main.tf
+++ b/examples/simple_regional_beta/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/simple_regional_beta/main.tf
+++ b/examples/simple_regional_beta/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.79.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_private/main.tf
+++ b/examples/simple_regional_private/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/simple_regional_private/main.tf
+++ b/examples/simple_regional_private/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_private_beta/main.tf
+++ b/examples/simple_regional_private_beta/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 
 provider "google-beta" {
-  version = "~> 3.79.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_private_beta/main.tf
+++ b/examples/simple_regional_private_beta/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 
 provider "google-beta" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/simple_regional_with_kubeconfig/main.tf
+++ b/examples/simple_regional_with_kubeconfig/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/simple_regional_with_kubeconfig/main.tf
+++ b/examples/simple_regional_with_kubeconfig/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_with_networking/main.tf
+++ b/examples/simple_regional_with_networking/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.45.0"
+  version = "~> 3.90.0"
 }
 
 data "google_client_config" "default" {}

--- a/examples/simple_regional_with_networking/main.tf
+++ b/examples/simple_regional_with_networking/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
 }
 
 data "google_client_config" "default" {}

--- a/examples/simple_zonal_private/main.tf
+++ b/examples/simple_zonal_private/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/simple_zonal_private/main.tf
+++ b/examples/simple_zonal_private/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/simple_zonal_with_acm/main.tf
+++ b/examples/simple_zonal_with_acm/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/simple_zonal_with_acm/main.tf
+++ b/examples/simple_zonal_with_acm/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/simple_zonal_with_asm/main.tf
+++ b/examples/simple_zonal_with_asm/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/simple_zonal_with_asm/main.tf
+++ b/examples/simple_zonal_with_asm/main.tf
@@ -19,12 +19,12 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.79.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 
 provider "google" {
-  version = "~> 3.63.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/simple_zonal_with_hub/main.tf
+++ b/examples/simple_zonal_with_hub/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/simple_zonal_with_hub/main.tf
+++ b/examples/simple_zonal_with_hub/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/stub_domains/main.tf
+++ b/examples/stub_domains/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/stub_domains/main.tf
+++ b/examples/stub_domains/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/stub_domains_private/main.tf
+++ b/examples/stub_domains_private/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/stub_domains_private/main.tf
+++ b/examples/stub_domains_private/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/stub_domains_upstream_nameservers/main.tf
+++ b/examples/stub_domains_upstream_nameservers/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/stub_domains_upstream_nameservers/main.tf
+++ b/examples/stub_domains_upstream_nameservers/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/upstream_nameservers/main.tf
+++ b/examples/upstream_nameservers/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/upstream_nameservers/main.tf
+++ b/examples/upstream_nameservers/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/workload_identity/main.tf
+++ b/examples/workload_identity/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/workload_identity/main.tf
+++ b/examples/workload_identity/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/examples/workload_metadata_config/main.tf
+++ b/examples/workload_metadata_config/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   region  = var.region
 }
 

--- a/examples/workload_metadata_config/main.tf
+++ b/examples/workload_metadata_config/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google-beta" {
-  version = "~> 3.79.0"
+  version = "~> 3.90.0"
   region  = var.region
 }
 

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -313,7 +313,7 @@ resource "google_container_cluster" "primary" {
     for_each = local.cluster_workload_identity_config
 
     content {
-      identity_namespace = workload_identity_config.value.identity_namespace
+      workload_pool = workload_identity_config.value.identity_namespace
     }
   }
 

--- a/modules/beta-private-cluster-update-variant/versions.tf
+++ b/modules/beta-private-cluster-update-variant/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.90.0, <4.0.0"
+      version = ">= 3.90.1, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-private-cluster-update-variant/versions.tf
+++ b/modules/beta-private-cluster-update-variant/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.79.0, <4.0.0"
+      version = ">= 4.0.0, <5.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-private-cluster-update-variant/versions.tf
+++ b/modules/beta-private-cluster-update-variant/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.0.0, <5.0.0"
+      version = ">= 3.90.0, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -313,7 +313,7 @@ resource "google_container_cluster" "primary" {
     for_each = local.cluster_workload_identity_config
 
     content {
-      identity_namespace = workload_identity_config.value.identity_namespace
+      workload_pool = workload_identity_config.value.identity_namespace
     }
   }
 

--- a/modules/beta-private-cluster/versions.tf
+++ b/modules/beta-private-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.90.0, <4.0.0"
+      version = ">= 3.90.1, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-private-cluster/versions.tf
+++ b/modules/beta-private-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.79.0, <4.0.0"
+      version = ">= 4.0.0, <5.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-private-cluster/versions.tf
+++ b/modules/beta-private-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.0.0, <5.0.0"
+      version = ">= 3.90.0, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -294,7 +294,7 @@ resource "google_container_cluster" "primary" {
     for_each = local.cluster_workload_identity_config
 
     content {
-      identity_namespace = workload_identity_config.value.identity_namespace
+      workload_pool = workload_identity_config.value.identity_namespace
     }
   }
 

--- a/modules/beta-public-cluster-update-variant/versions.tf
+++ b/modules/beta-public-cluster-update-variant/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.90.0, <4.0.0"
+      version = ">= 3.90.1, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-public-cluster-update-variant/versions.tf
+++ b/modules/beta-public-cluster-update-variant/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.79.0, <4.0.0"
+      version = ">= 4.0.0, <5.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-public-cluster-update-variant/versions.tf
+++ b/modules/beta-public-cluster-update-variant/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.0.0, <5.0.0"
+      version = ">= 3.90.0, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -294,7 +294,7 @@ resource "google_container_cluster" "primary" {
     for_each = local.cluster_workload_identity_config
 
     content {
-      identity_namespace = workload_identity_config.value.identity_namespace
+      workload_pool = workload_identity_config.value.identity_namespace
     }
   }
 

--- a/modules/beta-public-cluster/versions.tf
+++ b/modules/beta-public-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.90.0, <4.0.0"
+      version = ">= 3.90.1, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-public-cluster/versions.tf
+++ b/modules/beta-public-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.79.0, <4.0.0"
+      version = ">= 4.0.0, <5.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-public-cluster/versions.tf
+++ b/modules/beta-public-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.0.0, <5.0.0"
+      version = ">= 3.90.0, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -206,7 +206,7 @@ resource "google_container_cluster" "primary" {
     for_each = local.cluster_workload_identity_config
 
     content {
-      identity_namespace = workload_identity_config.value.identity_namespace
+      workload_pool = workload_identity_config.value.identity_namespace
     }
   }
 

--- a/modules/private-cluster-update-variant/versions.tf
+++ b/modules/private-cluster-update-variant/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.90.0, <4.0.0"
+      version = ">= 3.90.1, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/private-cluster-update-variant/versions.tf
+++ b/modules/private-cluster-update-variant/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.0.0, <5.0.0"
+      version = ">= 3.90.0, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/private-cluster-update-variant/versions.tf
+++ b/modules/private-cluster-update-variant/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.39.0, <4.0.0"
+      version = ">= 4.0.0, <5.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -206,7 +206,7 @@ resource "google_container_cluster" "primary" {
     for_each = local.cluster_workload_identity_config
 
     content {
-      identity_namespace = workload_identity_config.value.identity_namespace
+      workload_pool = workload_identity_config.value.identity_namespace
     }
   }
 

--- a/modules/private-cluster/versions.tf
+++ b/modules/private-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.90.0, <4.0.0"
+      version = ">= 3.90.1, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/private-cluster/versions.tf
+++ b/modules/private-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.0.0, <5.0.0"
+      version = ">= 3.90.0, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/private-cluster/versions.tf
+++ b/modules/private-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.39.0, <4.0.0"
+      version = ">= 4.0.0, <5.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/workload-identity/versions.tf
+++ b/modules/workload-identity/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.39.0, <4.0.0"
+      version = ">= 3.90.1, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/test/fixtures/beta_cluster/main.tf
+++ b/test/fixtures/beta_cluster/main.tf
@@ -27,7 +27,7 @@ resource "google_kms_key_ring" "db" {
 
 resource "google_kms_crypto_key" "db" {
   name     = local.name
-  key_ring = google_kms_key_ring.db.self_link
+  key_ring = google_kms_key_ring.db.id
 }
 
 module "this" {
@@ -49,7 +49,7 @@ module "this" {
 
   database_encryption = [{
     state    = "ENCRYPTED"
-    key_name = google_kms_crypto_key.db.self_link
+    key_name = google_kms_crypto_key.db.id
   }]
 
   cloudrun = true

--- a/test/fixtures/beta_cluster/outputs.tf
+++ b/test/fixtures/beta_cluster/outputs.tf
@@ -81,7 +81,7 @@ output "service_account" {
 }
 
 output "database_encryption_key_name" {
-  value = google_kms_crypto_key.db.self_link
+  value = google_kms_crypto_key.db.id
 }
 
 output "identity_namespace" {

--- a/test/fixtures/deploy_service/network.tf
+++ b/test/fixtures/deploy_service/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/deploy_service/network.tf
+++ b/test/fixtures/deploy_service/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/disable_client_cert/network.tf
+++ b/test/fixtures/disable_client_cert/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/disable_client_cert/network.tf
+++ b/test/fixtures/disable_client_cert/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/shared_vpc/network.tf
+++ b/test/fixtures/shared_vpc/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/shared_vpc/network.tf
+++ b/test/fixtures/shared_vpc/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/simple_regional/network.tf
+++ b/test/fixtures/simple_regional/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/simple_regional/network.tf
+++ b/test/fixtures/simple_regional/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/simple_regional_with_kubeconfig/network.tf
+++ b/test/fixtures/simple_regional_with_kubeconfig/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/simple_regional_with_kubeconfig/network.tf
+++ b/test/fixtures/simple_regional_with_kubeconfig/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/simple_zonal/network.tf
+++ b/test/fixtures/simple_zonal/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   project = var.project_ids[1]
 }
 

--- a/test/fixtures/simple_zonal/network.tf
+++ b/test/fixtures/simple_zonal/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   project = var.project_ids[1]
 }
 

--- a/test/fixtures/simple_zonal_with_asm/network.tf
+++ b/test/fixtures/simple_zonal_with_asm/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   project = var.project_ids[2]
 }
 

--- a/test/fixtures/simple_zonal_with_asm/network.tf
+++ b/test/fixtures/simple_zonal_with_asm/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.63.0"
+  version = "~> 3.90.0"
   project = var.project_ids[2]
 }
 

--- a/test/fixtures/stub_domains/network.tf
+++ b/test/fixtures/stub_domains/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   project = var.project_ids[1]
 }
 

--- a/test/fixtures/stub_domains/network.tf
+++ b/test/fixtures/stub_domains/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   project = var.project_ids[1]
 }
 

--- a/test/fixtures/stub_domains_upstream_nameservers/network.tf
+++ b/test/fixtures/stub_domains_upstream_nameservers/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   project = var.project_ids[1]
 }
 

--- a/test/fixtures/stub_domains_upstream_nameservers/network.tf
+++ b/test/fixtures/stub_domains_upstream_nameservers/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   project = var.project_ids[1]
 }
 

--- a/test/fixtures/upstream_nameservers/network.tf
+++ b/test/fixtures/upstream_nameservers/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.90.0"
+  version = "~> 3.90.1"
   project = var.project_ids[1]
 }
 

--- a/test/fixtures/upstream_nameservers/network.tf
+++ b/test/fixtures/upstream_nameservers/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.90.0"
   project = var.project_ids[1]
 }
 

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -16,12 +16,16 @@
 
 terraform {
   required_version = ">=0.12"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "3.50.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "3.50.0"
+    }
+  }
 }
 
-provider "google" {
-  version = "3.50.0"
-}
-
-provider "google-beta" {
-  version = "3.50.0"
-}

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "3.50.0"
+      version = "3.90.1"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "3.50.0"
+      version = "3.90.1"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.90.0, <4.0.0"
+      version = ">= 3.90.1, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/versions.tf
+++ b/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.0.0, <5.0.0"
+      version = ">= 3.90.0, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/versions.tf
+++ b/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.39.0, <4.0.0"
+      version = ">= 4.0.0, <5.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
- Fixes https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1051
- Fix some markdown files.
- Fix some deprecated code and updated all google providers to use v3.90.1 in preparation for the v4.0.0 provider upgrade.