### PR TITLE
nit: update Workload Identity README example for existing GSA

### DIFF
--- a/examples/workload_identity/main.tf
+++ b/examples/workload_identity/main.tf
@@ -95,5 +95,6 @@ module "workload_identity_existing_gsa" {
   name                = google_service_account.custom.account_id
   use_existing_gcp_sa = true
   # wait till custom GSA is created to force module data source read during apply
+  # https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1059
   depends_on = [google_service_account.custom]
 }

--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -59,6 +59,10 @@ module "my-app-workload-identity" {
   use_existing_gcp_sa = true
   name                = google_service_account.preexisting.account_id
   project_id          = var.project_id
+
+  # wait for the custom GSA to be created to force module data source read during apply
+  # https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1059
+  depends_on = [google_service_account.preexisting]
 }
 ```
 


### PR DESCRIPTION
This is a tiny doc update that adds a `depends_on` block to the Workload Identity README example for existing GSA, as discussed in #1059. This makes the README example match the `examples/workload_identity` module & prevents Terraform from trying to read the GSA data source before it is created.