### PR TITLE
[Workload Identity] Set K8S SA token automount default value to true

### DIFF
--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -96,7 +96,7 @@ already bear the `"iam.gke.io/gcp-service-account"` annotation.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | annotate\_k8s\_sa | Annotate the kubernetes service account with 'iam.gke.io/gcp-service-account' annotation. Valid in cases when an existing SA is used. | `bool` | `true` | no |
-| automount\_service\_account\_token | Enable automatic mounting of the service account token | `bool` | `false` | no |
+| automount\_service\_account\_token | Enable automatic mounting of the service account token | `bool` | `true` | no |
 | cluster\_name | Cluster name. Required if using existing KSA. | `string` | `""` | no |
 | gcp\_sa\_name | Name for the Google service account; overrides `var.name`. | `string` | `null` | no |
 | impersonate\_service\_account | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `""` | no |

--- a/modules/workload-identity/variables.tf
+++ b/modules/workload-identity/variables.tf
@@ -75,7 +75,7 @@ variable "annotate_k8s_sa" {
 variable "automount_service_account_token" {
   description = "Enable automatic mounting of the service account token"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "roles" {


### PR DESCRIPTION
## What?
This PR sets the `automount_service_account_token` default value to `true` in the `workload-identity` module

## Why?
While using the module I bumped into an issue where one of my pods was complaining about not being able to mount
```
var/run/secrets/kubernetes.io/serviceaccount/token
```

After some looking around a bit I ended up finding this issue https://github.com/kubernetes/kubernetes/issues/27973, where folks mentioned that it could be an issue when using the `kubernetes` provider for terraform.

The kubernetes has the `automount_service_account_token`  set by default to `true` for a while now.
https://github.com/hashicorp/terraform-provider-kubernetes/pull/1054

So I was wondering if makes sense to follow the pattern here.