### PR TITLE
feat: Make auto_provisioning_defaults a non-beta feature

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -86,15 +86,18 @@ resource "google_container_cluster" "primary" {
 
   cluster_autoscaling {
     enabled = var.cluster_autoscaling.enabled
-{% if beta_cluster %}
     dynamic "auto_provisioning_defaults" {
       for_each = var.cluster_autoscaling.enabled ? [1] : []
 
       content {
         service_account = local.service_account
         oauth_scopes = local.node_pools_oauth_scopes["all"]
+{% if beta_cluster %}
+        min_cpu_platform = lookup(var.node_pools[0], "min_cpu_platform", "")
+{% endif %}
       }
     }
+{% if beta_cluster %}
     autoscaling_profile = var.cluster_autoscaling.autoscaling_profile != null ? var.cluster_autoscaling.autoscaling_profile : "BALANCED"
 {% endif %}
     dynamic "resource_limits" {

--- a/cluster.tf
+++ b/cluster.tf
@@ -58,6 +58,14 @@ resource "google_container_cluster" "primary" {
 
   cluster_autoscaling {
     enabled = var.cluster_autoscaling.enabled
+    dynamic "auto_provisioning_defaults" {
+      for_each = var.cluster_autoscaling.enabled ? [1] : []
+
+      content {
+        service_account = local.service_account
+        oauth_scopes    = local.node_pools_oauth_scopes["all"]
+      }
+    }
     dynamic "resource_limits" {
       for_each = local.autoscaling_resource_limits
       content {

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -77,8 +77,9 @@ resource "google_container_cluster" "primary" {
       for_each = var.cluster_autoscaling.enabled ? [1] : []
 
       content {
-        service_account = local.service_account
-        oauth_scopes    = local.node_pools_oauth_scopes["all"]
+        service_account  = local.service_account
+        oauth_scopes     = local.node_pools_oauth_scopes["all"]
+        min_cpu_platform = lookup(var.node_pools[0], "min_cpu_platform", "")
       }
     }
     autoscaling_profile = var.cluster_autoscaling.autoscaling_profile != null ? var.cluster_autoscaling.autoscaling_profile : "BALANCED"

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -77,8 +77,9 @@ resource "google_container_cluster" "primary" {
       for_each = var.cluster_autoscaling.enabled ? [1] : []
 
       content {
-        service_account = local.service_account
-        oauth_scopes    = local.node_pools_oauth_scopes["all"]
+        service_account  = local.service_account
+        oauth_scopes     = local.node_pools_oauth_scopes["all"]
+        min_cpu_platform = lookup(var.node_pools[0], "min_cpu_platform", "")
       }
     }
     autoscaling_profile = var.cluster_autoscaling.autoscaling_profile != null ? var.cluster_autoscaling.autoscaling_profile : "BALANCED"

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -77,8 +77,9 @@ resource "google_container_cluster" "primary" {
       for_each = var.cluster_autoscaling.enabled ? [1] : []
 
       content {
-        service_account = local.service_account
-        oauth_scopes    = local.node_pools_oauth_scopes["all"]
+        service_account  = local.service_account
+        oauth_scopes     = local.node_pools_oauth_scopes["all"]
+        min_cpu_platform = lookup(var.node_pools[0], "min_cpu_platform", "")
       }
     }
     autoscaling_profile = var.cluster_autoscaling.autoscaling_profile != null ? var.cluster_autoscaling.autoscaling_profile : "BALANCED"

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -77,8 +77,9 @@ resource "google_container_cluster" "primary" {
       for_each = var.cluster_autoscaling.enabled ? [1] : []
 
       content {
-        service_account = local.service_account
-        oauth_scopes    = local.node_pools_oauth_scopes["all"]
+        service_account  = local.service_account
+        oauth_scopes     = local.node_pools_oauth_scopes["all"]
+        min_cpu_platform = lookup(var.node_pools[0], "min_cpu_platform", "")
       }
     }
     autoscaling_profile = var.cluster_autoscaling.autoscaling_profile != null ? var.cluster_autoscaling.autoscaling_profile : "BALANCED"

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -58,6 +58,14 @@ resource "google_container_cluster" "primary" {
 
   cluster_autoscaling {
     enabled = var.cluster_autoscaling.enabled
+    dynamic "auto_provisioning_defaults" {
+      for_each = var.cluster_autoscaling.enabled ? [1] : []
+
+      content {
+        service_account = local.service_account
+        oauth_scopes    = local.node_pools_oauth_scopes["all"]
+      }
+    }
     dynamic "resource_limits" {
       for_each = local.autoscaling_resource_limits
       content {

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -58,6 +58,14 @@ resource "google_container_cluster" "primary" {
 
   cluster_autoscaling {
     enabled = var.cluster_autoscaling.enabled
+    dynamic "auto_provisioning_defaults" {
+      for_each = var.cluster_autoscaling.enabled ? [1] : []
+
+      content {
+        service_account = local.service_account
+        oauth_scopes    = local.node_pools_oauth_scopes["all"]
+      }
+    }
     dynamic "resource_limits" {
       for_each = local.autoscaling_resource_limits
       content {


### PR DESCRIPTION
Fixes #1008 

This PR simply makes the auto-provisioning defaults block not beta-exclusive, but I also want to add the `min_cpu_platform` argument in the block as specified [here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_auto_provisioning_defaults) since it seems we added the feature for default node pools in #1057. However, I don't understand why we pull the value from the first node pool using `lookup(var.node_pools[0],...)` because, from what I understand, `min_cpu_platform` is a cluster-level variable, so it feels weird to read from a specific node pool's arguments, like `pool-01`, even though it will apply to other node pools as well. Shouldn't it be its own variable and read in like `var.min_cpu_platform` or something similar?