### PR TITLE
Allow datapath_provider in GA main module

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Then perform the following commands on the root folder:
 | configure\_ip\_masq | Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server. | `bool` | `false` | no |
 | create\_service\_account | Defines if service account specified to run nodes should be created. | `bool` | `true` | no |
 | database\_encryption | Application-layer Secrets Encryption settings. The object format is {state = string, key\_name = string}. Valid values of state are: "ENCRYPTED"; "DECRYPTED". key\_name is the name of a CloudKMS key. | `list(object({ state = string, key_name = string }))` | <pre>[<br>  {<br>    "key_name": "",<br>    "state": "DECRYPTED"<br>  }<br>]</pre> | no |
+| datapath\_provider | The desired datapath provider for this cluster. By default, `DATAPATH_PROVIDER_UNSPECIFIED` enables the IPTables-based kube-proxy implementation. `ADVANCED_DATAPATH` enables Dataplane-V2 feature. | `string` | `"DATAPATH_PROVIDER_UNSPECIFIED"` | no |
 | default\_max\_pods\_per\_node | The maximum number of pods to schedule per node | `number` | `110` | no |
 | description | The description of the cluster | `string` | `""` | no |
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | `bool` | `true` | no |

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -217,9 +217,8 @@ resource "google_container_cluster" "primary" {
     }
     {% endif %}
   }
-  {% if beta_cluster %}
+
   datapath_provider = var.datapath_provider
-  {% endif %}
 
   {% if beta_cluster %}
   networking_mode = "VPC_NATIVE"

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -107,13 +107,12 @@ variable "network_policy_provider" {
   description = "The network policy provider."
   default     = "CALICO"
 }
-{% if beta_cluster %}
+
 variable "datapath_provider" {
   type        = string
   description = "The desired datapath provider for this cluster. By default, `DATAPATH_PROVIDER_UNSPECIFIED` enables the IPTables-based kube-proxy implementation. `ADVANCED_DATAPATH` enables Dataplane-V2 feature."
   default     = "DATAPATH_PROVIDER_UNSPECIFIED"
 }
-{% endif %}
 
 variable "maintenance_start_time" {
   type        = string

--- a/autogen/main/versions.tf.tmpl
+++ b/autogen/main/versions.tf.tmpl
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.39.0, <4.0.0"
+      version = ">= 3.55.0, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/cluster.tf
+++ b/cluster.tf
@@ -120,6 +120,8 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  datapath_provider = var.datapath_provider
+
   ip_allocation_policy {
     cluster_secondary_range_name  = var.ip_range_pods
     services_secondary_range_name = var.ip_range_services

--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   region  = var.region
 }
 

--- a/examples/disable_client_cert/main.tf
+++ b/examples/disable_client_cert/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   region  = var.region
 }
 

--- a/examples/node_pool_update_variant/main.tf
+++ b/examples/node_pool_update_variant/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   region  = var.region
 }
 

--- a/examples/regional_private_node_pool_oauth_scopes/provider.tf
+++ b/examples/regional_private_node_pool_oauth_scopes/provider.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
 }
 
 provider "google-beta" {

--- a/examples/safer_cluster/main.tf
+++ b/examples/safer_cluster/main.tf
@@ -31,7 +31,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
 }
 
 provider "google-beta" {

--- a/examples/shared_vpc/main.tf
+++ b/examples/shared_vpc/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   region  = var.region
 }
 

--- a/examples/simple_regional/main.tf
+++ b/examples/simple_regional/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_private/main.tf
+++ b/examples/simple_regional_private/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_private_beta/main.tf
+++ b/examples/simple_regional_private_beta/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_with_kubeconfig/main.tf
+++ b/examples/simple_regional_with_kubeconfig/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   region  = var.region
 }
 

--- a/examples/simple_regional_with_networking/main.tf
+++ b/examples/simple_regional_with_networking/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.45.0"
+  version = "~> 3.55.0"
 }
 
 data "google_client_config" "default" {}

--- a/examples/simple_zonal_private/main.tf
+++ b/examples/simple_zonal_private/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   region  = var.region
 }
 

--- a/examples/simple_zonal_with_acm/main.tf
+++ b/examples/simple_zonal_with_acm/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   region  = var.region
 }
 

--- a/examples/simple_zonal_with_hub/main.tf
+++ b/examples/simple_zonal_with_hub/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   region  = var.region
 }
 

--- a/examples/stub_domains/main.tf
+++ b/examples/stub_domains/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   region  = var.region
 }
 

--- a/examples/stub_domains_private/main.tf
+++ b/examples/stub_domains_private/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   region  = var.region
 }
 

--- a/examples/stub_domains_upstream_nameservers/main.tf
+++ b/examples/stub_domains_upstream_nameservers/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   region  = var.region
 }
 

--- a/examples/upstream_nameservers/main.tf
+++ b/examples/upstream_nameservers/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   region  = var.region
 }
 

--- a/examples/workload_identity/main.tf
+++ b/examples/workload_identity/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   region  = var.region
 }
 

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -196,6 +196,7 @@ resource "google_container_cluster" "primary" {
       enabled = var.config_connector
     }
   }
+
   datapath_provider = var.datapath_provider
 
   networking_mode = "VPC_NATIVE"

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -107,6 +107,7 @@ variable "network_policy_provider" {
   description = "The network policy provider."
   default     = "CALICO"
 }
+
 variable "datapath_provider" {
   type        = string
   description = "The desired datapath provider for this cluster. By default, `DATAPATH_PROVIDER_UNSPECIFIED` enables the IPTables-based kube-proxy implementation. `ADVANCED_DATAPATH` enables Dataplane-V2 feature."

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -196,6 +196,7 @@ resource "google_container_cluster" "primary" {
       enabled = var.config_connector
     }
   }
+
   datapath_provider = var.datapath_provider
 
   networking_mode = "VPC_NATIVE"

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -107,6 +107,7 @@ variable "network_policy_provider" {
   description = "The network policy provider."
   default     = "CALICO"
 }
+
 variable "datapath_provider" {
   type        = string
   description = "The desired datapath provider for this cluster. By default, `DATAPATH_PROVIDER_UNSPECIFIED` enables the IPTables-based kube-proxy implementation. `ADVANCED_DATAPATH` enables Dataplane-V2 feature."

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -196,6 +196,7 @@ resource "google_container_cluster" "primary" {
       enabled = var.config_connector
     }
   }
+
   datapath_provider = var.datapath_provider
 
   networking_mode = "VPC_NATIVE"

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -107,6 +107,7 @@ variable "network_policy_provider" {
   description = "The network policy provider."
   default     = "CALICO"
 }
+
 variable "datapath_provider" {
   type        = string
   description = "The desired datapath provider for this cluster. By default, `DATAPATH_PROVIDER_UNSPECIFIED` enables the IPTables-based kube-proxy implementation. `ADVANCED_DATAPATH` enables Dataplane-V2 feature."

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -196,6 +196,7 @@ resource "google_container_cluster" "primary" {
       enabled = var.config_connector
     }
   }
+
   datapath_provider = var.datapath_provider
 
   networking_mode = "VPC_NATIVE"

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -107,6 +107,7 @@ variable "network_policy_provider" {
   description = "The network policy provider."
   default     = "CALICO"
 }
+
 variable "datapath_provider" {
   type        = string
   description = "The desired datapath provider for this cluster. By default, `DATAPATH_PROVIDER_UNSPECIFIED` enables the IPTables-based kube-proxy implementation. `ADVANCED_DATAPATH` enables Dataplane-V2 feature."

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -164,6 +164,7 @@ Then perform the following commands on the root folder:
 | configure\_ip\_masq | Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server. | `bool` | `false` | no |
 | create\_service\_account | Defines if service account specified to run nodes should be created. | `bool` | `true` | no |
 | database\_encryption | Application-layer Secrets Encryption settings. The object format is {state = string, key\_name = string}. Valid values of state are: "ENCRYPTED"; "DECRYPTED". key\_name is the name of a CloudKMS key. | `list(object({ state = string, key_name = string }))` | <pre>[<br>  {<br>    "key_name": "",<br>    "state": "DECRYPTED"<br>  }<br>]</pre> | no |
+| datapath\_provider | The desired datapath provider for this cluster. By default, `DATAPATH_PROVIDER_UNSPECIFIED` enables the IPTables-based kube-proxy implementation. `ADVANCED_DATAPATH` enables Dataplane-V2 feature. | `string` | `"DATAPATH_PROVIDER_UNSPECIFIED"` | no |
 | default\_max\_pods\_per\_node | The maximum number of pods to schedule per node | `number` | `110` | no |
 | deploy\_using\_private\_endpoint | (Beta) A toggle for Terraform and kubectl to connect to the master's internal IP address during deployment. | `bool` | `false` | no |
 | description | The description of the cluster | `string` | `""` | no |

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -120,6 +120,8 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  datapath_provider = var.datapath_provider
+
   ip_allocation_policy {
     cluster_secondary_range_name  = var.ip_range_pods
     services_secondary_range_name = var.ip_range_services

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -108,6 +108,12 @@ variable "network_policy_provider" {
   default     = "CALICO"
 }
 
+variable "datapath_provider" {
+  type        = string
+  description = "The desired datapath provider for this cluster. By default, `DATAPATH_PROVIDER_UNSPECIFIED` enables the IPTables-based kube-proxy implementation. `ADVANCED_DATAPATH` enables Dataplane-V2 feature."
+  default     = "DATAPATH_PROVIDER_UNSPECIFIED"
+}
+
 variable "maintenance_start_time" {
   type        = string
   description = "Time window specified for daily or recurring maintenance operations in RFC3339 format"

--- a/modules/private-cluster-update-variant/versions.tf
+++ b/modules/private-cluster-update-variant/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.39.0, <4.0.0"
+      version = ">= 3.55.0, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -142,6 +142,7 @@ Then perform the following commands on the root folder:
 | configure\_ip\_masq | Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server. | `bool` | `false` | no |
 | create\_service\_account | Defines if service account specified to run nodes should be created. | `bool` | `true` | no |
 | database\_encryption | Application-layer Secrets Encryption settings. The object format is {state = string, key\_name = string}. Valid values of state are: "ENCRYPTED"; "DECRYPTED". key\_name is the name of a CloudKMS key. | `list(object({ state = string, key_name = string }))` | <pre>[<br>  {<br>    "key_name": "",<br>    "state": "DECRYPTED"<br>  }<br>]</pre> | no |
+| datapath\_provider | The desired datapath provider for this cluster. By default, `DATAPATH_PROVIDER_UNSPECIFIED` enables the IPTables-based kube-proxy implementation. `ADVANCED_DATAPATH` enables Dataplane-V2 feature. | `string` | `"DATAPATH_PROVIDER_UNSPECIFIED"` | no |
 | default\_max\_pods\_per\_node | The maximum number of pods to schedule per node | `number` | `110` | no |
 | deploy\_using\_private\_endpoint | (Beta) A toggle for Terraform and kubectl to connect to the master's internal IP address during deployment. | `bool` | `false` | no |
 | description | The description of the cluster | `string` | `""` | no |

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -120,6 +120,8 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  datapath_provider = var.datapath_provider
+
   ip_allocation_policy {
     cluster_secondary_range_name  = var.ip_range_pods
     services_secondary_range_name = var.ip_range_services

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -108,6 +108,12 @@ variable "network_policy_provider" {
   default     = "CALICO"
 }
 
+variable "datapath_provider" {
+  type        = string
+  description = "The desired datapath provider for this cluster. By default, `DATAPATH_PROVIDER_UNSPECIFIED` enables the IPTables-based kube-proxy implementation. `ADVANCED_DATAPATH` enables Dataplane-V2 feature."
+  default     = "DATAPATH_PROVIDER_UNSPECIFIED"
+}
+
 variable "maintenance_start_time" {
   type        = string
   description = "Time window specified for daily or recurring maintenance operations in RFC3339 format"

--- a/modules/private-cluster/versions.tf
+++ b/modules/private-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.39.0, <4.0.0"
+      version = ">= 3.55.0, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/test/fixtures/deploy_service/network.tf
+++ b/test/fixtures/deploy_service/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/disable_client_cert/network.tf
+++ b/test/fixtures/disable_client_cert/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/shared_vpc/network.tf
+++ b/test/fixtures/shared_vpc/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/simple_regional/network.tf
+++ b/test/fixtures/simple_regional/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/simple_regional_with_kubeconfig/network.tf
+++ b/test/fixtures/simple_regional_with_kubeconfig/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   project = var.project_ids[0]
 }
 

--- a/test/fixtures/simple_zonal/network.tf
+++ b/test/fixtures/simple_zonal/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   project = var.project_ids[1]
 }
 

--- a/test/fixtures/stub_domains/network.tf
+++ b/test/fixtures/stub_domains/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   project = var.project_ids[1]
 }
 

--- a/test/fixtures/stub_domains_upstream_nameservers/network.tf
+++ b/test/fixtures/stub_domains_upstream_nameservers/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   project = var.project_ids[1]
 }
 

--- a/test/fixtures/upstream_nameservers/network.tf
+++ b/test/fixtures/upstream_nameservers/network.tf
@@ -21,7 +21,7 @@ resource "random_string" "suffix" {
 }
 
 provider "google" {
-  version = "~> 3.42.0"
+  version = "~> 3.55.0"
   project = var.project_ids[1]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -108,6 +108,12 @@ variable "network_policy_provider" {
   default     = "CALICO"
 }
 
+variable "datapath_provider" {
+  type        = string
+  description = "The desired datapath provider for this cluster. By default, `DATAPATH_PROVIDER_UNSPECIFIED` enables the IPTables-based kube-proxy implementation. `ADVANCED_DATAPATH` enables Dataplane-V2 feature."
+  default     = "DATAPATH_PROVIDER_UNSPECIFIED"
+}
+
 variable "maintenance_start_time" {
   type        = string
   description = "Time window specified for daily or recurring maintenance operations in RFC3339 format"

--- a/versions.tf
+++ b/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.39.0, <4.0.0"
+      version = ">= 3.55.0, <4.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
First time contributor implementing https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1074

Had to bump the main module GA google provider to 3.55.0 to enable `datapath_provider` being GA https://github.com/hashicorp/terraform-provider-google/blob/e2e533f83c388fecbf51ae8ca541326b152cede0/CHANGELOG.md#3550-february-1-2021