### PR TITLE
Default datapath_provider to ADVANCED_DATAPATH (aka. Dataplane V2) for safer-cluster with variable for fallback

### DIFF
--- a/autogen/safer-cluster/main.tf.tmpl
+++ b/autogen/safer-cluster/main.tf.tmpl
@@ -65,7 +65,11 @@ module "gke" {
   // NetworkPolicies need to be configured in every namespace. The network
   // policies should be under the control of a cental cluster management team,
   // rather than individual teams.
-  network_policy = true
+  //
+  // NOTE: Dataplane-V2 conflicts with the Calico network policy add-on because
+  // it provides redundant NetworkPolicy capabilities. If V2 is enabled, the
+  // Calico add-on should be disabled.
+  network_policy = var.datapath_provider == "ADVANCED_DATAPATH" ? false : true
 
   // Default to the recommended Dataplane V2 which enables NetworkPolicies and
   // allows for network policy logging of allowed and denied requests to Pods.

--- a/autogen/safer-cluster/main.tf.tmpl
+++ b/autogen/safer-cluster/main.tf.tmpl
@@ -67,6 +67,10 @@ module "gke" {
   // rather than individual teams.
   network_policy = true
 
+  // Default to the recommended Dataplane V2 which enables NetworkPolicies and
+  // allows for network policy logging of allowed and denied requests to Pods.
+  datapath_provider = var.datapath_provider
+
   maintenance_start_time = var.maintenance_start_time
 
   initial_node_count = var.initial_node_count

--- a/autogen/safer-cluster/variables.tf.tmpl
+++ b/autogen/safer-cluster/variables.tf.tmpl
@@ -95,6 +95,12 @@ variable "http_load_balancing" {
   default     = true
 }
 
+variable "datapath_provider" {
+  type        = string
+  description = "The desired datapath provider for this cluster. By default, `ADVANCED_DATAPATH` enables Dataplane-V2 feature. `DATAPATH_PROVIDER_UNSPECIFIED` enables the IPTables-based kube-proxy implementation as a fallback since upgrading to V2 requires a cluster re-creation."
+  default     = "ADVANCED_DATAPATH"
+}
+
 variable "maintenance_start_time" {
   type        = string
   description = "Time window specified for daily maintenance operations in RFC3339 format"

--- a/modules/safer-cluster-update-variant/README.md
+++ b/modules/safer-cluster-update-variant/README.md
@@ -208,6 +208,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | compute\_engine\_service\_account | Use the given service account for nodes rather than creating a new dedicated service account. | `string` | `""` | no |
 | config\_connector | (Beta) Whether ConfigConnector is enabled for this cluster. | `bool` | `false` | no |
 | database\_encryption | Application-layer Secrets Encryption settings. The object format is {state = string, key\_name = string}. Valid values of state are: "ENCRYPTED"; "DECRYPTED". key\_name is the name of a CloudKMS key. | `list(object({ state = string, key_name = string }))` | <pre>[<br>  {<br>    "key_name": "",<br>    "state": "DECRYPTED"<br>  }<br>]</pre> | no |
+| datapath\_provider | The desired datapath provider for this cluster. By default, `ADVANCED_DATAPATH` enables Dataplane-V2 feature. `DATAPATH_PROVIDER_UNSPECIFIED` enables the IPTables-based kube-proxy implementation as a fallback since upgrading to V2 requires a cluster re-creation. | `string` | `"ADVANCED_DATAPATH"` | no |
 | default\_max\_pods\_per\_node | The maximum number of pods to schedule per node | `number` | `110` | no |
 | description | The description of the cluster | `string` | `""` | no |
 | disable\_default\_snat | Whether to disable the default SNAT to support the private use of public IP addresses | `bool` | `false` | no |

--- a/modules/safer-cluster-update-variant/main.tf
+++ b/modules/safer-cluster-update-variant/main.tf
@@ -63,6 +63,10 @@ module "gke" {
   // rather than individual teams.
   network_policy = true
 
+  // Default to the recommended Dataplane V2 which enables NetworkPolicies and
+  // allows for network policy logging of allowed and denied requests to Pods.
+  datapath_provider = var.datapath_provider
+
   maintenance_start_time = var.maintenance_start_time
 
   initial_node_count = var.initial_node_count

--- a/modules/safer-cluster-update-variant/main.tf
+++ b/modules/safer-cluster-update-variant/main.tf
@@ -61,7 +61,11 @@ module "gke" {
   // NetworkPolicies need to be configured in every namespace. The network
   // policies should be under the control of a cental cluster management team,
   // rather than individual teams.
-  network_policy = true
+  //
+  // NOTE: Dataplane-V2 conflicts with the Calico network policy add-on because
+  // it provides redundant NetworkPolicy capabilities. If V2 is enabled, the
+  // Calico add-on should be disabled.
+  network_policy = var.datapath_provider == "ADVANCED_DATAPATH" ? false : true
 
   // Default to the recommended Dataplane V2 which enables NetworkPolicies and
   // allows for network policy logging of allowed and denied requests to Pods.

--- a/modules/safer-cluster-update-variant/variables.tf
+++ b/modules/safer-cluster-update-variant/variables.tf
@@ -95,6 +95,12 @@ variable "http_load_balancing" {
   default     = true
 }
 
+variable "datapath_provider" {
+  type        = string
+  description = "The desired datapath provider for this cluster. By default, `ADVANCED_DATAPATH` enables Dataplane-V2 feature. `DATAPATH_PROVIDER_UNSPECIFIED` enables the IPTables-based kube-proxy implementation as a fallback since upgrading to V2 requires a cluster re-creation."
+  default     = "ADVANCED_DATAPATH"
+}
+
 variable "maintenance_start_time" {
   type        = string
   description = "Time window specified for daily maintenance operations in RFC3339 format"

--- a/modules/safer-cluster/README.md
+++ b/modules/safer-cluster/README.md
@@ -208,6 +208,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | compute\_engine\_service\_account | Use the given service account for nodes rather than creating a new dedicated service account. | `string` | `""` | no |
 | config\_connector | (Beta) Whether ConfigConnector is enabled for this cluster. | `bool` | `false` | no |
 | database\_encryption | Application-layer Secrets Encryption settings. The object format is {state = string, key\_name = string}. Valid values of state are: "ENCRYPTED"; "DECRYPTED". key\_name is the name of a CloudKMS key. | `list(object({ state = string, key_name = string }))` | <pre>[<br>  {<br>    "key_name": "",<br>    "state": "DECRYPTED"<br>  }<br>]</pre> | no |
+| datapath\_provider | The desired datapath provider for this cluster. By default, `ADVANCED_DATAPATH` enables Dataplane-V2 feature. `DATAPATH_PROVIDER_UNSPECIFIED` enables the IPTables-based kube-proxy implementation as a fallback since upgrading to V2 requires a cluster re-creation. | `string` | `"ADVANCED_DATAPATH"` | no |
 | default\_max\_pods\_per\_node | The maximum number of pods to schedule per node | `number` | `110` | no |
 | description | The description of the cluster | `string` | `""` | no |
 | disable\_default\_snat | Whether to disable the default SNAT to support the private use of public IP addresses | `bool` | `false` | no |

--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -63,6 +63,10 @@ module "gke" {
   // rather than individual teams.
   network_policy = true
 
+  // Default to the recommended Dataplane V2 which enables NetworkPolicies and
+  // allows for network policy logging of allowed and denied requests to Pods.
+  datapath_provider = var.datapath_provider
+
   maintenance_start_time = var.maintenance_start_time
 
   initial_node_count = var.initial_node_count

--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -61,7 +61,11 @@ module "gke" {
   // NetworkPolicies need to be configured in every namespace. The network
   // policies should be under the control of a cental cluster management team,
   // rather than individual teams.
-  network_policy = true
+  //
+  // NOTE: Dataplane-V2 conflicts with the Calico network policy add-on because
+  // it provides redundant NetworkPolicy capabilities. If V2 is enabled, the
+  // Calico add-on should be disabled.
+  network_policy = var.datapath_provider == "ADVANCED_DATAPATH" ? false : true
 
   // Default to the recommended Dataplane V2 which enables NetworkPolicies and
   // allows for network policy logging of allowed and denied requests to Pods.

--- a/modules/safer-cluster/variables.tf
+++ b/modules/safer-cluster/variables.tf
@@ -95,6 +95,12 @@ variable "http_load_balancing" {
   default     = true
 }
 
+variable "datapath_provider" {
+  type        = string
+  description = "The desired datapath provider for this cluster. By default, `ADVANCED_DATAPATH` enables Dataplane-V2 feature. `DATAPATH_PROVIDER_UNSPECIFIED` enables the IPTables-based kube-proxy implementation as a fallback since upgrading to V2 requires a cluster re-creation."
+  default     = "ADVANCED_DATAPATH"
+}
+
 variable "maintenance_start_time" {
   type        = string
   description = "Time window specified for daily maintenance operations in RFC3339 format"

--- a/test/integration/safer_cluster/controls/gcloud.rb
+++ b/test/integration/safer_cluster/controls/gcloud.rb
@@ -65,9 +65,7 @@ control "gcloud" do
     end
 
     it "has network policy disabled" do
-      expect(data['networkPolicy']).to eq({
-        "enabled" => false,
-      })
+      expect(data['networkPolicy']).to be_nil
     end
 
     it "has dataplane v2 enabled" do

--- a/test/integration/safer_cluster/controls/gcloud.rb
+++ b/test/integration/safer_cluster/controls/gcloud.rb
@@ -57,16 +57,23 @@ control "gcloud" do
             "kubernetesDashboard" => including(
               "disabled" => true,
             ),
-            "networkPolicyConfig" => {},
+            "networkPolicyConfig" => including(
+              "disabled" => true,
+            ),
           )
       end
     end
 
-    it "has network policy enabled" do
+    it "has network policy disabled" do
       expect(data['networkPolicy']).to eq({
-        "enabled" => true,
-        "provider" => "CALICO",
+        "enabled" => false,
       })
+    end
+
+    it "has dataplane v2 enabled" do
+      expect(data['networkConfig']).to include(
+        "datapathProvider" => "ADVANCED_DATAPATH"
+      )
     end
 
     it "has binary authorization" do


### PR DESCRIPTION
First time contributor implementing https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1064

Default safer-cluster to Dataplane V2 with
```
datapath_provider = "ADVANCED_DATAPATH"
```

But allow module consumers to set V1 as a fallback via a module variable, as upgrading to Dataplane V2 requires cluster re-creation.