### PR TITLE
Allow users to specify network tags for the default node pool

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -288,6 +288,13 @@ resource "google_container_cluster" "primary" {
 
       service_account = lookup(var.node_pools[0], "service_account", local.service_account)
 
+      tags = concat(
+        lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
+        lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
+        lookup(local.node_pools_tags, "all", []),
+        lookup(local.node_pools_tags, "default-pool", []),
+      )
+
       dynamic "workload_metadata_config" {
         for_each = local.cluster_node_metadata_config
 

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -292,7 +292,7 @@ resource "google_container_cluster" "primary" {
         lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
         lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
         lookup(local.node_pools_tags, "all", []),
-        lookup(local.node_pools_tags, "default-pool", []),
+        lookup(local.node_pools_tags, var.node_pools[0].name, []),
       )
 
       dynamic "workload_metadata_config" {

--- a/cluster.tf
+++ b/cluster.tf
@@ -156,7 +156,7 @@ resource "google_container_cluster" "primary" {
         lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
         lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
         lookup(local.node_pools_tags, "all", []),
-        lookup(local.node_pools_tags, "default-pool", []),
+        lookup(local.node_pools_tags, var.node_pools[0].name, []),
       )
 
       dynamic "workload_metadata_config" {

--- a/cluster.tf
+++ b/cluster.tf
@@ -152,6 +152,13 @@ resource "google_container_cluster" "primary" {
 
       service_account = lookup(var.node_pools[0], "service_account", local.service_account)
 
+      tags = concat(
+        lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
+        lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
+        lookup(local.node_pools_tags, "all", []),
+        lookup(local.node_pools_tags, "default-pool", []),
+      )
+
       dynamic "workload_metadata_config" {
         for_each = local.cluster_node_metadata_config
 

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -257,7 +257,7 @@ resource "google_container_cluster" "primary" {
         lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
         lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
         lookup(local.node_pools_tags, "all", []),
-        lookup(local.node_pools_tags, "default-pool", []),
+        lookup(local.node_pools_tags, var.node_pools[0].name, []),
       )
 
       dynamic "workload_metadata_config" {

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -253,6 +253,13 @@ resource "google_container_cluster" "primary" {
 
       service_account = lookup(var.node_pools[0], "service_account", local.service_account)
 
+      tags = concat(
+        lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
+        lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
+        lookup(local.node_pools_tags, "all", []),
+        lookup(local.node_pools_tags, "default-pool", []),
+      )
+
       dynamic "workload_metadata_config" {
         for_each = local.cluster_node_metadata_config
 

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -257,7 +257,7 @@ resource "google_container_cluster" "primary" {
         lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
         lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
         lookup(local.node_pools_tags, "all", []),
-        lookup(local.node_pools_tags, "default-pool", []),
+        lookup(local.node_pools_tags, var.node_pools[0].name, []),
       )
 
       dynamic "workload_metadata_config" {

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -253,6 +253,13 @@ resource "google_container_cluster" "primary" {
 
       service_account = lookup(var.node_pools[0], "service_account", local.service_account)
 
+      tags = concat(
+        lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
+        lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
+        lookup(local.node_pools_tags, "all", []),
+        lookup(local.node_pools_tags, "default-pool", []),
+      )
+
       dynamic "workload_metadata_config" {
         for_each = local.cluster_node_metadata_config
 

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -257,7 +257,7 @@ resource "google_container_cluster" "primary" {
         lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
         lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
         lookup(local.node_pools_tags, "all", []),
-        lookup(local.node_pools_tags, "default-pool", []),
+        lookup(local.node_pools_tags, var.node_pools[0].name, []),
       )
 
       dynamic "workload_metadata_config" {

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -253,6 +253,13 @@ resource "google_container_cluster" "primary" {
 
       service_account = lookup(var.node_pools[0], "service_account", local.service_account)
 
+      tags = concat(
+        lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
+        lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
+        lookup(local.node_pools_tags, "all", []),
+        lookup(local.node_pools_tags, "default-pool", []),
+      )
+
       dynamic "workload_metadata_config" {
         for_each = local.cluster_node_metadata_config
 

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -257,7 +257,7 @@ resource "google_container_cluster" "primary" {
         lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
         lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
         lookup(local.node_pools_tags, "all", []),
-        lookup(local.node_pools_tags, "default-pool", []),
+        lookup(local.node_pools_tags, var.node_pools[0].name, []),
       )
 
       dynamic "workload_metadata_config" {

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -253,6 +253,13 @@ resource "google_container_cluster" "primary" {
 
       service_account = lookup(var.node_pools[0], "service_account", local.service_account)
 
+      tags = concat(
+        lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
+        lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
+        lookup(local.node_pools_tags, "all", []),
+        lookup(local.node_pools_tags, "default-pool", []),
+      )
+
       dynamic "workload_metadata_config" {
         for_each = local.cluster_node_metadata_config
 

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -156,7 +156,7 @@ resource "google_container_cluster" "primary" {
         lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
         lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
         lookup(local.node_pools_tags, "all", []),
-        lookup(local.node_pools_tags, "default-pool", []),
+        lookup(local.node_pools_tags, var.node_pools[0].name, []),
       )
 
       dynamic "workload_metadata_config" {

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -152,6 +152,13 @@ resource "google_container_cluster" "primary" {
 
       service_account = lookup(var.node_pools[0], "service_account", local.service_account)
 
+      tags = concat(
+        lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
+        lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
+        lookup(local.node_pools_tags, "all", []),
+        lookup(local.node_pools_tags, "default-pool", []),
+      )
+
       dynamic "workload_metadata_config" {
         for_each = local.cluster_node_metadata_config
 

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -156,7 +156,7 @@ resource "google_container_cluster" "primary" {
         lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
         lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
         lookup(local.node_pools_tags, "all", []),
-        lookup(local.node_pools_tags, "default-pool", []),
+        lookup(local.node_pools_tags, var.node_pools[0].name, []),
       )
 
       dynamic "workload_metadata_config" {

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -152,6 +152,13 @@ resource "google_container_cluster" "primary" {
 
       service_account = lookup(var.node_pools[0], "service_account", local.service_account)
 
+      tags = concat(
+        lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
+        lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
+        lookup(local.node_pools_tags, "all", []),
+        lookup(local.node_pools_tags, "default-pool", []),
+      )
+
       dynamic "workload_metadata_config" {
         for_each = local.cluster_node_metadata_config
 


### PR DESCRIPTION
Addresses #1118.

This will apply the following tags to the default node pool:
* the [`cluster_network_tag`](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/c2dbc6f8aabbfc722a56e6a56e7121e3fbe6826a/autogen/main/main.tf.tmpl#L167) (`gke-${var.name}`)
* the pool variant of the `cluster_network_tag` (`gke-${var.name}-default-pool`)
* user-specified tags in `var.node_pools_tags["all"]`
* user-specified tags in `var.node_pools_tags["default-pool"]`

This may be needed for private clusters in VPC networks with a "default-deny-all" firewall rule that use network tags to define exceptions for e.g., egress to the `master_ipv4_cidr_block`.

Two quick notes/questions:
* I deviated slightly from @morgante's [suggestion](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1118#issuecomment-1009633635) in the related issue (adding the network tags from the first pool in the cluster config like for the [service account](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/14a0536bbcfeb89dc1af21f8fef0cb46affdc52e/autogen/main/cluster.tf.tmpl#L289)): `node_pools_tags` is a map-of-lists unlike `node_pools`, which is a list-of-maps. The "first" pool here wouldn't be well defined -- I think the approach I went with is more natural in any case.
* Are there any existing tests where we'd like to add coverage for this?
  * It's unfortunately a bit difficult for me to spin up tests as described in [CONTRIBUTING.md](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/master/CONTRIBUTING.md#test-environment) (we have an org policy that blocks the creation of service account keys), so I'm afraid the only testing I have of the above is manually spinning up an instance in our existing env and confirming that it contained the desired tags.
  * For some tests it seems like I could add an `it "has the expected network tags" do` block to the default pool checks (e.g., [simple_regional](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/14a0536bbcfeb89dc1af21f8fef0cb46affdc52e/test/integration/simple_regional/controls/gcloud.rb#L78))