### PR TITLE
fix: Create separate firewall rule for egress to TPUs

### DIFF
--- a/autogen/main/firewall.tf.tmpl
+++ b/autogen/main/firewall.tf.tmpl
@@ -34,20 +34,11 @@ resource "google_compute_firewall" "intra_egress" {
   direction   = "EGRESS"
 
   target_tags = [local.cluster_network_tag]
-  {% if beta_cluster %}
-  destination_ranges = compact([
-    local.cluster_endpoint_for_nodes,
-    local.cluster_subnet_cidr,
-    local.cluster_alias_ranges_cidr[var.ip_range_pods],
-    google_container_cluster.primary.tpu_ipv4_cidr_block,
-  ])
-  {% else %}
   destination_ranges = [
     local.cluster_endpoint_for_nodes,
     local.cluster_subnet_cidr,
     local.cluster_alias_ranges_cidr[var.ip_range_pods],
   ]
-  {% endif %}
 
   # Allow all possible protocols
   allow { protocol = "tcp" }
@@ -65,6 +56,46 @@ resource "google_compute_firewall" "intra_egress" {
 }
 
 
+{% if beta_cluster %}
+/******************************************
+  Allow egress to the TPU IPv4 CIDR block
+
+  This rule is defined separately from the
+  intra_egress rule above since it requires
+  an output from the google_container_cluster
+  resource.
+
+  https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1124
+ *****************************************/
+resource "google_compute_firewall" "tpu_egress" {
+  count       = var.add_cluster_firewall_rules && var.enable_tpu ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-tpu-egress"
+  description = "Managed by terraform gke module: Allow pods to communicate with TPUs"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "EGRESS"
+
+  target_tags        = [local.cluster_network_tag]
+  destination_ranges = [google_container_cluster.primary.tpu_ipv4_cidr_block]
+
+  # Allow all possible protocols
+  allow { protocol = "tcp" }
+  allow { protocol = "udp" }
+  allow { protocol = "icmp" }
+  allow { protocol = "sctp" }
+  allow { protocol = "esp" }
+  allow { protocol = "ah" }
+
+  {% if not private_cluster %}
+  depends_on = [
+    google_container_cluster.primary,
+  ]
+  {% endif %}
+}
+
+
+{% endif %}
 /******************************************
   Allow GKE master to hit non 443 ports for
   Webhooks/Admission Controllers

--- a/modules/beta-private-cluster-update-variant/firewall.tf
+++ b/modules/beta-private-cluster-update-variant/firewall.tf
@@ -34,12 +34,44 @@ resource "google_compute_firewall" "intra_egress" {
   direction   = "EGRESS"
 
   target_tags = [local.cluster_network_tag]
-  destination_ranges = compact([
+  destination_ranges = [
     local.cluster_endpoint_for_nodes,
     local.cluster_subnet_cidr,
     local.cluster_alias_ranges_cidr[var.ip_range_pods],
-    google_container_cluster.primary.tpu_ipv4_cidr_block,
-  ])
+  ]
+
+  # Allow all possible protocols
+  allow { protocol = "tcp" }
+  allow { protocol = "udp" }
+  allow { protocol = "icmp" }
+  allow { protocol = "sctp" }
+  allow { protocol = "esp" }
+  allow { protocol = "ah" }
+
+}
+
+
+/******************************************
+  Allow egress to the TPU IPv4 CIDR block
+
+  This rule is defined separately from the
+  intra_egress rule above since it requires
+  an output from the google_container_cluster
+  resource.
+
+  https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1124
+ *****************************************/
+resource "google_compute_firewall" "tpu_egress" {
+  count       = var.add_cluster_firewall_rules && var.enable_tpu ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-tpu-egress"
+  description = "Managed by terraform gke module: Allow pods to communicate with TPUs"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "EGRESS"
+
+  target_tags        = [local.cluster_network_tag]
+  destination_ranges = [google_container_cluster.primary.tpu_ipv4_cidr_block]
 
   # Allow all possible protocols
   allow { protocol = "tcp" }

--- a/modules/beta-private-cluster/firewall.tf
+++ b/modules/beta-private-cluster/firewall.tf
@@ -34,12 +34,44 @@ resource "google_compute_firewall" "intra_egress" {
   direction   = "EGRESS"
 
   target_tags = [local.cluster_network_tag]
-  destination_ranges = compact([
+  destination_ranges = [
     local.cluster_endpoint_for_nodes,
     local.cluster_subnet_cidr,
     local.cluster_alias_ranges_cidr[var.ip_range_pods],
-    google_container_cluster.primary.tpu_ipv4_cidr_block,
-  ])
+  ]
+
+  # Allow all possible protocols
+  allow { protocol = "tcp" }
+  allow { protocol = "udp" }
+  allow { protocol = "icmp" }
+  allow { protocol = "sctp" }
+  allow { protocol = "esp" }
+  allow { protocol = "ah" }
+
+}
+
+
+/******************************************
+  Allow egress to the TPU IPv4 CIDR block
+
+  This rule is defined separately from the
+  intra_egress rule above since it requires
+  an output from the google_container_cluster
+  resource.
+
+  https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1124
+ *****************************************/
+resource "google_compute_firewall" "tpu_egress" {
+  count       = var.add_cluster_firewall_rules && var.enable_tpu ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-tpu-egress"
+  description = "Managed by terraform gke module: Allow pods to communicate with TPUs"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "EGRESS"
+
+  target_tags        = [local.cluster_network_tag]
+  destination_ranges = [google_container_cluster.primary.tpu_ipv4_cidr_block]
 
   # Allow all possible protocols
   allow { protocol = "tcp" }

--- a/modules/beta-public-cluster-update-variant/firewall.tf
+++ b/modules/beta-public-cluster-update-variant/firewall.tf
@@ -34,12 +34,47 @@ resource "google_compute_firewall" "intra_egress" {
   direction   = "EGRESS"
 
   target_tags = [local.cluster_network_tag]
-  destination_ranges = compact([
+  destination_ranges = [
     local.cluster_endpoint_for_nodes,
     local.cluster_subnet_cidr,
     local.cluster_alias_ranges_cidr[var.ip_range_pods],
-    google_container_cluster.primary.tpu_ipv4_cidr_block,
-  ])
+  ]
+
+  # Allow all possible protocols
+  allow { protocol = "tcp" }
+  allow { protocol = "udp" }
+  allow { protocol = "icmp" }
+  allow { protocol = "sctp" }
+  allow { protocol = "esp" }
+  allow { protocol = "ah" }
+
+  depends_on = [
+    google_container_cluster.primary,
+  ]
+}
+
+
+/******************************************
+  Allow egress to the TPU IPv4 CIDR block
+
+  This rule is defined separately from the
+  intra_egress rule above since it requires
+  an output from the google_container_cluster
+  resource.
+
+  https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1124
+ *****************************************/
+resource "google_compute_firewall" "tpu_egress" {
+  count       = var.add_cluster_firewall_rules && var.enable_tpu ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-tpu-egress"
+  description = "Managed by terraform gke module: Allow pods to communicate with TPUs"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "EGRESS"
+
+  target_tags        = [local.cluster_network_tag]
+  destination_ranges = [google_container_cluster.primary.tpu_ipv4_cidr_block]
 
   # Allow all possible protocols
   allow { protocol = "tcp" }

--- a/modules/beta-public-cluster/firewall.tf
+++ b/modules/beta-public-cluster/firewall.tf
@@ -34,12 +34,47 @@ resource "google_compute_firewall" "intra_egress" {
   direction   = "EGRESS"
 
   target_tags = [local.cluster_network_tag]
-  destination_ranges = compact([
+  destination_ranges = [
     local.cluster_endpoint_for_nodes,
     local.cluster_subnet_cidr,
     local.cluster_alias_ranges_cidr[var.ip_range_pods],
-    google_container_cluster.primary.tpu_ipv4_cidr_block,
-  ])
+  ]
+
+  # Allow all possible protocols
+  allow { protocol = "tcp" }
+  allow { protocol = "udp" }
+  allow { protocol = "icmp" }
+  allow { protocol = "sctp" }
+  allow { protocol = "esp" }
+  allow { protocol = "ah" }
+
+  depends_on = [
+    google_container_cluster.primary,
+  ]
+}
+
+
+/******************************************
+  Allow egress to the TPU IPv4 CIDR block
+
+  This rule is defined separately from the
+  intra_egress rule above since it requires
+  an output from the google_container_cluster
+  resource.
+
+  https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1124
+ *****************************************/
+resource "google_compute_firewall" "tpu_egress" {
+  count       = var.add_cluster_firewall_rules && var.enable_tpu ? 1 : 0
+  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-tpu-egress"
+  description = "Managed by terraform gke module: Allow pods to communicate with TPUs"
+  project     = local.network_project_id
+  network     = var.network
+  priority    = var.firewall_priority
+  direction   = "EGRESS"
+
+  target_tags        = [local.cluster_network_tag]
+  destination_ranges = [google_container_cluster.primary.tpu_ipv4_cidr_block]
 
   # Allow all possible protocols
   allow { protocol = "tcp" }


### PR DESCRIPTION
Addresses #1124.

I bumped into this when trying to create a `safer-cluster` in a VPC network with a default deny egress rule. The `intra_egress` firewall rule was required to allow the default pool to report back to the control plane so it could be deleted (as part of the `google_container_cluster.primary` create operation).

However, the `intra_egress` firewall rule had a Terraform dependency on the `google_container_cluster.primary` resource, so it was never created, preventing the cluster from creating successfully.

This PR simply creates a separate rule for egress to the `tpu_ipv4_cidr_block`, allowing the `intra_egress` rule to get created before the `google_container_cluster` resource.