### PR TITLE
chore: fix test setup

### DIFF
--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -75,10 +75,8 @@ module "gke-project-2" {
 
 # apis as documented https://cloud.google.com/service-mesh/docs/scripted-install/reference#setting_up_your_project
 module "gke-project-asm" {
-  source = "github.com/terraform-google-modules/terraform-google-project-factory.git?ref=master"
-
-  #source  = "terraform-google-modules/project-factory/google"
-  #version = "~> 11.3"
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 11.3"
 
   name              = "ci-gke-asm-${random_id.random_project_id_suffix.hex}"
   random_project_id = true


### PR DESCRIPTION
Looks like I forgot to switch this back in https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/1129 and this pf feature bumped required providers