### PR TITLE
Fix asm module variable descriptions

### DIFF
--- a/modules/asm/variables.tf
+++ b/modules/asm/variables.tf
@@ -76,13 +76,13 @@ variable "enable_vpc_sc" {
 }
 
 variable "enable_fleet_registration" {
-  description = "Determines whether the module enables the mesh feature on the fleet."
+  description = "Determines whether the module registers the cluster to the fleet."
   type        = bool
   default     = false
 }
 
 variable "enable_mesh_feature" {
-  description = "Determines whether the module registers the cluster to the fleet."
+  description = "Determines whether the module enables the mesh feature on the fleet."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
The variable descriptions for `enable_fleet_registration` and `enable_mesh_feature` swapped