### PR TITLE
Apply applicable ASM_OPTS in config_map

### DIFF
--- a/modules/asm/main.tf
+++ b/modules/asm/main.tf
@@ -45,6 +45,7 @@ resource "kubernetes_config_map" "asm_options" {
 
   data = {
     multicluster_mode = var.multicluster_mode
+    ASM_OPTS          = var.enable_cni ? "CNI=on" : null
   }
 
   depends_on = [google_gke_hub_membership.membership, google_gke_hub_feature.mesh]


### PR DESCRIPTION
[In autopilot clusters,] subsequent terraform runs overwrite the `ASM_OPTS: "CNI=on"` value in the asm_option config map. This prevents new or restating workloads from being scheduled as the proxy tries to cap add NET_ADMIN on start. This PR conditionally adds the expected setting.