### PR TITLE
Make GKE module cluster_name computed attribute

### DIFF
--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -177,7 +177,7 @@ locals {
   cluster_name                               = local.cluster_output_name
   {% if autopilot_cluster != true %}
   // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", google_container_node_pool.pools.0.id), length(split("/", google_container_node_pool.pools.0.id)) - 2)
+  cluster_name_computed                      = element(split("/", element(google_container_node_pool.pools[*].id, 0)), length(split("/", element(google_container_node_pool.pools[*].id, 0))) - 2)
   {% else %}
   // cluster ID is in the form project/location/name
   cluster_name_computed                      = element(split("/", local.cluster_id), length(split("/", local.cluster_id)) - 1)

--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -174,7 +174,6 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name                               = local.cluster_output_name
   {% if autopilot_cluster != true %}
   // node pool ID is in the form projects/<project-id>/locations/<location>/clusters/<cluster-name>/nodePools/<nodepool-name>
   cluster_name_parts_from_nodepool           = split("/", element(values(google_container_node_pool.pools)[*].id, 0))

--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -177,7 +177,7 @@ locals {
   cluster_name                               = local.cluster_output_name
   {% if autopilot_cluster != true %}
   // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", element(google_container_node_pool.pools[*].id, 0)), length(split("/", element(google_container_node_pool.pools[*].id, 0))) - 2)
+  cluster_name_computed                      = element(split("/", element(values(google_container_node_pool.pools)[*].id, 0)), length(split("/", element(values(google_container_node_pool.pools)[*].id, 0))) - 3)
   {% else %}
   // cluster ID is in the form project/location/name
   cluster_name_computed                      = element(split("/", local.cluster_id), length(split("/", local.cluster_id)) - 1)

--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -176,8 +176,9 @@ locals {
 
   cluster_name                               = local.cluster_output_name
   {% if autopilot_cluster != true %}
-  // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", element(values(google_container_node_pool.pools)[*].id, 0)), length(split("/", element(values(google_container_node_pool.pools)[*].id, 0))) - 3)
+  // node pool ID is in the form projects/<project-id>/locations/<location>/clusters/<cluster-name>/nodePools/<nodepool-name>
+  cluster_name_parts_from_nodepool           = split("/", element(values(google_container_node_pool.pools)[*].id, 0))
+  cluster_name_computed                      = element(local.cluster_name_parts_from_nodepool, length(local.cluster_name_parts_from_nodepool) - 3)
   {% else %}
   // cluster ID is in the form project/location/name
   cluster_name_computed                      = element(split("/", local.cluster_id), length(split("/", local.cluster_id)) - 1)

--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -175,6 +175,13 @@ locals {
   cluster_zones    = sort(local.cluster_output_zones)
 
   cluster_name                               = local.cluster_output_name
+  {% if autopilot_cluster != true %}
+  // node pool ID is in the form project/location/cluster/name
+  cluster_name_computed                      = element(split("/", google_container_node_pool.pools.0.id), length(split("/", google_container_node_pool.pools.0.id)) - 2)
+  {% else %}
+  // cluster ID is in the form project/location/name
+  cluster_name_computed                      = element(split("/", local.cluster_id), length(split("/", local.cluster_id)) - 1)
+  {% endif %}
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/autogen/main/outputs.tf.tmpl
+++ b/autogen/main/outputs.tf.tmpl
@@ -23,7 +23,7 @@ output "cluster_id" {
 
 output "name" {
   description = "Cluster name"
-  value       = local.cluster_name
+  value       = local.cluster_name_computed
   depends_on = [
     /* Nominally, the cluster name is populated as soon as it is known to Terraform.
     * However, the cluster may not be in a usable state yet.  Therefore any

--- a/autogen/main/outputs.tf.tmpl
+++ b/autogen/main/outputs.tf.tmpl
@@ -24,6 +24,18 @@ output "cluster_id" {
 output "name" {
   description = "Cluster name"
   value       = local.cluster_name
+  depends_on = [
+    /* Nominally, the cluster name is populated as soon as it is known to Terraform.
+    * However, the cluster may not be in a usable state yet.  Therefore any
+    * resources dependent on the cluster being up will fail to deploy.  With
+    * this explicit dependency, dependent resources can wait for the cluster
+    * to be up.
+    */
+    google_container_cluster.primary,
+    {% if autopilot_cluster != true %}
+    google_container_node_pool.pools,
+    {% endif %}
+  ]
 }
 
 output "type" {

--- a/examples/simple_zonal_with_asm/main.tf
+++ b/examples/simple_zonal_with_asm/main.tf
@@ -33,7 +33,7 @@ data "google_project" "project" {
 module "gke" {
   source                  = "../../"
   project_id              = var.project_id
-  name                    = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
+  name                    = "test-prefix-cluster-test-suffix"
   regional                = false
   region                  = var.region
   zones                   = var.zones

--- a/main.tf
+++ b/main.tf
@@ -125,8 +125,9 @@ locals {
   cluster_zones    = sort(local.cluster_output_zones)
 
   cluster_name = local.cluster_output_name
-  // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", element(values(google_container_node_pool.pools)[*].id, 0)), length(split("/", element(values(google_container_node_pool.pools)[*].id, 0))) - 3)
+  // node pool ID is in the form projects/<project-id>/locations/<location>/clusters/<cluster-name>/nodePools/<nodepool-name>
+  cluster_name_parts_from_nodepool           = split("/", element(values(google_container_node_pool.pools)[*].id, 0))
+  cluster_name_computed                      = element(local.cluster_name_parts_from_nodepool, length(local.cluster_name_parts_from_nodepool) - 3)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/main.tf
+++ b/main.tf
@@ -126,7 +126,7 @@ locals {
 
   cluster_name = local.cluster_output_name
   // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", google_container_node_pool.pools.0.id), length(split("/", google_container_node_pool.pools.0.id)) - 2)
+  cluster_name_computed                      = element(split("/", element(google_container_node_pool.pools[*].id, 0)), length(split("/", element(google_container_node_pool.pools[*].id, 0))) - 2)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/main.tf
+++ b/main.tf
@@ -126,7 +126,7 @@ locals {
 
   cluster_name = local.cluster_output_name
   // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", element(google_container_node_pool.pools[*].id, 0)), length(split("/", element(google_container_node_pool.pools[*].id, 0))) - 2)
+  cluster_name_computed                      = element(split("/", element(values(google_container_node_pool.pools)[*].id, 0)), length(split("/", element(values(google_container_node_pool.pools)[*].id, 0))) - 3)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,6 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name = local.cluster_output_name
   // node pool ID is in the form projects/<project-id>/locations/<location>/clusters/<cluster-name>/nodePools/<nodepool-name>
   cluster_name_parts_from_nodepool           = split("/", element(values(google_container_node_pool.pools)[*].id, 0))
   cluster_name_computed                      = element(local.cluster_name_parts_from_nodepool, length(local.cluster_name_parts_from_nodepool) - 3)

--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,9 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name                               = local.cluster_output_name
+  cluster_name = local.cluster_output_name
+  // node pool ID is in the form project/location/cluster/name
+  cluster_name_computed                      = element(split("/", google_container_node_pool.pools.0.id), length(split("/", google_container_node_pool.pools.0.id)) - 2)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/asm/README.md
+++ b/modules/asm/README.md
@@ -14,7 +14,7 @@ There is a full example provided [here](../../examples/simple_zonal_with_asm). D
 
 ```tf
 module "asm" {
-  source            = "../../modules/asm"
+  source            = "terraform-google-modules/kubernetes-engine/google//modules/asm"
   project_id        = var.project_id
   cluster_name      = module.gke.name
   cluster_location  = module.gke.location

--- a/modules/beta-autopilot-private-cluster/main.tf
+++ b/modules/beta-autopilot-private-cluster/main.tf
@@ -107,7 +107,9 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name                               = local.cluster_output_name
+  cluster_name = local.cluster_output_name
+  // cluster ID is in the form project/location/name
+  cluster_name_computed                      = element(split("/", local.cluster_id), length(split("/", local.cluster_id)) - 1)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/beta-autopilot-private-cluster/main.tf
+++ b/modules/beta-autopilot-private-cluster/main.tf
@@ -107,7 +107,6 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name = local.cluster_output_name
   // cluster ID is in the form project/location/name
   cluster_name_computed                      = element(split("/", local.cluster_id), length(split("/", local.cluster_id)) - 1)
   cluster_network_tag                        = "gke-${var.name}"

--- a/modules/beta-autopilot-private-cluster/outputs.tf
+++ b/modules/beta-autopilot-private-cluster/outputs.tf
@@ -23,7 +23,7 @@ output "cluster_id" {
 
 output "name" {
   description = "Cluster name"
-  value       = local.cluster_name
+  value       = local.cluster_name_computed
   depends_on = [
     /* Nominally, the cluster name is populated as soon as it is known to Terraform.
     * However, the cluster may not be in a usable state yet.  Therefore any

--- a/modules/beta-autopilot-private-cluster/outputs.tf
+++ b/modules/beta-autopilot-private-cluster/outputs.tf
@@ -24,6 +24,15 @@ output "cluster_id" {
 output "name" {
   description = "Cluster name"
   value       = local.cluster_name
+  depends_on = [
+    /* Nominally, the cluster name is populated as soon as it is known to Terraform.
+    * However, the cluster may not be in a usable state yet.  Therefore any
+    * resources dependent on the cluster being up will fail to deploy.  With
+    * this explicit dependency, dependent resources can wait for the cluster
+    * to be up.
+    */
+    google_container_cluster.primary,
+  ]
 }
 
 output "type" {

--- a/modules/beta-autopilot-public-cluster/main.tf
+++ b/modules/beta-autopilot-public-cluster/main.tf
@@ -106,7 +106,9 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name                               = local.cluster_output_name
+  cluster_name = local.cluster_output_name
+  // cluster ID is in the form project/location/name
+  cluster_name_computed                      = element(split("/", local.cluster_id), length(split("/", local.cluster_id)) - 1)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/beta-autopilot-public-cluster/main.tf
+++ b/modules/beta-autopilot-public-cluster/main.tf
@@ -106,7 +106,6 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name = local.cluster_output_name
   // cluster ID is in the form project/location/name
   cluster_name_computed                      = element(split("/", local.cluster_id), length(split("/", local.cluster_id)) - 1)
   cluster_network_tag                        = "gke-${var.name}"

--- a/modules/beta-autopilot-public-cluster/outputs.tf
+++ b/modules/beta-autopilot-public-cluster/outputs.tf
@@ -23,7 +23,7 @@ output "cluster_id" {
 
 output "name" {
   description = "Cluster name"
-  value       = local.cluster_name
+  value       = local.cluster_name_computed
   depends_on = [
     /* Nominally, the cluster name is populated as soon as it is known to Terraform.
     * However, the cluster may not be in a usable state yet.  Therefore any

--- a/modules/beta-autopilot-public-cluster/outputs.tf
+++ b/modules/beta-autopilot-public-cluster/outputs.tf
@@ -24,6 +24,15 @@ output "cluster_id" {
 output "name" {
   description = "Cluster name"
   value       = local.cluster_name
+  depends_on = [
+    /* Nominally, the cluster name is populated as soon as it is known to Terraform.
+    * However, the cluster may not be in a usable state yet.  Therefore any
+    * resources dependent on the cluster being up will fail to deploy.  With
+    * this explicit dependency, dependent resources can wait for the cluster
+    * to be up.
+    */
+    google_container_cluster.primary,
+  ]
 }
 
 output "type" {

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -147,7 +147,9 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name                               = local.cluster_output_name
+  cluster_name = local.cluster_output_name
+  // node pool ID is in the form project/location/cluster/name
+  cluster_name_computed                      = element(split("/", google_container_node_pool.pools.0.id), length(split("/", google_container_node_pool.pools.0.id)) - 2)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -147,7 +147,6 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name = local.cluster_output_name
   // node pool ID is in the form projects/<project-id>/locations/<location>/clusters/<cluster-name>/nodePools/<nodepool-name>
   cluster_name_parts_from_nodepool           = split("/", element(values(google_container_node_pool.pools)[*].id, 0))
   cluster_name_computed                      = element(local.cluster_name_parts_from_nodepool, length(local.cluster_name_parts_from_nodepool) - 3)

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -148,8 +148,9 @@ locals {
   cluster_zones    = sort(local.cluster_output_zones)
 
   cluster_name = local.cluster_output_name
-  // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", element(values(google_container_node_pool.pools)[*].id, 0)), length(split("/", element(values(google_container_node_pool.pools)[*].id, 0))) - 3)
+  // node pool ID is in the form projects/<project-id>/locations/<location>/clusters/<cluster-name>/nodePools/<nodepool-name>
+  cluster_name_parts_from_nodepool           = split("/", element(values(google_container_node_pool.pools)[*].id, 0))
+  cluster_name_computed                      = element(local.cluster_name_parts_from_nodepool, length(local.cluster_name_parts_from_nodepool) - 3)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -149,7 +149,7 @@ locals {
 
   cluster_name = local.cluster_output_name
   // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", google_container_node_pool.pools.0.id), length(split("/", google_container_node_pool.pools.0.id)) - 2)
+  cluster_name_computed                      = element(split("/", element(google_container_node_pool.pools[*].id, 0)), length(split("/", element(google_container_node_pool.pools[*].id, 0))) - 2)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -149,7 +149,7 @@ locals {
 
   cluster_name = local.cluster_output_name
   // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", element(google_container_node_pool.pools[*].id, 0)), length(split("/", element(google_container_node_pool.pools[*].id, 0))) - 2)
+  cluster_name_computed                      = element(split("/", element(values(google_container_node_pool.pools)[*].id, 0)), length(split("/", element(values(google_container_node_pool.pools)[*].id, 0))) - 3)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/beta-private-cluster-update-variant/outputs.tf
+++ b/modules/beta-private-cluster-update-variant/outputs.tf
@@ -23,7 +23,7 @@ output "cluster_id" {
 
 output "name" {
   description = "Cluster name"
-  value       = local.cluster_name
+  value       = local.cluster_name_computed
   depends_on = [
     /* Nominally, the cluster name is populated as soon as it is known to Terraform.
     * However, the cluster may not be in a usable state yet.  Therefore any

--- a/modules/beta-private-cluster-update-variant/outputs.tf
+++ b/modules/beta-private-cluster-update-variant/outputs.tf
@@ -24,6 +24,16 @@ output "cluster_id" {
 output "name" {
   description = "Cluster name"
   value       = local.cluster_name
+  depends_on = [
+    /* Nominally, the cluster name is populated as soon as it is known to Terraform.
+    * However, the cluster may not be in a usable state yet.  Therefore any
+    * resources dependent on the cluster being up will fail to deploy.  With
+    * this explicit dependency, dependent resources can wait for the cluster
+    * to be up.
+    */
+    google_container_cluster.primary,
+    google_container_node_pool.pools,
+  ]
 }
 
 output "type" {

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -147,7 +147,9 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name                               = local.cluster_output_name
+  cluster_name = local.cluster_output_name
+  // node pool ID is in the form project/location/cluster/name
+  cluster_name_computed                      = element(split("/", google_container_node_pool.pools.0.id), length(split("/", google_container_node_pool.pools.0.id)) - 2)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -147,7 +147,6 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name = local.cluster_output_name
   // node pool ID is in the form projects/<project-id>/locations/<location>/clusters/<cluster-name>/nodePools/<nodepool-name>
   cluster_name_parts_from_nodepool           = split("/", element(values(google_container_node_pool.pools)[*].id, 0))
   cluster_name_computed                      = element(local.cluster_name_parts_from_nodepool, length(local.cluster_name_parts_from_nodepool) - 3)

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -148,8 +148,9 @@ locals {
   cluster_zones    = sort(local.cluster_output_zones)
 
   cluster_name = local.cluster_output_name
-  // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", element(values(google_container_node_pool.pools)[*].id, 0)), length(split("/", element(values(google_container_node_pool.pools)[*].id, 0))) - 3)
+  // node pool ID is in the form projects/<project-id>/locations/<location>/clusters/<cluster-name>/nodePools/<nodepool-name>
+  cluster_name_parts_from_nodepool           = split("/", element(values(google_container_node_pool.pools)[*].id, 0))
+  cluster_name_computed                      = element(local.cluster_name_parts_from_nodepool, length(local.cluster_name_parts_from_nodepool) - 3)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -149,7 +149,7 @@ locals {
 
   cluster_name = local.cluster_output_name
   // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", google_container_node_pool.pools.0.id), length(split("/", google_container_node_pool.pools.0.id)) - 2)
+  cluster_name_computed                      = element(split("/", element(google_container_node_pool.pools[*].id, 0)), length(split("/", element(google_container_node_pool.pools[*].id, 0))) - 2)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -149,7 +149,7 @@ locals {
 
   cluster_name = local.cluster_output_name
   // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", element(google_container_node_pool.pools[*].id, 0)), length(split("/", element(google_container_node_pool.pools[*].id, 0))) - 2)
+  cluster_name_computed                      = element(split("/", element(values(google_container_node_pool.pools)[*].id, 0)), length(split("/", element(values(google_container_node_pool.pools)[*].id, 0))) - 3)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/beta-private-cluster/outputs.tf
+++ b/modules/beta-private-cluster/outputs.tf
@@ -23,7 +23,7 @@ output "cluster_id" {
 
 output "name" {
   description = "Cluster name"
-  value       = local.cluster_name
+  value       = local.cluster_name_computed
   depends_on = [
     /* Nominally, the cluster name is populated as soon as it is known to Terraform.
     * However, the cluster may not be in a usable state yet.  Therefore any

--- a/modules/beta-private-cluster/outputs.tf
+++ b/modules/beta-private-cluster/outputs.tf
@@ -24,6 +24,16 @@ output "cluster_id" {
 output "name" {
   description = "Cluster name"
   value       = local.cluster_name
+  depends_on = [
+    /* Nominally, the cluster name is populated as soon as it is known to Terraform.
+    * However, the cluster may not be in a usable state yet.  Therefore any
+    * resources dependent on the cluster being up will fail to deploy.  With
+    * this explicit dependency, dependent resources can wait for the cluster
+    * to be up.
+    */
+    google_container_cluster.primary,
+    google_container_node_pool.pools,
+  ]
 }
 
 output "type" {

--- a/modules/beta-public-cluster-update-variant/main.tf
+++ b/modules/beta-public-cluster-update-variant/main.tf
@@ -147,8 +147,9 @@ locals {
   cluster_zones    = sort(local.cluster_output_zones)
 
   cluster_name = local.cluster_output_name
-  // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", element(values(google_container_node_pool.pools)[*].id, 0)), length(split("/", element(values(google_container_node_pool.pools)[*].id, 0))) - 3)
+  // node pool ID is in the form projects/<project-id>/locations/<location>/clusters/<cluster-name>/nodePools/<nodepool-name>
+  cluster_name_parts_from_nodepool           = split("/", element(values(google_container_node_pool.pools)[*].id, 0))
+  cluster_name_computed                      = element(local.cluster_name_parts_from_nodepool, length(local.cluster_name_parts_from_nodepool) - 3)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/beta-public-cluster-update-variant/main.tf
+++ b/modules/beta-public-cluster-update-variant/main.tf
@@ -146,7 +146,6 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name = local.cluster_output_name
   // node pool ID is in the form projects/<project-id>/locations/<location>/clusters/<cluster-name>/nodePools/<nodepool-name>
   cluster_name_parts_from_nodepool           = split("/", element(values(google_container_node_pool.pools)[*].id, 0))
   cluster_name_computed                      = element(local.cluster_name_parts_from_nodepool, length(local.cluster_name_parts_from_nodepool) - 3)

--- a/modules/beta-public-cluster-update-variant/main.tf
+++ b/modules/beta-public-cluster-update-variant/main.tf
@@ -148,7 +148,7 @@ locals {
 
   cluster_name = local.cluster_output_name
   // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", google_container_node_pool.pools.0.id), length(split("/", google_container_node_pool.pools.0.id)) - 2)
+  cluster_name_computed                      = element(split("/", element(google_container_node_pool.pools[*].id, 0)), length(split("/", element(google_container_node_pool.pools[*].id, 0))) - 2)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/beta-public-cluster-update-variant/main.tf
+++ b/modules/beta-public-cluster-update-variant/main.tf
@@ -148,7 +148,7 @@ locals {
 
   cluster_name = local.cluster_output_name
   // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", element(google_container_node_pool.pools[*].id, 0)), length(split("/", element(google_container_node_pool.pools[*].id, 0))) - 2)
+  cluster_name_computed                      = element(split("/", element(values(google_container_node_pool.pools)[*].id, 0)), length(split("/", element(values(google_container_node_pool.pools)[*].id, 0))) - 3)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/beta-public-cluster-update-variant/main.tf
+++ b/modules/beta-public-cluster-update-variant/main.tf
@@ -146,7 +146,9 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name                               = local.cluster_output_name
+  cluster_name = local.cluster_output_name
+  // node pool ID is in the form project/location/cluster/name
+  cluster_name_computed                      = element(split("/", google_container_node_pool.pools.0.id), length(split("/", google_container_node_pool.pools.0.id)) - 2)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/beta-public-cluster-update-variant/outputs.tf
+++ b/modules/beta-public-cluster-update-variant/outputs.tf
@@ -23,7 +23,7 @@ output "cluster_id" {
 
 output "name" {
   description = "Cluster name"
-  value       = local.cluster_name
+  value       = local.cluster_name_computed
   depends_on = [
     /* Nominally, the cluster name is populated as soon as it is known to Terraform.
     * However, the cluster may not be in a usable state yet.  Therefore any

--- a/modules/beta-public-cluster-update-variant/outputs.tf
+++ b/modules/beta-public-cluster-update-variant/outputs.tf
@@ -24,6 +24,16 @@ output "cluster_id" {
 output "name" {
   description = "Cluster name"
   value       = local.cluster_name
+  depends_on = [
+    /* Nominally, the cluster name is populated as soon as it is known to Terraform.
+    * However, the cluster may not be in a usable state yet.  Therefore any
+    * resources dependent on the cluster being up will fail to deploy.  With
+    * this explicit dependency, dependent resources can wait for the cluster
+    * to be up.
+    */
+    google_container_cluster.primary,
+    google_container_node_pool.pools,
+  ]
 }
 
 output "type" {

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -147,8 +147,9 @@ locals {
   cluster_zones    = sort(local.cluster_output_zones)
 
   cluster_name = local.cluster_output_name
-  // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", element(values(google_container_node_pool.pools)[*].id, 0)), length(split("/", element(values(google_container_node_pool.pools)[*].id, 0))) - 3)
+  // node pool ID is in the form projects/<project-id>/locations/<location>/clusters/<cluster-name>/nodePools/<nodepool-name>
+  cluster_name_parts_from_nodepool           = split("/", element(values(google_container_node_pool.pools)[*].id, 0))
+  cluster_name_computed                      = element(local.cluster_name_parts_from_nodepool, length(local.cluster_name_parts_from_nodepool) - 3)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -146,7 +146,6 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name = local.cluster_output_name
   // node pool ID is in the form projects/<project-id>/locations/<location>/clusters/<cluster-name>/nodePools/<nodepool-name>
   cluster_name_parts_from_nodepool           = split("/", element(values(google_container_node_pool.pools)[*].id, 0))
   cluster_name_computed                      = element(local.cluster_name_parts_from_nodepool, length(local.cluster_name_parts_from_nodepool) - 3)

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -148,7 +148,7 @@ locals {
 
   cluster_name = local.cluster_output_name
   // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", google_container_node_pool.pools.0.id), length(split("/", google_container_node_pool.pools.0.id)) - 2)
+  cluster_name_computed                      = element(split("/", element(google_container_node_pool.pools[*].id, 0)), length(split("/", element(google_container_node_pool.pools[*].id, 0))) - 2)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -148,7 +148,7 @@ locals {
 
   cluster_name = local.cluster_output_name
   // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", element(google_container_node_pool.pools[*].id, 0)), length(split("/", element(google_container_node_pool.pools[*].id, 0))) - 2)
+  cluster_name_computed                      = element(split("/", element(values(google_container_node_pool.pools)[*].id, 0)), length(split("/", element(values(google_container_node_pool.pools)[*].id, 0))) - 3)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -146,7 +146,9 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name                               = local.cluster_output_name
+  cluster_name = local.cluster_output_name
+  // node pool ID is in the form project/location/cluster/name
+  cluster_name_computed                      = element(split("/", google_container_node_pool.pools.0.id), length(split("/", google_container_node_pool.pools.0.id)) - 2)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/beta-public-cluster/outputs.tf
+++ b/modules/beta-public-cluster/outputs.tf
@@ -23,7 +23,7 @@ output "cluster_id" {
 
 output "name" {
   description = "Cluster name"
-  value       = local.cluster_name
+  value       = local.cluster_name_computed
   depends_on = [
     /* Nominally, the cluster name is populated as soon as it is known to Terraform.
     * However, the cluster may not be in a usable state yet.  Therefore any

--- a/modules/beta-public-cluster/outputs.tf
+++ b/modules/beta-public-cluster/outputs.tf
@@ -24,6 +24,16 @@ output "cluster_id" {
 output "name" {
   description = "Cluster name"
   value       = local.cluster_name
+  depends_on = [
+    /* Nominally, the cluster name is populated as soon as it is known to Terraform.
+    * However, the cluster may not be in a usable state yet.  Therefore any
+    * resources dependent on the cluster being up will fail to deploy.  With
+    * this explicit dependency, dependent resources can wait for the cluster
+    * to be up.
+    */
+    google_container_cluster.primary,
+    google_container_node_pool.pools,
+  ]
 }
 
 output "type" {

--- a/modules/private-cluster-update-variant/main.tf
+++ b/modules/private-cluster-update-variant/main.tf
@@ -125,7 +125,6 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name = local.cluster_output_name
   // node pool ID is in the form projects/<project-id>/locations/<location>/clusters/<cluster-name>/nodePools/<nodepool-name>
   cluster_name_parts_from_nodepool           = split("/", element(values(google_container_node_pool.pools)[*].id, 0))
   cluster_name_computed                      = element(local.cluster_name_parts_from_nodepool, length(local.cluster_name_parts_from_nodepool) - 3)

--- a/modules/private-cluster-update-variant/main.tf
+++ b/modules/private-cluster-update-variant/main.tf
@@ -127,7 +127,7 @@ locals {
 
   cluster_name = local.cluster_output_name
   // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", element(google_container_node_pool.pools[*].id, 0)), length(split("/", element(google_container_node_pool.pools[*].id, 0))) - 2)
+  cluster_name_computed                      = element(split("/", element(values(google_container_node_pool.pools)[*].id, 0)), length(split("/", element(values(google_container_node_pool.pools)[*].id, 0))) - 3)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/private-cluster-update-variant/main.tf
+++ b/modules/private-cluster-update-variant/main.tf
@@ -125,7 +125,9 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name                               = local.cluster_output_name
+  cluster_name = local.cluster_output_name
+  // node pool ID is in the form project/location/cluster/name
+  cluster_name_computed                      = element(split("/", google_container_node_pool.pools.0.id), length(split("/", google_container_node_pool.pools.0.id)) - 2)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/private-cluster-update-variant/main.tf
+++ b/modules/private-cluster-update-variant/main.tf
@@ -127,7 +127,7 @@ locals {
 
   cluster_name = local.cluster_output_name
   // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", google_container_node_pool.pools.0.id), length(split("/", google_container_node_pool.pools.0.id)) - 2)
+  cluster_name_computed                      = element(split("/", element(google_container_node_pool.pools[*].id, 0)), length(split("/", element(google_container_node_pool.pools[*].id, 0))) - 2)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/private-cluster-update-variant/main.tf
+++ b/modules/private-cluster-update-variant/main.tf
@@ -126,8 +126,9 @@ locals {
   cluster_zones    = sort(local.cluster_output_zones)
 
   cluster_name = local.cluster_output_name
-  // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", element(values(google_container_node_pool.pools)[*].id, 0)), length(split("/", element(values(google_container_node_pool.pools)[*].id, 0))) - 3)
+  // node pool ID is in the form projects/<project-id>/locations/<location>/clusters/<cluster-name>/nodePools/<nodepool-name>
+  cluster_name_parts_from_nodepool           = split("/", element(values(google_container_node_pool.pools)[*].id, 0))
+  cluster_name_computed                      = element(local.cluster_name_parts_from_nodepool, length(local.cluster_name_parts_from_nodepool) - 3)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/private-cluster-update-variant/outputs.tf
+++ b/modules/private-cluster-update-variant/outputs.tf
@@ -23,7 +23,7 @@ output "cluster_id" {
 
 output "name" {
   description = "Cluster name"
-  value       = local.cluster_name
+  value       = local.cluster_name_computed
   depends_on = [
     /* Nominally, the cluster name is populated as soon as it is known to Terraform.
     * However, the cluster may not be in a usable state yet.  Therefore any

--- a/modules/private-cluster-update-variant/outputs.tf
+++ b/modules/private-cluster-update-variant/outputs.tf
@@ -24,6 +24,16 @@ output "cluster_id" {
 output "name" {
   description = "Cluster name"
   value       = local.cluster_name
+  depends_on = [
+    /* Nominally, the cluster name is populated as soon as it is known to Terraform.
+    * However, the cluster may not be in a usable state yet.  Therefore any
+    * resources dependent on the cluster being up will fail to deploy.  With
+    * this explicit dependency, dependent resources can wait for the cluster
+    * to be up.
+    */
+    google_container_cluster.primary,
+    google_container_node_pool.pools,
+  ]
 }
 
 output "type" {

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -125,7 +125,6 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name = local.cluster_output_name
   // node pool ID is in the form projects/<project-id>/locations/<location>/clusters/<cluster-name>/nodePools/<nodepool-name>
   cluster_name_parts_from_nodepool           = split("/", element(values(google_container_node_pool.pools)[*].id, 0))
   cluster_name_computed                      = element(local.cluster_name_parts_from_nodepool, length(local.cluster_name_parts_from_nodepool) - 3)

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -127,7 +127,7 @@ locals {
 
   cluster_name = local.cluster_output_name
   // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", element(google_container_node_pool.pools[*].id, 0)), length(split("/", element(google_container_node_pool.pools[*].id, 0))) - 2)
+  cluster_name_computed                      = element(split("/", element(values(google_container_node_pool.pools)[*].id, 0)), length(split("/", element(values(google_container_node_pool.pools)[*].id, 0))) - 3)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -125,7 +125,9 @@ locals {
   cluster_region   = var.regional ? var.region : join("-", slice(split("-", local.cluster_location), 0, 2))
   cluster_zones    = sort(local.cluster_output_zones)
 
-  cluster_name                               = local.cluster_output_name
+  cluster_name = local.cluster_output_name
+  // node pool ID is in the form project/location/cluster/name
+  cluster_name_computed                      = element(split("/", google_container_node_pool.pools.0.id), length(split("/", google_container_node_pool.pools.0.id)) - 2)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -127,7 +127,7 @@ locals {
 
   cluster_name = local.cluster_output_name
   // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", google_container_node_pool.pools.0.id), length(split("/", google_container_node_pool.pools.0.id)) - 2)
+  cluster_name_computed                      = element(split("/", element(google_container_node_pool.pools[*].id, 0)), length(split("/", element(google_container_node_pool.pools[*].id, 0))) - 2)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -126,8 +126,9 @@ locals {
   cluster_zones    = sort(local.cluster_output_zones)
 
   cluster_name = local.cluster_output_name
-  // node pool ID is in the form project/location/cluster/name
-  cluster_name_computed                      = element(split("/", element(values(google_container_node_pool.pools)[*].id, 0)), length(split("/", element(values(google_container_node_pool.pools)[*].id, 0))) - 3)
+  // node pool ID is in the form projects/<project-id>/locations/<location>/clusters/<cluster-name>/nodePools/<nodepool-name>
+  cluster_name_parts_from_nodepool           = split("/", element(values(google_container_node_pool.pools)[*].id, 0))
+  cluster_name_computed                      = element(local.cluster_name_parts_from_nodepool, length(local.cluster_name_parts_from_nodepool) - 3)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/private-cluster/outputs.tf
+++ b/modules/private-cluster/outputs.tf
@@ -23,7 +23,7 @@ output "cluster_id" {
 
 output "name" {
   description = "Cluster name"
-  value       = local.cluster_name
+  value       = local.cluster_name_computed
   depends_on = [
     /* Nominally, the cluster name is populated as soon as it is known to Terraform.
     * However, the cluster may not be in a usable state yet.  Therefore any

--- a/modules/private-cluster/outputs.tf
+++ b/modules/private-cluster/outputs.tf
@@ -24,6 +24,16 @@ output "cluster_id" {
 output "name" {
   description = "Cluster name"
   value       = local.cluster_name
+  depends_on = [
+    /* Nominally, the cluster name is populated as soon as it is known to Terraform.
+    * However, the cluster may not be in a usable state yet.  Therefore any
+    * resources dependent on the cluster being up will fail to deploy.  With
+    * this explicit dependency, dependent resources can wait for the cluster
+    * to be up.
+    */
+    google_container_cluster.primary,
+    google_container_node_pool.pools,
+  ]
 }
 
 output "type" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,7 +23,7 @@ output "cluster_id" {
 
 output "name" {
   description = "Cluster name"
-  value       = local.cluster_name
+  value       = local.cluster_name_computed
   depends_on = [
     /* Nominally, the cluster name is populated as soon as it is known to Terraform.
     * However, the cluster may not be in a usable state yet.  Therefore any

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,6 +24,16 @@ output "cluster_id" {
 output "name" {
   description = "Cluster name"
   value       = local.cluster_name
+  depends_on = [
+    /* Nominally, the cluster name is populated as soon as it is known to Terraform.
+    * However, the cluster may not be in a usable state yet.  Therefore any
+    * resources dependent on the cluster being up will fail to deploy.  With
+    * this explicit dependency, dependent resources can wait for the cluster
+    * to be up.
+    */
+    google_container_cluster.primary,
+    google_container_node_pool.pools,
+  ]
 }
 
 output "type" {


### PR DESCRIPTION
Fixes #1181.

Change to the `simple_zonal_with_asm` module is just to get a passing run in CI with a static cluster name.