### PR TITLE
Removed unused variable ip_source_ranges_ssh from example safer_cluster_iap_bastion

### DIFF
--- a/examples/safer_cluster_iap_bastion/README.md
+++ b/examples/safer_cluster_iap_bastion/README.md
@@ -41,7 +41,6 @@ To deploy this example:
 | cluster\_name | The name of the cluster | `string` | `"safer-cluster-iap-bastion"` | no |
 | ip\_range\_pods\_name | The secondary ip range to use for pods | `string` | `"ip-range-pods"` | no |
 | ip\_range\_services\_name | The secondary ip range to use for pods | `string` | `"ip-range-svc"` | no |
-| ip\_source\_ranges\_ssh | Additional source ranges to allow for ssh to bastion host. 35.235.240.0/20 allowed by default for IAP tunnel. | `list(string)` | `[]` | no |
 | network\_name | The name of the network being created to host the cluster in | `string` | `"safer-cluster-network"` | no |
 | project\_id | The project ID to host the cluster in | `string` | n/a | yes |
 | region | The region to host the cluster in | `string` | `"us-central1"` | no |

--- a/examples/safer_cluster_iap_bastion/variables.tf
+++ b/examples/safer_cluster_iap_bastion/variables.tf
@@ -69,9 +69,3 @@ variable "bastion_members" {
   description = "List of users, groups, SAs who need access to the bastion host"
   default     = []
 }
-
-variable "ip_source_ranges_ssh" {
-  type        = list(string)
-  description = "Additional source ranges to allow for ssh to bastion host. 35.235.240.0/20 allowed by default for IAP tunnel."
-  default     = []
-}


### PR DESCRIPTION
Fixes [#1155](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1155)