### PR TITLE
docs: Expand independent ASM submodule example req

### DIFF
--- a/modules/asm/README.md
+++ b/modules/asm/README.md
@@ -4,11 +4,22 @@ This module installs [Anthos Service Mesh](https://cloud.google.com/service-mesh
 
 ## Usage
 
-There are a few prerequisites to using this module that can be done either through Terraform or manually:
+There are a few prerequisites to using this module that can be done either through Terraform and/or manually:
 
 1. Enable the `mesh.googleapis.com` service
 1. Enable the `servicemesh` feature on the cluster hub
 1. Register target cluster to the servicemesh-enabled hub
+1. Configure the [Kubernetes Provider](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs) for the target cluster, for example:
+
+```tf
+provider "kubernetes" {
+  host                   = "https://${module.gke.endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(module.gke.ca_certificate)
+}
+
+data "google_client_config" "default" {}
+```
 
 There is a full example provided [here](../../examples/simple_zonal_with_asm). Detailed usage example is as follows:
 


### PR DESCRIPTION
Expands the independent ASM submodule documentation example to include the requirement to configure the Kubernetes Provider for the target cluster.   Without configuration the Kubernetes Provider silently falls back to localhost rather than a raising a warning or error. #1208 