### PR TITLE
feat!: update kube-dns configMap using kubernetes_config_map_v1_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,10 @@ Then perform the following commands on the root folder:
 | filestore\_csi\_driver | The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes | `bool` | `false` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers. Either flag `add_master_webhook_firewall_rules` or `add_cluster_firewall_rules` (also adds egress rules) must be set to `true` for inbound-ports firewall rules to be applied. | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
-| gcloud\_upgrade | Whether to upgrade gcloud at runtime | `bool` | `false` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer and artifactregistry.reader roles. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
-| impersonate\_service\_account | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `""` | no |
 | initial\_node\_count | The number of nodes to create in this cluster's default node pool. | `number` | `0` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |

--- a/autogen/main/dns.tf.tmpl
+++ b/autogen/main/dns.tf.tmpl
@@ -17,43 +17,15 @@
 {{ autogeneration_note }}
 
 /******************************************
-  Delete default kube-dns configmap
+  Manage kube-dns configmaps
  *****************************************/
-module "gcloud_delete_default_kube_dns_configmap" {
-  source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
-  version = "~> 3.1"
 
-  enabled                     = (local.custom_kube_dns_config || local.upstream_nameservers_config) && !var.skip_provisioners
-  cluster_name                = google_container_cluster.primary.name
-  cluster_location            = google_container_cluster.primary.location
-  project_id                  = var.project_id
-  upgrade                     = var.gcloud_upgrade
-  impersonate_service_account = var.impersonate_service_account
-
-  kubectl_create_command  = "${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
-  kubectl_destroy_command = ""
-
-  module_depends_on = concat(
-    [google_container_cluster.primary.master_version],
-    {% if autopilot_cluster != true %}
-    [for pool in google_container_node_pool.pools : pool.name]
-    {% endif %}
-  )
-}
-
-/******************************************
-  Create kube-dns confimap
- *****************************************/
-resource "kubernetes_config_map" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube-dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -62,8 +34,9 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     {% if autopilot_cluster != true %}
     google_container_node_pool.pools,
@@ -71,17 +44,12 @@ EOF
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-namservers" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-namservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
-    name = "kube-dns"
-
+    name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -90,8 +58,9 @@ ${jsonencode(var.upstream_nameservers)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     {% if autopilot_cluster != true %}
     google_container_node_pool.pools,
@@ -99,16 +68,12 @@ EOF
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -121,8 +86,9 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     {% if autopilot_cluster != true %}
     google_container_node_pool.pools,

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -458,12 +458,6 @@ variable "firewall_inbound_ports" {
   default     = ["8443", "9443", "15017"]
 }
 
-variable "gcloud_upgrade" {
-  type        = bool
-  description = "Whether to upgrade gcloud at runtime"
-  default     = false
-}
-
 variable "add_shadow_firewall_rules" {
   type = bool
   description = "Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled)."
@@ -489,12 +483,6 @@ variable "disable_default_snat" {
   default     = false
 }
 {% endif %}
-
-variable "impersonate_service_account" {
-  type        = string
-  description = "An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials."
-  default     = ""
-}
 
 {% if beta_cluster %}
 variable "notification_config_topic" {

--- a/autogen/main/versions.tf.tmpl
+++ b/autogen/main/versions.tf.tmpl
@@ -28,7 +28,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.0"
+      version = "~> 2.10"
     }
   }
   provider_meta "google-beta" {
@@ -42,7 +42,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.0"
+      version = "~> 2.10"
     }
   }
   provider_meta "google" {

--- a/dns.tf
+++ b/dns.tf
@@ -17,41 +17,15 @@
 // This file was automatically generated from a template in ./autogen/main
 
 /******************************************
-  Delete default kube-dns configmap
+  Manage kube-dns configmaps
  *****************************************/
-module "gcloud_delete_default_kube_dns_configmap" {
-  source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
-  version = "~> 3.1"
 
-  enabled                     = (local.custom_kube_dns_config || local.upstream_nameservers_config) && !var.skip_provisioners
-  cluster_name                = google_container_cluster.primary.name
-  cluster_location            = google_container_cluster.primary.location
-  project_id                  = var.project_id
-  upgrade                     = var.gcloud_upgrade
-  impersonate_service_account = var.impersonate_service_account
-
-  kubectl_create_command  = "${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
-  kubectl_destroy_command = ""
-
-  module_depends_on = concat(
-    [google_container_cluster.primary.master_version],
-    [for pool in google_container_node_pool.pools : pool.name]
-  )
-}
-
-/******************************************
-  Create kube-dns confimap
- *****************************************/
-resource "kubernetes_config_map" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube-dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -60,24 +34,20 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-namservers" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-namservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
-    name = "kube-dns"
-
+    name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -86,23 +56,20 @@ ${jsonencode(var.upstream_nameservers)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -115,8 +82,9 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]

--- a/docs/upgrading_to_v21.0.md
+++ b/docs/upgrading_to_v21.0.md
@@ -1,0 +1,16 @@
+# Upgrading to v21.0
+
+The v21.0 release of *kubernetes-engine* is a backwards incompatible
+release.
+
+### Terraform Kubernetes Engine Module
+
+The [Terraform Kubernetes Engine Module](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine) has been rewritten to use the 'kubernetes_config_map_v1_data' resouce added to the Terraform Kubernetes provider version 2.10.
+
+1. Run `terraform state rm module.gke.kubernetes_config_map.kube-dns`
+2. Update the module version to v21.0
+4. Run `terraform apply`
+
+### Kubernetes Provider upgrade
+The Terraform Kubernetes Engine module now requires version 2.10 or higher of
+the Kubernetes Provider.

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -91,12 +91,10 @@ Then perform the following commands on the root folder:
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | `bool` | `false` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers. Either flag `add_master_webhook_firewall_rules` or `add_cluster_firewall_rules` (also adds egress rules) must be set to `true` for inbound-ports firewall rules to be applied. | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
-| gcloud\_upgrade | Whether to upgrade gcloud at runtime | `bool` | `false` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer and artifactregistry.reader roles. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
-| impersonate\_service\_account | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `""` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | `string` | n/a | yes |

--- a/modules/beta-autopilot-private-cluster/dns.tf
+++ b/modules/beta-autopilot-private-cluster/dns.tf
@@ -17,40 +17,15 @@
 // This file was automatically generated from a template in ./autogen/main
 
 /******************************************
-  Delete default kube-dns configmap
+  Manage kube-dns configmaps
  *****************************************/
-module "gcloud_delete_default_kube_dns_configmap" {
-  source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
-  version = "~> 3.1"
 
-  enabled                     = (local.custom_kube_dns_config || local.upstream_nameservers_config) && !var.skip_provisioners
-  cluster_name                = google_container_cluster.primary.name
-  cluster_location            = google_container_cluster.primary.location
-  project_id                  = var.project_id
-  upgrade                     = var.gcloud_upgrade
-  impersonate_service_account = var.impersonate_service_account
-
-  kubectl_create_command  = "${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
-  kubectl_destroy_command = ""
-
-  module_depends_on = concat(
-    [google_container_cluster.primary.master_version],
-  )
-}
-
-/******************************************
-  Create kube-dns confimap
- *****************************************/
-resource "kubernetes_config_map" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube-dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -59,23 +34,19 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-namservers" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-namservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
-    name = "kube-dns"
-
+    name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -84,22 +55,19 @@ ${jsonencode(var.upstream_nameservers)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -112,8 +80,9 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
   ]
 }

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -337,12 +337,6 @@ variable "firewall_inbound_ports" {
   default     = ["8443", "9443", "15017"]
 }
 
-variable "gcloud_upgrade" {
-  type        = bool
-  description = "Whether to upgrade gcloud at runtime"
-  default     = false
-}
-
 variable "add_shadow_firewall_rules" {
   type        = bool
   description = "Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled)."
@@ -365,12 +359,6 @@ variable "disable_default_snat" {
   type        = bool
   description = "Whether to disable the default SNAT to support the private use of public IP addresses"
   default     = false
-}
-
-variable "impersonate_service_account" {
-  type        = string
-  description = "An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials."
-  default     = ""
 }
 
 variable "notification_config_topic" {

--- a/modules/beta-autopilot-private-cluster/versions.tf
+++ b/modules/beta-autopilot-private-cluster/versions.tf
@@ -25,7 +25,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.0"
+      version = "~> 2.10"
     }
   }
   provider_meta "google-beta" {

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -82,12 +82,10 @@ Then perform the following commands on the root folder:
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | `bool` | `false` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers. Either flag `add_master_webhook_firewall_rules` or `add_cluster_firewall_rules` (also adds egress rules) must be set to `true` for inbound-ports firewall rules to be applied. | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
-| gcloud\_upgrade | Whether to upgrade gcloud at runtime | `bool` | `false` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer and artifactregistry.reader roles. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
-| impersonate\_service\_account | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `""` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | `string` | n/a | yes |

--- a/modules/beta-autopilot-public-cluster/dns.tf
+++ b/modules/beta-autopilot-public-cluster/dns.tf
@@ -17,40 +17,15 @@
 // This file was automatically generated from a template in ./autogen/main
 
 /******************************************
-  Delete default kube-dns configmap
+  Manage kube-dns configmaps
  *****************************************/
-module "gcloud_delete_default_kube_dns_configmap" {
-  source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
-  version = "~> 3.1"
 
-  enabled                     = (local.custom_kube_dns_config || local.upstream_nameservers_config) && !var.skip_provisioners
-  cluster_name                = google_container_cluster.primary.name
-  cluster_location            = google_container_cluster.primary.location
-  project_id                  = var.project_id
-  upgrade                     = var.gcloud_upgrade
-  impersonate_service_account = var.impersonate_service_account
-
-  kubectl_create_command  = "${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
-  kubectl_destroy_command = ""
-
-  module_depends_on = concat(
-    [google_container_cluster.primary.master_version],
-  )
-}
-
-/******************************************
-  Create kube-dns confimap
- *****************************************/
-resource "kubernetes_config_map" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube-dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -59,23 +34,19 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-namservers" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-namservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
-    name = "kube-dns"
-
+    name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -84,22 +55,19 @@ ${jsonencode(var.upstream_nameservers)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -112,8 +80,9 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
   ]
 }

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -306,12 +306,6 @@ variable "firewall_inbound_ports" {
   default     = ["8443", "9443", "15017"]
 }
 
-variable "gcloud_upgrade" {
-  type        = bool
-  description = "Whether to upgrade gcloud at runtime"
-  default     = false
-}
-
 variable "add_shadow_firewall_rules" {
   type        = bool
   description = "Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled)."
@@ -334,12 +328,6 @@ variable "disable_default_snat" {
   type        = bool
   description = "Whether to disable the default SNAT to support the private use of public IP addresses"
   default     = false
-}
-
-variable "impersonate_service_account" {
-  type        = string
-  description = "An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials."
-  default     = ""
 }
 
 variable "notification_config_topic" {

--- a/modules/beta-autopilot-public-cluster/versions.tf
+++ b/modules/beta-autopilot-public-cluster/versions.tf
@@ -25,7 +25,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.0"
+      version = "~> 2.10"
     }
   }
   provider_meta "google-beta" {

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -198,12 +198,10 @@ Then perform the following commands on the root folder:
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers. Either flag `add_master_webhook_firewall_rules` or `add_cluster_firewall_rules` (also adds egress rules) must be set to `true` for inbound-ports firewall rules to be applied. | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | `bool` | `false` | no |
-| gcloud\_upgrade | Whether to upgrade gcloud at runtime | `bool` | `false` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer and artifactregistry.reader roles. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
-| impersonate\_service\_account | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `""` | no |
 | initial\_node\_count | The number of nodes to create in this cluster's default node pool. | `number` | `0` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |

--- a/modules/beta-private-cluster-update-variant/dns.tf
+++ b/modules/beta-private-cluster-update-variant/dns.tf
@@ -17,41 +17,15 @@
 // This file was automatically generated from a template in ./autogen/main
 
 /******************************************
-  Delete default kube-dns configmap
+  Manage kube-dns configmaps
  *****************************************/
-module "gcloud_delete_default_kube_dns_configmap" {
-  source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
-  version = "~> 3.1"
 
-  enabled                     = (local.custom_kube_dns_config || local.upstream_nameservers_config) && !var.skip_provisioners
-  cluster_name                = google_container_cluster.primary.name
-  cluster_location            = google_container_cluster.primary.location
-  project_id                  = var.project_id
-  upgrade                     = var.gcloud_upgrade
-  impersonate_service_account = var.impersonate_service_account
-
-  kubectl_create_command  = "${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
-  kubectl_destroy_command = ""
-
-  module_depends_on = concat(
-    [google_container_cluster.primary.master_version],
-    [for pool in google_container_node_pool.pools : pool.name]
-  )
-}
-
-/******************************************
-  Create kube-dns confimap
- *****************************************/
-resource "kubernetes_config_map" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube-dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -60,24 +34,20 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-namservers" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-namservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
-    name = "kube-dns"
-
+    name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -86,23 +56,20 @@ ${jsonencode(var.upstream_nameservers)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -115,8 +82,9 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -434,12 +434,6 @@ variable "firewall_inbound_ports" {
   default     = ["8443", "9443", "15017"]
 }
 
-variable "gcloud_upgrade" {
-  type        = bool
-  description = "Whether to upgrade gcloud at runtime"
-  default     = false
-}
-
 variable "add_shadow_firewall_rules" {
   type        = bool
   description = "Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled)."
@@ -462,12 +456,6 @@ variable "disable_default_snat" {
   type        = bool
   description = "Whether to disable the default SNAT to support the private use of public IP addresses"
   default     = false
-}
-
-variable "impersonate_service_account" {
-  type        = string
-  description = "An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials."
-  default     = ""
 }
 
 variable "notification_config_topic" {

--- a/modules/beta-private-cluster-update-variant/versions.tf
+++ b/modules/beta-private-cluster-update-variant/versions.tf
@@ -25,7 +25,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.0"
+      version = "~> 2.10"
     }
   }
   provider_meta "google-beta" {

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -176,12 +176,10 @@ Then perform the following commands on the root folder:
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers. Either flag `add_master_webhook_firewall_rules` or `add_cluster_firewall_rules` (also adds egress rules) must be set to `true` for inbound-ports firewall rules to be applied. | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | `bool` | `false` | no |
-| gcloud\_upgrade | Whether to upgrade gcloud at runtime | `bool` | `false` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer and artifactregistry.reader roles. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
-| impersonate\_service\_account | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `""` | no |
 | initial\_node\_count | The number of nodes to create in this cluster's default node pool. | `number` | `0` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |

--- a/modules/beta-private-cluster/dns.tf
+++ b/modules/beta-private-cluster/dns.tf
@@ -17,41 +17,15 @@
 // This file was automatically generated from a template in ./autogen/main
 
 /******************************************
-  Delete default kube-dns configmap
+  Manage kube-dns configmaps
  *****************************************/
-module "gcloud_delete_default_kube_dns_configmap" {
-  source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
-  version = "~> 3.1"
 
-  enabled                     = (local.custom_kube_dns_config || local.upstream_nameservers_config) && !var.skip_provisioners
-  cluster_name                = google_container_cluster.primary.name
-  cluster_location            = google_container_cluster.primary.location
-  project_id                  = var.project_id
-  upgrade                     = var.gcloud_upgrade
-  impersonate_service_account = var.impersonate_service_account
-
-  kubectl_create_command  = "${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
-  kubectl_destroy_command = ""
-
-  module_depends_on = concat(
-    [google_container_cluster.primary.master_version],
-    [for pool in google_container_node_pool.pools : pool.name]
-  )
-}
-
-/******************************************
-  Create kube-dns confimap
- *****************************************/
-resource "kubernetes_config_map" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube-dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -60,24 +34,20 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-namservers" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-namservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
-    name = "kube-dns"
-
+    name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -86,23 +56,20 @@ ${jsonencode(var.upstream_nameservers)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -115,8 +82,9 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -434,12 +434,6 @@ variable "firewall_inbound_ports" {
   default     = ["8443", "9443", "15017"]
 }
 
-variable "gcloud_upgrade" {
-  type        = bool
-  description = "Whether to upgrade gcloud at runtime"
-  default     = false
-}
-
 variable "add_shadow_firewall_rules" {
   type        = bool
   description = "Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled)."
@@ -462,12 +456,6 @@ variable "disable_default_snat" {
   type        = bool
   description = "Whether to disable the default SNAT to support the private use of public IP addresses"
   default     = false
-}
-
-variable "impersonate_service_account" {
-  type        = string
-  description = "An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials."
-  default     = ""
 }
 
 variable "notification_config_topic" {

--- a/modules/beta-private-cluster/versions.tf
+++ b/modules/beta-private-cluster/versions.tf
@@ -25,7 +25,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.0"
+      version = "~> 2.10"
     }
   }
   provider_meta "google-beta" {

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -189,12 +189,10 @@ Then perform the following commands on the root folder:
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers. Either flag `add_master_webhook_firewall_rules` or `add_cluster_firewall_rules` (also adds egress rules) must be set to `true` for inbound-ports firewall rules to be applied. | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | `bool` | `false` | no |
-| gcloud\_upgrade | Whether to upgrade gcloud at runtime | `bool` | `false` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer and artifactregistry.reader roles. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
-| impersonate\_service\_account | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `""` | no |
 | initial\_node\_count | The number of nodes to create in this cluster's default node pool. | `number` | `0` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |

--- a/modules/beta-public-cluster-update-variant/dns.tf
+++ b/modules/beta-public-cluster-update-variant/dns.tf
@@ -17,41 +17,15 @@
 // This file was automatically generated from a template in ./autogen/main
 
 /******************************************
-  Delete default kube-dns configmap
+  Manage kube-dns configmaps
  *****************************************/
-module "gcloud_delete_default_kube_dns_configmap" {
-  source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
-  version = "~> 3.1"
 
-  enabled                     = (local.custom_kube_dns_config || local.upstream_nameservers_config) && !var.skip_provisioners
-  cluster_name                = google_container_cluster.primary.name
-  cluster_location            = google_container_cluster.primary.location
-  project_id                  = var.project_id
-  upgrade                     = var.gcloud_upgrade
-  impersonate_service_account = var.impersonate_service_account
-
-  kubectl_create_command  = "${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
-  kubectl_destroy_command = ""
-
-  module_depends_on = concat(
-    [google_container_cluster.primary.master_version],
-    [for pool in google_container_node_pool.pools : pool.name]
-  )
-}
-
-/******************************************
-  Create kube-dns confimap
- *****************************************/
-resource "kubernetes_config_map" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube-dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -60,24 +34,20 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-namservers" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-namservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
-    name = "kube-dns"
-
+    name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -86,23 +56,20 @@ ${jsonencode(var.upstream_nameservers)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -115,8 +82,9 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -403,12 +403,6 @@ variable "firewall_inbound_ports" {
   default     = ["8443", "9443", "15017"]
 }
 
-variable "gcloud_upgrade" {
-  type        = bool
-  description = "Whether to upgrade gcloud at runtime"
-  default     = false
-}
-
 variable "add_shadow_firewall_rules" {
   type        = bool
   description = "Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled)."
@@ -431,12 +425,6 @@ variable "disable_default_snat" {
   type        = bool
   description = "Whether to disable the default SNAT to support the private use of public IP addresses"
   default     = false
-}
-
-variable "impersonate_service_account" {
-  type        = string
-  description = "An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials."
-  default     = ""
 }
 
 variable "notification_config_topic" {

--- a/modules/beta-public-cluster-update-variant/versions.tf
+++ b/modules/beta-public-cluster-update-variant/versions.tf
@@ -25,7 +25,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.0"
+      version = "~> 2.10"
     }
   }
   provider_meta "google-beta" {

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -167,12 +167,10 @@ Then perform the following commands on the root folder:
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers. Either flag `add_master_webhook_firewall_rules` or `add_cluster_firewall_rules` (also adds egress rules) must be set to `true` for inbound-ports firewall rules to be applied. | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | `bool` | `false` | no |
-| gcloud\_upgrade | Whether to upgrade gcloud at runtime | `bool` | `false` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer and artifactregistry.reader roles. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
-| impersonate\_service\_account | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `""` | no |
 | initial\_node\_count | The number of nodes to create in this cluster's default node pool. | `number` | `0` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |

--- a/modules/beta-public-cluster/dns.tf
+++ b/modules/beta-public-cluster/dns.tf
@@ -17,41 +17,15 @@
 // This file was automatically generated from a template in ./autogen/main
 
 /******************************************
-  Delete default kube-dns configmap
+  Manage kube-dns configmaps
  *****************************************/
-module "gcloud_delete_default_kube_dns_configmap" {
-  source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
-  version = "~> 3.1"
 
-  enabled                     = (local.custom_kube_dns_config || local.upstream_nameservers_config) && !var.skip_provisioners
-  cluster_name                = google_container_cluster.primary.name
-  cluster_location            = google_container_cluster.primary.location
-  project_id                  = var.project_id
-  upgrade                     = var.gcloud_upgrade
-  impersonate_service_account = var.impersonate_service_account
-
-  kubectl_create_command  = "${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
-  kubectl_destroy_command = ""
-
-  module_depends_on = concat(
-    [google_container_cluster.primary.master_version],
-    [for pool in google_container_node_pool.pools : pool.name]
-  )
-}
-
-/******************************************
-  Create kube-dns confimap
- *****************************************/
-resource "kubernetes_config_map" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube-dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -60,24 +34,20 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-namservers" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-namservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
-    name = "kube-dns"
-
+    name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -86,23 +56,20 @@ ${jsonencode(var.upstream_nameservers)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -115,8 +82,9 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -403,12 +403,6 @@ variable "firewall_inbound_ports" {
   default     = ["8443", "9443", "15017"]
 }
 
-variable "gcloud_upgrade" {
-  type        = bool
-  description = "Whether to upgrade gcloud at runtime"
-  default     = false
-}
-
 variable "add_shadow_firewall_rules" {
   type        = bool
   description = "Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled)."
@@ -431,12 +425,6 @@ variable "disable_default_snat" {
   type        = bool
   description = "Whether to disable the default SNAT to support the private use of public IP addresses"
   default     = false
-}
-
-variable "impersonate_service_account" {
-  type        = string
-  description = "An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials."
-  default     = ""
 }
 
 variable "notification_config_topic" {

--- a/modules/beta-public-cluster/versions.tf
+++ b/modules/beta-public-cluster/versions.tf
@@ -25,7 +25,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.0"
+      version = "~> 2.10"
     }
   }
   provider_meta "google-beta" {

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -179,12 +179,10 @@ Then perform the following commands on the root folder:
 | filestore\_csi\_driver | The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes | `bool` | `false` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers. Either flag `add_master_webhook_firewall_rules` or `add_cluster_firewall_rules` (also adds egress rules) must be set to `true` for inbound-ports firewall rules to be applied. | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
-| gcloud\_upgrade | Whether to upgrade gcloud at runtime | `bool` | `false` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer and artifactregistry.reader roles. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
-| impersonate\_service\_account | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `""` | no |
 | initial\_node\_count | The number of nodes to create in this cluster's default node pool. | `number` | `0` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |

--- a/modules/private-cluster-update-variant/dns.tf
+++ b/modules/private-cluster-update-variant/dns.tf
@@ -17,41 +17,15 @@
 // This file was automatically generated from a template in ./autogen/main
 
 /******************************************
-  Delete default kube-dns configmap
+  Manage kube-dns configmaps
  *****************************************/
-module "gcloud_delete_default_kube_dns_configmap" {
-  source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
-  version = "~> 3.1"
 
-  enabled                     = (local.custom_kube_dns_config || local.upstream_nameservers_config) && !var.skip_provisioners
-  cluster_name                = google_container_cluster.primary.name
-  cluster_location            = google_container_cluster.primary.location
-  project_id                  = var.project_id
-  upgrade                     = var.gcloud_upgrade
-  impersonate_service_account = var.impersonate_service_account
-
-  kubectl_create_command  = "${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
-  kubectl_destroy_command = ""
-
-  module_depends_on = concat(
-    [google_container_cluster.primary.master_version],
-    [for pool in google_container_node_pool.pools : pool.name]
-  )
-}
-
-/******************************************
-  Create kube-dns confimap
- *****************************************/
-resource "kubernetes_config_map" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube-dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -60,24 +34,20 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-namservers" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-namservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
-    name = "kube-dns"
-
+    name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -86,23 +56,20 @@ ${jsonencode(var.upstream_nameservers)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -115,8 +82,9 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -391,12 +391,6 @@ variable "firewall_inbound_ports" {
   default     = ["8443", "9443", "15017"]
 }
 
-variable "gcloud_upgrade" {
-  type        = bool
-  description = "Whether to upgrade gcloud at runtime"
-  default     = false
-}
-
 variable "add_shadow_firewall_rules" {
   type        = bool
   description = "Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled)."
@@ -409,12 +403,6 @@ variable "shadow_firewall_rules_priority" {
   default     = 999
 }
 
-
-variable "impersonate_service_account" {
-  type        = string
-  description = "An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials."
-  default     = ""
-}
 
 variable "network_policy" {
   type        = bool

--- a/modules/private-cluster-update-variant/versions.tf
+++ b/modules/private-cluster-update-variant/versions.tf
@@ -25,7 +25,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.0"
+      version = "~> 2.10"
     }
   }
   provider_meta "google" {

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -157,12 +157,10 @@ Then perform the following commands on the root folder:
 | filestore\_csi\_driver | The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes | `bool` | `false` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers. Either flag `add_master_webhook_firewall_rules` or `add_cluster_firewall_rules` (also adds egress rules) must be set to `true` for inbound-ports firewall rules to be applied. | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
-| gcloud\_upgrade | Whether to upgrade gcloud at runtime | `bool` | `false` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer and artifactregistry.reader roles. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
-| impersonate\_service\_account | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `""` | no |
 | initial\_node\_count | The number of nodes to create in this cluster's default node pool. | `number` | `0` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |

--- a/modules/private-cluster/dns.tf
+++ b/modules/private-cluster/dns.tf
@@ -17,41 +17,15 @@
 // This file was automatically generated from a template in ./autogen/main
 
 /******************************************
-  Delete default kube-dns configmap
+  Manage kube-dns configmaps
  *****************************************/
-module "gcloud_delete_default_kube_dns_configmap" {
-  source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
-  version = "~> 3.1"
 
-  enabled                     = (local.custom_kube_dns_config || local.upstream_nameservers_config) && !var.skip_provisioners
-  cluster_name                = google_container_cluster.primary.name
-  cluster_location            = google_container_cluster.primary.location
-  project_id                  = var.project_id
-  upgrade                     = var.gcloud_upgrade
-  impersonate_service_account = var.impersonate_service_account
-
-  kubectl_create_command  = "${path.module}/scripts/delete-default-resource.sh kube-system configmap kube-dns"
-  kubectl_destroy_command = ""
-
-  module_depends_on = concat(
-    [google_container_cluster.primary.master_version],
-    [for pool in google_container_node_pool.pools : pool.name]
-  )
-}
-
-/******************************************
-  Create kube-dns confimap
- *****************************************/
-resource "kubernetes_config_map" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube-dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -60,24 +34,20 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-namservers" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-namservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
-    name = "kube-dns"
-
+    name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -86,23 +56,20 @@ ${jsonencode(var.upstream_nameservers)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]
 }
 
-resource "kubernetes_config_map" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
     name      = "kube-dns"
     namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
   }
 
   data = {
@@ -115,8 +82,9 @@ ${jsonencode(var.stub_domains)}
 EOF
   }
 
+  force = true
+
   depends_on = [
-    module.gcloud_delete_default_kube_dns_configmap.wait,
     google_container_cluster.primary,
     google_container_node_pool.pools,
   ]

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -391,12 +391,6 @@ variable "firewall_inbound_ports" {
   default     = ["8443", "9443", "15017"]
 }
 
-variable "gcloud_upgrade" {
-  type        = bool
-  description = "Whether to upgrade gcloud at runtime"
-  default     = false
-}
-
 variable "add_shadow_firewall_rules" {
   type        = bool
   description = "Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled)."
@@ -409,12 +403,6 @@ variable "shadow_firewall_rules_priority" {
   default     = 999
 }
 
-
-variable "impersonate_service_account" {
-  type        = string
-  description = "An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials."
-  default     = ""
-}
 
 variable "network_policy" {
   type        = bool

--- a/modules/private-cluster/versions.tf
+++ b/modules/private-cluster/versions.tf
@@ -25,7 +25,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.0"
+      version = "~> 2.10"
     }
   }
   provider_meta "google" {

--- a/test/integration/node_pool/controls/gcloud.rb
+++ b/test/integration/node_pool/controls/gcloud.rb
@@ -60,7 +60,7 @@ control "gcloud" do
     end
 
     describe "node pools" do
-      let(:node_pools) { data['nodePools'].reject { |p| p['name'] == "default-pool" } }
+      let(:node_pools) { data['nodePools'].reject { |p| p['name'] == "default-pool" || p['name'] =~ %r{^nap-.*} } }
 
       it "has 3" do
         expect(node_pools.count).to eq 3

--- a/test/integration/stub_domains/controls/kubectl.rb
+++ b/test/integration/stub_domains/controls/kubectl.rb
@@ -46,8 +46,8 @@ control "kubectl" do
       describe "kube-dns" do
         let(:kubedns_configmap) { client.get_config_map("kube-dns", "kube-system") }
 
-        it "is created by Terraform" do
-          expect(kubedns_configmap.metadata.labels.maintained_by).to eq "terraform"
+        it "is managed by Terraform" do
+          expect(kubedns_configmap.metadata.managedFields[0].manager).to eq "Terraform"
         end
 
         it "reflects the stub_domains configuration" do

--- a/test/integration/stub_domains_private/controls/kubectl.rb
+++ b/test/integration/stub_domains_private/controls/kubectl.rb
@@ -42,8 +42,8 @@ control "kubectl" do
       describe "kube-dns" do
         let(:kubedns_configmap) { client.get_config_map("kube-dns", "kube-system") }
 
-        it "is created by Terraform" do
-          expect(kubedns_configmap.metadata.labels.maintained_by).to eq "terraform"
+        it "is managed by Terraform" do
+          expect(kubedns_configmap.metadata.managedFields[0].manager).to eq "Terraform"
         end
 
         it "reflects the stub_domains configuration" do

--- a/test/integration/stub_domains_upstream_nameservers/controls/kubectl.rb
+++ b/test/integration/stub_domains_upstream_nameservers/controls/kubectl.rb
@@ -46,8 +46,8 @@ control "kubectl" do
       describe "kube-dns" do
         let(:kubedns_configmap) { client.get_config_map("kube-dns", "kube-system") }
 
-        it "is created by Terraform" do
-          expect(kubedns_configmap.metadata.labels.maintained_by).to eq "terraform"
+        it "is managed by Terraform" do
+          expect(kubedns_configmap.metadata.managedFields[0].manager).to eq "Terraform"
         end
 
         it "reflects the stub_domains configuration" do

--- a/test/integration/upstream_nameservers/controls/kubectl.rb
+++ b/test/integration/upstream_nameservers/controls/kubectl.rb
@@ -46,8 +46,8 @@ control "kubectl" do
       describe "kube-dns" do
         let(:kubedns_configmap) { client.get_config_map("kube-dns", "kube-system") }
 
-        it "is created by Terraform" do
-          expect(kubedns_configmap.metadata.labels.maintained_by).to eq "terraform"
+        it "is managed by Terraform" do
+          expect(kubedns_configmap.metadata.managedFields[0].manager).to eq "Terraform"
         end
 
         it "reflects the upstream_nameservers configuration" do

--- a/variables.tf
+++ b/variables.tf
@@ -367,12 +367,6 @@ variable "firewall_inbound_ports" {
   default     = ["8443", "9443", "15017"]
 }
 
-variable "gcloud_upgrade" {
-  type        = bool
-  description = "Whether to upgrade gcloud at runtime"
-  default     = false
-}
-
 variable "add_shadow_firewall_rules" {
   type        = bool
   description = "Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled)."
@@ -385,12 +379,6 @@ variable "shadow_firewall_rules_priority" {
   default     = 999
 }
 
-
-variable "impersonate_service_account" {
-  type        = string
-  description = "An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials."
-  default     = ""
-}
 
 variable "network_policy" {
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -25,7 +25,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.0"
+      version = "~> 2.10"
     }
   }
   provider_meta "google" {


### PR DESCRIPTION
- Update `kube-dns` configMap in-place using new `kubernetes_config_map_v1_data` in Kubernetes Provider v2.10
- Avoid possible conflict with `addon-manager` recreating the configMap faster than the previous drop and replace method Close #1197
- fix: node_pool test with node auto-provisioning (nap-) nodePools Closes #1223 