### PR TITLE
Add required kubernetes provider to ASM module

### DIFF
--- a/modules/asm/versions.tf
+++ b/modules/asm/versions.tf
@@ -18,6 +18,13 @@
 terraform {
   required_version = ">= 0.13.0"
 
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+
   provider_meta "google" {
     module_name = "blueprints/terraform/terraform-google-kubernetes-engine:asm/v20.0.0"
   }


### PR DESCRIPTION
This makes it so that if a user wants to create multiple clusters in a single application, they can pass a provider alias into the module to install ASM on both.

Example:

```
provider "kubernetes" {
  host                   = "https://${google_container_cluster.alpha.endpoint}"
  token                  = data.google_client_config.default.access_token
  cluster_ca_certificate = base64decode(google_container_cluster.alpha.master_auth[0].cluster_ca_certificate)
  alias                  = "cluster-alpha"
}

provider "kubernetes" {
  host                   = "https://${google_container_cluster.beta.endpoint}"
  token                  = data.google_client_config.default.access_token
  cluster_ca_certificate = base64decode(google_container_cluster.beta.master_auth[0].cluster_ca_certificate)
  alias                  = "cluster-beta"
}

resource "google_container_cluster" "alpha" {
  project            = var.project_id
  name               = "cluster-alpha"
  location           = var.region
  initial_node_count = 3
  workload_identity_config {
    workload_pool = "${var.project_id}.svc.id.goog"
  }
  timeouts {
    create = "30m"
    update = "40m"
  }
}

resource "google_container_cluster" "beta" {
  project            = var.project_id
  name               = "cluster-beta"
  location           = var.region
  initial_node_count = 3
  workload_identity_config {
    workload_pool = "${var.project_id}.svc.id.goog"
  }
  timeouts {
    create = "30m"
    update = "40m"
  }
}

module "asm-alpha" {
  source                    = "../modules/asm"
  project_id                = var.project_id
  cluster_name              = local.cluster_alpha_computed_name
  cluster_location          = var.region
  enable_cni                = true
  multicluster_mode         = "connected"
  enable_fleet_registration = true
  providers = {
    kubernetes = kubernetes.cluster-alpha
  }
}

module "asm-beta" {
  source                    = "../modules/asm"
  project_id                = var.project_id
  cluster_name              = local.cluster_beta_computed_name
  cluster_location          = var.region
  enable_cni                = true
  multicluster_mode         = "connected"
  enable_fleet_registration = true
  providers = {
    kubernetes = kubernetes.cluster-beta
  }
}
```