### PR TITLE
fix: set initial_node_count with remove_default_node_pool

### DIFF
--- a/autogen/safer-cluster/main.tf.tmpl
+++ b/autogen/safer-cluster/main.tf.tmpl
@@ -77,11 +77,11 @@ module "gke" {
 
   maintenance_start_time = var.maintenance_start_time
 
-  initial_node_count = var.initial_node_count
-
   // We suggest removing the default node pool, as it cannot be modified without
   // destroying the cluster.
   remove_default_node_pool = true
+  // If removing the default node pool, initial_node_count should be at least 1.
+  initial_node_count = (var.initial_node_count == 0) ? 1 : var.initial_node_count
 
   node_pools          = var.node_pools
   node_pools_labels   = var.node_pools_labels

--- a/modules/safer-cluster-update-variant/main.tf
+++ b/modules/safer-cluster-update-variant/main.tf
@@ -73,11 +73,11 @@ module "gke" {
 
   maintenance_start_time = var.maintenance_start_time
 
-  initial_node_count = var.initial_node_count
-
   // We suggest removing the default node pool, as it cannot be modified without
   // destroying the cluster.
   remove_default_node_pool = true
+  // If removing the default node pool, initial_node_count should be at least 1.
+  initial_node_count = (var.initial_node_count == 0) ? 1 : var.initial_node_count
 
   node_pools          = var.node_pools
   node_pools_labels   = var.node_pools_labels

--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -73,11 +73,11 @@ module "gke" {
 
   maintenance_start_time = var.maintenance_start_time
 
-  initial_node_count = var.initial_node_count
-
   // We suggest removing the default node pool, as it cannot be modified without
   // destroying the cluster.
   remove_default_node_pool = true
+  // If removing the default node pool, initial_node_count should be at least 1.
+  initial_node_count = (var.initial_node_count == 0) ? 1 : var.initial_node_count
 
   node_pools          = var.node_pools
   node_pools_labels   = var.node_pools_labels


### PR DESCRIPTION
Set `initial_node_count` to `1` if `0` supplied in safer-cluster [inline with TPG documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster) for the opinionated `remove_default_node_pool=true`.