### PR TITLE
fix: auto-pilot cluster always uses the default service account

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -61,6 +61,11 @@ resource "google_container_cluster" "primary" {
     }
   }
 {% endif %}
+{% if autopilot_cluster %}
+  node_config {
+    service_account = local.service_account
+  }
+{% endif %}
 
   subnetwork = "projects/${local.network_project_id}/regions/${local.region}/subnetworks/${var.subnetwork}"
 

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -45,6 +45,9 @@ resource "google_container_cluster" "primary" {
       enabled = confidential_nodes.value.enabled
     }
   }
+  node_config {
+    service_account = local.service_account
+  }
 
   subnetwork = "projects/${local.network_project_id}/regions/${local.region}/subnetworks/${var.subnetwork}"
 

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -45,6 +45,9 @@ resource "google_container_cluster" "primary" {
       enabled = confidential_nodes.value.enabled
     }
   }
+  node_config {
+    service_account = local.service_account
+  }
 
   subnetwork = "projects/${local.network_project_id}/regions/${local.region}/subnetworks/${var.subnetwork}"
 


### PR DESCRIPTION
Use the suggestion mentioned here: https://github.com/hashicorp/terraform-provider-google/issues/8918#issuecomment-860444750