### PR TITLE
Add keeper for `enable_secure_boot` nodepool option for update variant.

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -440,6 +440,7 @@ locals {
     {% endif %}
     "service_account",
     "enable_gcfs",
+    "enable_secure_boot",
   ]
 }
 

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -379,6 +379,7 @@ locals {
     "spot",
     "service_account",
     "enable_gcfs",
+    "enable_secure_boot",
   ]
 }
 

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -360,6 +360,7 @@ locals {
     "spot",
     "service_account",
     "enable_gcfs",
+    "enable_secure_boot",
   ]
 }
 

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -252,6 +252,7 @@ locals {
     "preemptible",
     "service_account",
     "enable_gcfs",
+    "enable_secure_boot",
   ]
 }
 


### PR DESCRIPTION
As changing the enable_secure_boot config currently forces a replacement of
the node pool, see:
https://github.com/hashicorp/terraform-provider-google/blob/5290a9f74d491bd3a05c32cdc60773ac6c53d4ae/google/node_config.go#L217

Fixes #1276 