### PR TITLE
ASM module - Add a note about the `mesh_id` label on the GKE cluster

### DIFF
--- a/modules/asm/README.md
+++ b/modules/asm/README.md
@@ -33,6 +33,13 @@ module "asm" {
 }
 ```
 
+Note that the `mesh_id` label on the cluster is required for metrics to get displayed on the Anthos Service Mesh pages in the Cloud console (Topology, etc.). Illustrated with the full example mentioned above, here is an example of what your cluster should have:
+```tf
+...
+cluster_resource_labels = { "mesh_id" : "proj-${data.google_project.project.number}" }
+...
+```
+
 To deploy this config:
 
 1. Run `terraform apply`

--- a/modules/asm/README.md
+++ b/modules/asm/README.md
@@ -35,6 +35,7 @@ module "asm" {
 
 Note that the `mesh_id` label on the cluster is required for metrics to get displayed on the Anthos Service Mesh pages in the Cloud console (Topology, etc.). Illustrated with the full example mentioned above, here is an example of what your cluster should have:
 ```tf
+module "gke" {
 ...
 cluster_resource_labels = { "mesh_id" : "proj-${data.google_project.project.number}" }
 ...

--- a/modules/asm/README.md
+++ b/modules/asm/README.md
@@ -33,12 +33,13 @@ module "asm" {
 }
 ```
 
-Note that the `mesh_id` label on the cluster is required for metrics to get displayed on the Anthos Service Mesh pages in the Cloud console (Topology, etc.). Illustrated with the full example mentioned above, here is an example of what your cluster should have:
+Note that the [`mesh_id` label on the cluster](https://cloud.google.com/service-mesh/docs/managed/auto-control-plane-with-fleet#apply_the_mesh_id_label) is required for metrics to get displayed on the Anthos Service Mesh pages in the Cloud console (Topology, etc.). Illustrated with the full example mentioned above, here is an example of what your cluster should have:
 ```tf
 module "gke" {
 ...
-cluster_resource_labels = { "mesh_id" : "proj-${data.google_project.project.number}" }
+  cluster_resource_labels = { "mesh_id" : "proj-${data.google_project.project.number}" }
 ...
+}
 ```
 
 To deploy this config:


### PR DESCRIPTION
Now that the ASM module is not using the `install_asm` or the `asmcli`, the users need to manually set the `mesh_id` on their GKE cluster in order to get the ASM features in the Google Cloud console working (Topology, etc.). Even if it's illustrated in the simple zonal with ASM example, it's not obvious for the ASM module user. We got some evidence internally about Googlers and customers having issues with that.

I'm proposing adding an explicit note about that on the main ASM module doc.