### PR TITLE
feat: source node pools' auto_upgrade configuration from the GKE default config

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -530,7 +530,7 @@ resource "google_container_node_pool" "pools" {
 
   cluster = google_container_cluster.primary.name
 
-  version = lookup(each.value, "auto_upgrade", false) ? "" : lookup(
+  version = lookup(each.value, "auto_upgrade", local.default_auto_upgrade) ? "" : lookup(
     each.value,
     "version",
     google_container_cluster.primary.min_master_version,

--- a/cluster.tf
+++ b/cluster.tf
@@ -259,7 +259,7 @@ resource "google_container_node_pool" "pools" {
 
   cluster = google_container_cluster.primary.name
 
-  version = lookup(each.value, "auto_upgrade", false) ? "" : lookup(
+  version = lookup(each.value, "auto_upgrade", local.default_auto_upgrade) ? "" : lookup(
     each.value,
     "version",
     google_container_cluster.primary.min_master_version,

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -465,7 +465,7 @@ resource "google_container_node_pool" "pools" {
 
   cluster = google_container_cluster.primary.name
 
-  version = lookup(each.value, "auto_upgrade", false) ? "" : lookup(
+  version = lookup(each.value, "auto_upgrade", local.default_auto_upgrade) ? "" : lookup(
     each.value,
     "version",
     google_container_cluster.primary.min_master_version,

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -377,7 +377,7 @@ resource "google_container_node_pool" "pools" {
 
   cluster = google_container_cluster.primary.name
 
-  version = lookup(each.value, "auto_upgrade", false) ? "" : lookup(
+  version = lookup(each.value, "auto_upgrade", local.default_auto_upgrade) ? "" : lookup(
     each.value,
     "version",
     google_container_cluster.primary.min_master_version,

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -446,7 +446,7 @@ resource "google_container_node_pool" "pools" {
 
   cluster = google_container_cluster.primary.name
 
-  version = lookup(each.value, "auto_upgrade", false) ? "" : lookup(
+  version = lookup(each.value, "auto_upgrade", local.default_auto_upgrade) ? "" : lookup(
     each.value,
     "version",
     google_container_cluster.primary.min_master_version,

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -358,7 +358,7 @@ resource "google_container_node_pool" "pools" {
 
   cluster = google_container_cluster.primary.name
 
-  version = lookup(each.value, "auto_upgrade", false) ? "" : lookup(
+  version = lookup(each.value, "auto_upgrade", local.default_auto_upgrade) ? "" : lookup(
     each.value,
     "version",
     google_container_cluster.primary.min_master_version,

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -359,7 +359,7 @@ resource "google_container_node_pool" "pools" {
 
   cluster = google_container_cluster.primary.name
 
-  version = lookup(each.value, "auto_upgrade", false) ? "" : lookup(
+  version = lookup(each.value, "auto_upgrade", local.default_auto_upgrade) ? "" : lookup(
     each.value,
     "version",
     google_container_cluster.primary.min_master_version,

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -272,7 +272,7 @@ resource "google_container_node_pool" "pools" {
 
   cluster = google_container_cluster.primary.name
 
-  version = lookup(each.value, "auto_upgrade", false) ? "" : lookup(
+  version = lookup(each.value, "auto_upgrade", local.default_auto_upgrade) ? "" : lookup(
     each.value,
     "version",
     google_container_cluster.primary.min_master_version,


### PR DESCRIPTION
Allows the module to use the `default_auto_upgrade` to infer if the auto_upgrade is enabled for the node pool. This is in line with how the `auto_upgrade` config is [calculated in the `node_pool` resource ](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/compare/master...MrwanBaghdad%3Amaster?body=&expand=1)

```
  management {
    auto_repair  = lookup(each.value, "auto_repair", true)
    auto_upgrade = lookup(each.value, "auto_upgrade", local.default_auto_upgrade)
  }
```
