### PR TITLE
feat!: promote Spot VM to GA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ Session.vim
 # IntelliJ IDEA files:
 .idea/
 
+# Visual Studio Code files:
+.vscode/
+
 ### https://raw.github.com/github/gitignore/90f149de451a5433aebd94d02d11b0e28843a1af/Terraform.gitignore
 
 # Local .terraform directories

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ module "gke" {
       min_count                 = 1
       max_count                 = 100
       local_ssd_count           = 0
+      spot                      = false
       disk_size_gb              = 100
       disk_type                 = "pd-standard"
       image_type                = "COS_CONTAINERD"
@@ -254,6 +255,7 @@ The node_pools variable takes the following parameters:
 | node_locations | The list of zones in which the cluster's nodes are located. Nodes must be in the region of their regional cluster or in the same region as their cluster's zone for zonal clusters. Defaults to cluster level node locations if nothing is specified | " " | Optional |
 | node_metadata | Options to expose the node metadata to the workload running on the node | | Optional |
 | preemptible | A boolean that represents whether or not the underlying node VMs are preemptible | false | Optional |
+| spot | A boolean that represents whether the underlying node VMs are spot | false | Optional |
 | service_account | The service account to be used by the Node VMs | " " | Optional |
 | tags | The list of instance tags applied to all nodes | | Required |
 | value | The value for the taint | | Required |

--- a/autogen/main/README.md
+++ b/autogen/main/README.md
@@ -101,8 +101,8 @@ module "gke" {
       min_count                 = 1
       max_count                 = 100
       local_ssd_count           = 0
-      {% if beta_cluster %}
       spot                      = false
+      {% if beta_cluster %}
       local_ssd_ephemeral_count = 0
       {% endif %}
       disk_size_gb              = 100
@@ -223,8 +223,8 @@ The node_pools variable takes the following parameters:
 | node_locations | The list of zones in which the cluster's nodes are located. Nodes must be in the region of their regional cluster or in the same region as their cluster's zone for zonal clusters. Defaults to cluster level node locations if nothing is specified | " " | Optional |
 | node_metadata | Options to expose the node metadata to the workload running on the node | | Optional |
 | preemptible | A boolean that represents whether or not the underlying node VMs are preemptible | false | Optional |
-{% if beta_cluster %}
 | spot | A boolean that represents whether the underlying node VMs are spot | false | Optional |
+{% if beta_cluster %}
 | sandbox_type | Sandbox to use for pods in the node pool | | Required |
 {% endif %}
 | service_account | The service account to be used by the Node VMs | " " | Optional |

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -429,9 +429,7 @@ locals {
     "machine_type",
     "min_cpu_platform",
     "preemptible",
-    {% if beta_cluster %}
     "spot",
-    {% endif %}
     "service_account",
     "enable_gcfs",
     "enable_secure_boot",
@@ -637,9 +635,7 @@ resource "google_container_node_pool" "pools" {
       local.service_account,
     )
     preemptible = lookup(each.value, "preemptible", false)
-    {% if beta_cluster %}
     spot = lookup(each.value, "spot", false)
-    {% endif %}
 
     oauth_scopes = concat(
       local.node_pools_oauth_scopes["all"],

--- a/autogen/main/versions.tf.tmpl
+++ b/autogen/main/versions.tf.tmpl
@@ -38,7 +38,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.10.0, < 5.0"
+      version = ">= 4.25.0, < 5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/cluster.tf
+++ b/cluster.tf
@@ -344,6 +344,7 @@ resource "google_container_node_pool" "pools" {
       local.service_account,
     )
     preemptible = lookup(each.value, "preemptible", false)
+    spot        = lookup(each.value, "spot", false)
 
     oauth_scopes = concat(
       local.node_pools_oauth_scopes["all"],

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -83,6 +83,7 @@ module "gke" {
       min_count                 = 1
       max_count                 = 100
       local_ssd_count           = 0
+      spot                      = false
       disk_size_gb              = 100
       disk_type                 = "pd-standard"
       image_type                = "COS_CONTAINERD"
@@ -288,6 +289,7 @@ The node_pools variable takes the following parameters:
 | node_locations | The list of zones in which the cluster's nodes are located. Nodes must be in the region of their regional cluster or in the same region as their cluster's zone for zonal clusters. Defaults to cluster level node locations if nothing is specified | " " | Optional |
 | node_metadata | Options to expose the node metadata to the workload running on the node | | Optional |
 | preemptible | A boolean that represents whether or not the underlying node VMs are preemptible | false | Optional |
+| spot | A boolean that represents whether the underlying node VMs are spot | false | Optional |
 | service_account | The service account to be used by the Node VMs | " " | Optional |
 | tags | The list of instance tags applied to all nodes | | Required |
 | value | The value for the taint | | Required |

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -271,6 +271,7 @@ locals {
     "machine_type",
     "min_cpu_platform",
     "preemptible",
+    "spot",
     "service_account",
     "enable_gcfs",
     "enable_secure_boot",
@@ -444,6 +445,7 @@ resource "google_container_node_pool" "pools" {
       local.service_account,
     )
     preemptible = lookup(each.value, "preemptible", false)
+    spot        = lookup(each.value, "spot", false)
 
     oauth_scopes = concat(
       local.node_pools_oauth_scopes["all"],

--- a/modules/private-cluster-update-variant/versions.tf
+++ b/modules/private-cluster-update-variant/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.10.0, < 5.0"
+      version = ">= 4.25.0, < 5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -61,6 +61,7 @@ module "gke" {
       min_count                 = 1
       max_count                 = 100
       local_ssd_count           = 0
+      spot                      = false
       disk_size_gb              = 100
       disk_type                 = "pd-standard"
       image_type                = "COS_CONTAINERD"
@@ -266,6 +267,7 @@ The node_pools variable takes the following parameters:
 | node_locations | The list of zones in which the cluster's nodes are located. Nodes must be in the region of their regional cluster or in the same region as their cluster's zone for zonal clusters. Defaults to cluster level node locations if nothing is specified | " " | Optional |
 | node_metadata | Options to expose the node metadata to the workload running on the node | | Optional |
 | preemptible | A boolean that represents whether or not the underlying node VMs are preemptible | false | Optional |
+| spot | A boolean that represents whether the underlying node VMs are spot | false | Optional |
 | service_account | The service account to be used by the Node VMs | " " | Optional |
 | tags | The list of instance tags applied to all nodes | | Required |
 | value | The value for the taint | | Required |

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -357,6 +357,7 @@ resource "google_container_node_pool" "pools" {
       local.service_account,
     )
     preemptible = lookup(each.value, "preemptible", false)
+    spot        = lookup(each.value, "spot", false)
 
     oauth_scopes = concat(
       local.node_pools_oauth_scopes["all"],

--- a/modules/private-cluster/versions.tf
+++ b/modules/private-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.10.0, < 5.0"
+      version = ">= 4.25.0, < 5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/versions.tf
+++ b/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.10.0, < 5.0"
+      version = ">= 4.25.0, < 5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
Hi,
with the release `v4.25.0` of the Google provider, we can now use Spot VM on stable cluster.

Thank you