### PR TITLE
Exposing use_existing_context variable

### DIFF
--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -106,6 +106,7 @@ already bear the `"iam.gke.io/gcp-service-account"` annotation.
 | namespace | Namespace for the Kubernetes service account | `string` | `"default"` | no |
 | project\_id | GCP project ID | `string` | n/a | yes |
 | roles | A list of roles to be added to the created service account | `list(string)` | `[]` | no |
+| use\_existing\_context | An optional flag to use local kubectl config context. | `bool` | `false` | no |
 | use\_existing\_gcp\_sa | Use an existing Google service account instead of creating one | `bool` | `false` | no |
 | use\_existing\_k8s\_sa | Use an existing kubernetes service account instead of creating one | `bool` | `false` | no |
 

--- a/modules/workload-identity/main.tf
+++ b/modules/workload-identity/main.tf
@@ -67,6 +67,7 @@ module "annotate-sa" {
   cluster_location            = var.location
   project_id                  = var.project_id
   impersonate_service_account = var.impersonate_service_account
+  use_existing_context        = var.use_existing_context
 
   kubectl_create_command  = "kubectl annotate --overwrite sa -n ${local.output_k8s_namespace} ${local.k8s_given_name} iam.gke.io/gcp-service-account=${local.gcp_sa_email}"
   kubectl_destroy_command = "kubectl annotate sa -n ${local.output_k8s_namespace} ${local.k8s_given_name} iam.gke.io/gcp-service-account-"

--- a/modules/workload-identity/variables.tf
+++ b/modules/workload-identity/variables.tf
@@ -89,3 +89,9 @@ variable "impersonate_service_account" {
   type        = string
   default     = ""
 }
+
+variable "use_existing_context" {
+  description = "An optional flag to use local kubectl config context."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
exposing use_existing_context variable to allow kubectl wrapper to run kubectl using local kube config context