### PR TITLE
chore: Update tests to use 1.4 image

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,6 +15,7 @@
 driver:
   name: "terraform"
   command_timeout: 2700
+  verify_version: false
 
 provisioner:
   name: "terraform"

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -364,6 +364,6 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.4'
 options:
   machineType: 'N1_HIGHCPU_8'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -22,7 +22,7 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.4'
 options:
   machineType: 'N1_HIGHCPU_8'
   env:


### PR DESCRIPTION
Update tests to use 1.4 image with TF v1.1.x