### PR TITLE
fix: autopilot also supports managed prometheus

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -71,7 +71,7 @@ resource "google_container_cluster" "primary" {
 {% endif %}
   min_master_version = var.release_channel != null ? null : local.master_version
 
-{% if beta_cluster and  autopilot_cluster != true %}
+{% if beta_cluster and autopilot_cluster != true %}
   dynamic "cluster_telemetry" {
     for_each = local.cluster_telemetry_type_is_set ? [1] : []
     content {
@@ -106,6 +106,17 @@ resource "google_container_cluster" "primary" {
 {% else %}
   logging_service    = var.logging_service
   monitoring_service = var.monitoring_service
+  {% if beta_cluster %}
+  dynamic "monitoring_config" {
+    for_each = var.monitoring_enable_managed_prometheus ? [1] : []
+
+    content {
+      managed_prometheus {
+        enabled = var.monitoring_enable_managed_prometheus
+      }
+    }
+  }
+  {% endif %}
 {% endif %}
   {% if autopilot_cluster != true %}
   cluster_autoscaling {

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -583,7 +583,8 @@ variable "timeouts" {
     error_message = "Only create, update, delete timeouts can be specified."
   }
 }
-{% if beta_cluster and  autopilot_cluster != true %}
+{% if beta_cluster %}
+  {% if autopilot_cluster != true %}
 
 variable "enable_kubernetes_alpha" {
   type        = bool
@@ -602,12 +603,14 @@ variable "monitoring_enabled_components" {
   description = "List of services to monitor: SYSTEM_COMPONENTS, WORKLOADS (provider version >= 3.89.0). Empty list is default GKE configuration."
   default     = []
 }
+  {% endif %}
 
 variable "monitoring_enable_managed_prometheus" {
   type        = bool
   description = "(Beta) Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled."
   default     = false
 }
+  {% if autopilot_cluster != true %}
 
 variable "istio" {
   description = "(Beta) Enable Istio addon"
@@ -678,4 +681,5 @@ variable "gce_pd_csi_driver" {
   description = "(Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver."
   default     = false
 }
+  {% endif %}
 {% endif %}

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -110,6 +110,7 @@ Then perform the following commands on the root folder:
 | master\_authorized\_networks | List of master authorized networks. If none are provided, disallow external access (except the cluster node IPs, which GKE automatically whitelists). | `list(object({ cidr_block = string, display_name = string }))` | `[]` | no |
 | master\_global\_access\_enabled | (Beta) Whether the cluster master is accessible globally (from any region) or only within the same region as the private endpoint. | `bool` | `true` | no |
 | master\_ipv4\_cidr\_block | (Beta) The IP range in CIDR notation to use for the hosted master network | `string` | `"10.0.0.0/28"` | no |
+| monitoring\_enable\_managed\_prometheus | (Beta) Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled. | `bool` | `false` | no |
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |
 | name | The name of the cluster (required) | `string` | n/a | yes |
 | network | The VPC network to host the cluster in (required) | `string` | n/a | yes |

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -55,6 +55,15 @@ resource "google_container_cluster" "primary" {
 
   logging_service    = var.logging_service
   monitoring_service = var.monitoring_service
+  dynamic "monitoring_config" {
+    for_each = var.monitoring_enable_managed_prometheus ? [1] : []
+
+    content {
+      managed_prometheus {
+        enabled = var.monitoring_enable_managed_prometheus
+      }
+    }
+  }
   vertical_pod_autoscaling {
     enabled = var.enable_vertical_pod_autoscaling
   }

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -392,3 +392,9 @@ variable "timeouts" {
     error_message = "Only create, update, delete timeouts can be specified."
   }
 }
+
+variable "monitoring_enable_managed_prometheus" {
+  type        = bool
+  description = "(Beta) Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled."
+  default     = false
+}

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -99,6 +99,7 @@ Then perform the following commands on the root folder:
 | maintenance\_recurrence | Frequency of the recurring maintenance window in RFC5545 format. | `string` | `""` | no |
 | maintenance\_start\_time | Time window specified for daily or recurring maintenance operations in RFC3339 format | `string` | `"05:00"` | no |
 | master\_authorized\_networks | List of master authorized networks. If none are provided, disallow external access (except the cluster node IPs, which GKE automatically whitelists). | `list(object({ cidr_block = string, display_name = string }))` | `[]` | no |
+| monitoring\_enable\_managed\_prometheus | (Beta) Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled. | `bool` | `false` | no |
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |
 | name | The name of the cluster (required) | `string` | n/a | yes |
 | network | The VPC network to host the cluster in (required) | `string` | n/a | yes |

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -55,6 +55,15 @@ resource "google_container_cluster" "primary" {
 
   logging_service    = var.logging_service
   monitoring_service = var.monitoring_service
+  dynamic "monitoring_config" {
+    for_each = var.monitoring_enable_managed_prometheus ? [1] : []
+
+    content {
+      managed_prometheus {
+        enabled = var.monitoring_enable_managed_prometheus
+      }
+    }
+  }
   vertical_pod_autoscaling {
     enabled = var.enable_vertical_pod_autoscaling
   }

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -361,3 +361,9 @@ variable "timeouts" {
     error_message = "Only create, update, delete timeouts can be specified."
   }
 }
+
+variable "monitoring_enable_managed_prometheus" {
+  type        = bool
+  description = "(Beta) Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled."
+  default     = false
+}


### PR DESCRIPTION
Follow-up #1307

#1307 is missing Autopilot support. This Pull Request will allow Managed Prometheus to be used with Autopilot as well.