### PR TITLE
Allow enabling managed Prometheus for safer cluster variants

### DIFF
--- a/autogen/safer-cluster/main.tf.tmpl
+++ b/autogen/safer-cluster/main.tf.tmpl
@@ -100,6 +100,8 @@ module "gke" {
   logging_service    = var.logging_service
   monitoring_service = var.monitoring_service
 
+  monitoring_enable_managed_prometheus = var.monitoring_enable_managed_prometheus
+
   // We never use the default service account for the cluster. The default
   // project/editor permissions can create problems if nodes were to be ever
   // compromised.

--- a/autogen/safer-cluster/variables.tf.tmpl
+++ b/autogen/safer-cluster/variables.tf.tmpl
@@ -226,6 +226,12 @@ variable "monitoring_service" {
   default     = "monitoring.googleapis.com/kubernetes"
 }
 
+variable "monitoring_enable_managed_prometheus" {
+  type        = bool
+  description = "(Beta) Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled."
+  default     = false
+}
+
 variable "grant_registry_access" {
   type        = bool
   description = "Grants created cluster-specific service account storage.objectViewer role."

--- a/modules/safer-cluster-update-variant/README.md
+++ b/modules/safer-cluster-update-variant/README.md
@@ -240,6 +240,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | maintenance\_start\_time | Time window specified for daily maintenance operations in RFC3339 format | `string` | `"05:00"` | no |
 | master\_authorized\_networks | List of master authorized networks. If none are provided, disallow external access (except the cluster node IPs, which GKE automatically whitelists). | `list(object({ cidr_block = string, display_name = string }))` | `[]` | no |
 | master\_ipv4\_cidr\_block | The IP range in CIDR notation to use for the hosted master network | `string` | `"10.0.0.0/28"` | no |
+| monitoring\_enable\_managed\_prometheus | (Beta) Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled. | `bool` | `false` | no |
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |
 | name | The name of the cluster | `string` | n/a | yes |
 | network | The VPC network to host the cluster in | `string` | n/a | yes |

--- a/modules/safer-cluster-update-variant/main.tf
+++ b/modules/safer-cluster-update-variant/main.tf
@@ -96,6 +96,8 @@ module "gke" {
   logging_service    = var.logging_service
   monitoring_service = var.monitoring_service
 
+  monitoring_enable_managed_prometheus = var.monitoring_enable_managed_prometheus
+
   // We never use the default service account for the cluster. The default
   // project/editor permissions can create problems if nodes were to be ever
   // compromised.

--- a/modules/safer-cluster-update-variant/variables.tf
+++ b/modules/safer-cluster-update-variant/variables.tf
@@ -226,6 +226,12 @@ variable "monitoring_service" {
   default     = "monitoring.googleapis.com/kubernetes"
 }
 
+variable "monitoring_enable_managed_prometheus" {
+  type        = bool
+  description = "(Beta) Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled."
+  default     = false
+}
+
 variable "grant_registry_access" {
   type        = bool
   description = "Grants created cluster-specific service account storage.objectViewer role."

--- a/modules/safer-cluster/README.md
+++ b/modules/safer-cluster/README.md
@@ -240,6 +240,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | maintenance\_start\_time | Time window specified for daily maintenance operations in RFC3339 format | `string` | `"05:00"` | no |
 | master\_authorized\_networks | List of master authorized networks. If none are provided, disallow external access (except the cluster node IPs, which GKE automatically whitelists). | `list(object({ cidr_block = string, display_name = string }))` | `[]` | no |
 | master\_ipv4\_cidr\_block | The IP range in CIDR notation to use for the hosted master network | `string` | `"10.0.0.0/28"` | no |
+| monitoring\_enable\_managed\_prometheus | (Beta) Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled. | `bool` | `false` | no |
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |
 | name | The name of the cluster | `string` | n/a | yes |
 | network | The VPC network to host the cluster in | `string` | n/a | yes |

--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -96,6 +96,8 @@ module "gke" {
   logging_service    = var.logging_service
   monitoring_service = var.monitoring_service
 
+  monitoring_enable_managed_prometheus = var.monitoring_enable_managed_prometheus
+
   // We never use the default service account for the cluster. The default
   // project/editor permissions can create problems if nodes were to be ever
   // compromised.

--- a/modules/safer-cluster/variables.tf
+++ b/modules/safer-cluster/variables.tf
@@ -226,6 +226,12 @@ variable "monitoring_service" {
   default     = "monitoring.googleapis.com/kubernetes"
 }
 
+variable "monitoring_enable_managed_prometheus" {
+  type        = bool
+  description = "(Beta) Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled."
+  default     = false
+}
+
 variable "grant_registry_access" {
   type        = bool
   description = "Grants created cluster-specific service account storage.objectViewer role."


### PR DESCRIPTION
Follow up to https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/1307