### PR TITLE
chore: pin workload_identity example to k8s 1.23

### DIFF
--- a/examples/workload_identity/main.tf
+++ b/examples/workload_identity/main.tf
@@ -38,6 +38,8 @@ module "gke" {
   remove_default_node_pool = true
   service_account          = "create"
   node_metadata            = "GKE_METADATA"
+  # https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1313
+  kubernetes_version = "1.23"
   node_pools = [
     {
       name         = "wi-pool"

--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -14,6 +14,8 @@ The `terraform-google-workload-identity` can create service accounts for you,
 or you can use existing accounts; this applies for both the Google and
 Kubernetes accounts.
 
+Note: This module currently supports Kubernetes <= 1.23.
+
 ### Creating a Workload Identity
 
 ```hcl


### PR DESCRIPTION
* A temporary fix for #1313.  With k8s 1.24 (no channel), the k8s provider resource "kubernetes_service_account" doesn't currently work as expected.  This temporarily sets the workload-identity example/module to k8s 1.23: https://cloud.google.com/kubernetes-engine/docs/release-schedule