### PR TITLE
fix: issue with kubernetes_service_account in k8s 1.24

### DIFF
--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -99,12 +99,12 @@ already bear the `"iam.gke.io/gcp-service-account"` annotation.
 |------|-------------|------|---------|:--------:|
 | annotate\_k8s\_sa | Annotate the kubernetes service account with 'iam.gke.io/gcp-service-account' annotation. Valid in cases when an existing SA is used. | `bool` | `true` | no |
 | automount\_service\_account\_token | Enable automatic mounting of the service account token | `bool` | `false` | no |
-| cluster\_name | Cluster name. Required if using existing KSA. | `string` | `""` | no |
+| cluster\_name | Cluster name. | `string` | `""` | yes |
 | gcp\_sa\_name | Name for the Google service account; overrides `var.name`. | `string` | `null` | no |
 | impersonate\_service\_account | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `""` | no |
 | k8s\_sa\_name | Name for the Kubernetes service account; overrides `var.name`. `cluster_name` and `location` must be set when this input is specified. | `string` | `null` | no |
 | k8s\_sa\_project\_id | GCP project ID of the k8s service account; overrides `var.project_id`. | `string` | `null` | no |
-| location | Cluster location (region if regional cluster, zone if zonal cluster). Required if using existing KSA. | `string` | `""` | no |
+| location | Cluster location (region if regional cluster, zone if zonal cluster). | `string` | `""` | yes |
 | name | Name for both service accounts. The GCP SA will be truncated to the first 30 chars if necessary. | `string` | n/a | yes |
 | namespace | Namespace for the Kubernetes service account | `string` | `"default"` | no |
 | project\_id | GCP project ID | `string` | n/a | yes |

--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -99,12 +99,12 @@ already bear the `"iam.gke.io/gcp-service-account"` annotation.
 |------|-------------|------|---------|:--------:|
 | annotate\_k8s\_sa | Annotate the kubernetes service account with 'iam.gke.io/gcp-service-account' annotation. Valid in cases when an existing SA is used. | `bool` | `true` | no |
 | automount\_service\_account\_token | Enable automatic mounting of the service account token | `bool` | `false` | no |
-| cluster\_name | Cluster name. | `string` | `""` | yes |
+| cluster\_name | Cluster name. | `string` | `""` | no |
 | gcp\_sa\_name | Name for the Google service account; overrides `var.name`. | `string` | `null` | no |
 | impersonate\_service\_account | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `""` | no |
 | k8s\_sa\_name | Name for the Kubernetes service account; overrides `var.name`. `cluster_name` and `location` must be set when this input is specified. | `string` | `null` | no |
 | k8s\_sa\_project\_id | GCP project ID of the k8s service account; overrides `var.project_id`. | `string` | `null` | no |
-| location | Cluster location (region if regional cluster, zone if zonal cluster). | `string` | `""` | yes |
+| location | Cluster location (region if regional cluster, zone if zonal cluster). | `string` | `""` | no |
 | name | Name for both service accounts. The GCP SA will be truncated to the first 30 chars if necessary. | `string` | n/a | yes |
 | namespace | Namespace for the Kubernetes service account | `string` | `"default"` | no |
 | project\_id | GCP project ID | `string` | n/a | yes |

--- a/modules/workload-identity/main.tf
+++ b/modules/workload-identity/main.tf
@@ -59,6 +59,9 @@ resource "kubernetes_manifest" "main_secret" {
 
     "type" = "kubernetes.io/service-account-token"
   }
+  depends_on = [
+    kubernetes_manifest.main_sa
+  ]
 }
 
 resource "kubernetes_manifest" "main_sa" {
@@ -81,9 +84,6 @@ resource "kubernetes_manifest" "main_sa" {
       }
     ]
   }
-  depends_on = [
-    kubernetes_manifest.main_secret
-  ]
 }
 
 module "annotate-sa" {

--- a/modules/workload-identity/main.tf
+++ b/modules/workload-identity/main.tf
@@ -83,7 +83,7 @@ EOF
 EOT
 
   kubectl_destroy_command = <<-EOT
-kubectl delete -f - <<EOF
+kubectl delete -f - <<EOF || echo "resource does not exist"
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -93,9 +93,9 @@ metadata:
     iam.gke.io/gcp-service-account: ${local.gcp_sa_email}
 secrets:
 - name: ${local.k8s_given_name}
-EOF || echo "resource does not exist"
+EOF
 
-kubectl delete -f - <<EOF
+kubectl delete -f - <<EOF || echo "resource does not exist"
 apiVersion: v1
 kind: Secret
 metadata:
@@ -104,7 +104,7 @@ metadata:
   annotations:
     kubernetes.io/service-account.name: ${local.k8s_given_name}
 type: kubernetes.io/service-account-token
-EOF || echo "resource does not exist"
+EOF
 EOT
 }
 

--- a/modules/workload-identity/variables.tf
+++ b/modules/workload-identity/variables.tf
@@ -39,11 +39,13 @@ variable "use_existing_gcp_sa" {
 variable "cluster_name" {
   description = "Cluster name."
   type        = string
+  default     = ""
 }
 
 variable "location" {
   description = "Cluster location (region if regional cluster, zone if zonal cluster)."
   type        = string
+  default     = ""
 }
 
 variable "k8s_sa_name" {

--- a/modules/workload-identity/variables.tf
+++ b/modules/workload-identity/variables.tf
@@ -37,15 +37,13 @@ variable "use_existing_gcp_sa" {
 }
 
 variable "cluster_name" {
-  description = "Cluster name. Required if using existing KSA."
+  description = "Cluster name."
   type        = string
-  default     = ""
 }
 
 variable "location" {
-  description = "Cluster location (region if regional cluster, zone if zonal cluster). Required if using existing KSA."
+  description = "Cluster location (region if regional cluster, zone if zonal cluster)."
   type        = string
-  default     = ""
 }
 
 variable "k8s_sa_name" {


### PR DESCRIPTION
The problem when generating new service accounts, is that the secret containing the SA token is no longer generated automatically since the `LegacyServiceAccountTokenNoAutoGeneration` feature gate was enabled as true in Kubernetes clusters version 1.24.
(references: https://github.com/kubernetes/enhancements/issues/2799
https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/)

This is the reported issue for the terraform resource `kubernetes_service_account`
https://github.com/hashicorp/terraform-provider-kubernetes/issues/1724

Alternative changes were made using the terraform resource `kubernetes_manifest` to manually generate the service accounts along with their secret