### PR TITLE
fix: resolve deprecation warning for binary authorization

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -151,7 +151,14 @@ resource "google_container_cluster" "primary" {
   {% if autopilot_cluster != true %}
   default_max_pods_per_node = var.default_max_pods_per_node
   enable_shielded_nodes       = var.enable_shielded_nodes
-  enable_binary_authorization = var.enable_binary_authorization
+
+  dynamic "binary_authorization" {
+    for_each = var.enable_binary_authorization ? [var.enable_binary_authorization] : []
+    content {
+      evaluation_mode = "PROJECT_SINGLETON_POLICY_ENFORCE"
+    }
+  }
+
   {% if beta_cluster %}
   enable_intranode_visibility = var.enable_intranode_visibility
   enable_kubernetes_alpha     = var.enable_kubernetes_alpha

--- a/cluster.tf
+++ b/cluster.tf
@@ -76,9 +76,16 @@ resource "google_container_cluster" "primary" {
   vertical_pod_autoscaling {
     enabled = var.enable_vertical_pod_autoscaling
   }
-  default_max_pods_per_node   = var.default_max_pods_per_node
-  enable_shielded_nodes       = var.enable_shielded_nodes
-  enable_binary_authorization = var.enable_binary_authorization
+  default_max_pods_per_node = var.default_max_pods_per_node
+  enable_shielded_nodes     = var.enable_shielded_nodes
+
+  dynamic "binary_authorization" {
+    for_each = var.enable_binary_authorization ? [var.enable_binary_authorization] : []
+    content {
+      evaluation_mode = "PROJECT_SINGLETON_POLICY_ENFORCE"
+    }
+  }
+
   dynamic "master_authorized_networks_config" {
     for_each = local.master_authorized_networks_config
     content {

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -116,9 +116,16 @@ resource "google_container_cluster" "primary" {
   vertical_pod_autoscaling {
     enabled = var.enable_vertical_pod_autoscaling
   }
-  default_max_pods_per_node   = var.default_max_pods_per_node
-  enable_shielded_nodes       = var.enable_shielded_nodes
-  enable_binary_authorization = var.enable_binary_authorization
+  default_max_pods_per_node = var.default_max_pods_per_node
+  enable_shielded_nodes     = var.enable_shielded_nodes
+
+  dynamic "binary_authorization" {
+    for_each = var.enable_binary_authorization ? [var.enable_binary_authorization] : []
+    content {
+      evaluation_mode = "PROJECT_SINGLETON_POLICY_ENFORCE"
+    }
+  }
+
   enable_intranode_visibility = var.enable_intranode_visibility
   enable_kubernetes_alpha     = var.enable_kubernetes_alpha
   enable_tpu                  = var.enable_tpu

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -116,9 +116,16 @@ resource "google_container_cluster" "primary" {
   vertical_pod_autoscaling {
     enabled = var.enable_vertical_pod_autoscaling
   }
-  default_max_pods_per_node   = var.default_max_pods_per_node
-  enable_shielded_nodes       = var.enable_shielded_nodes
-  enable_binary_authorization = var.enable_binary_authorization
+  default_max_pods_per_node = var.default_max_pods_per_node
+  enable_shielded_nodes     = var.enable_shielded_nodes
+
+  dynamic "binary_authorization" {
+    for_each = var.enable_binary_authorization ? [var.enable_binary_authorization] : []
+    content {
+      evaluation_mode = "PROJECT_SINGLETON_POLICY_ENFORCE"
+    }
+  }
+
   enable_intranode_visibility = var.enable_intranode_visibility
   enable_kubernetes_alpha     = var.enable_kubernetes_alpha
   enable_tpu                  = var.enable_tpu

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -116,9 +116,16 @@ resource "google_container_cluster" "primary" {
   vertical_pod_autoscaling {
     enabled = var.enable_vertical_pod_autoscaling
   }
-  default_max_pods_per_node   = var.default_max_pods_per_node
-  enable_shielded_nodes       = var.enable_shielded_nodes
-  enable_binary_authorization = var.enable_binary_authorization
+  default_max_pods_per_node = var.default_max_pods_per_node
+  enable_shielded_nodes     = var.enable_shielded_nodes
+
+  dynamic "binary_authorization" {
+    for_each = var.enable_binary_authorization ? [var.enable_binary_authorization] : []
+    content {
+      evaluation_mode = "PROJECT_SINGLETON_POLICY_ENFORCE"
+    }
+  }
+
   enable_intranode_visibility = var.enable_intranode_visibility
   enable_kubernetes_alpha     = var.enable_kubernetes_alpha
   enable_tpu                  = var.enable_tpu

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -116,9 +116,16 @@ resource "google_container_cluster" "primary" {
   vertical_pod_autoscaling {
     enabled = var.enable_vertical_pod_autoscaling
   }
-  default_max_pods_per_node   = var.default_max_pods_per_node
-  enable_shielded_nodes       = var.enable_shielded_nodes
-  enable_binary_authorization = var.enable_binary_authorization
+  default_max_pods_per_node = var.default_max_pods_per_node
+  enable_shielded_nodes     = var.enable_shielded_nodes
+
+  dynamic "binary_authorization" {
+    for_each = var.enable_binary_authorization ? [var.enable_binary_authorization] : []
+    content {
+      evaluation_mode = "PROJECT_SINGLETON_POLICY_ENFORCE"
+    }
+  }
+
   enable_intranode_visibility = var.enable_intranode_visibility
   enable_kubernetes_alpha     = var.enable_kubernetes_alpha
   enable_tpu                  = var.enable_tpu

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -76,9 +76,16 @@ resource "google_container_cluster" "primary" {
   vertical_pod_autoscaling {
     enabled = var.enable_vertical_pod_autoscaling
   }
-  default_max_pods_per_node   = var.default_max_pods_per_node
-  enable_shielded_nodes       = var.enable_shielded_nodes
-  enable_binary_authorization = var.enable_binary_authorization
+  default_max_pods_per_node = var.default_max_pods_per_node
+  enable_shielded_nodes     = var.enable_shielded_nodes
+
+  dynamic "binary_authorization" {
+    for_each = var.enable_binary_authorization ? [var.enable_binary_authorization] : []
+    content {
+      evaluation_mode = "PROJECT_SINGLETON_POLICY_ENFORCE"
+    }
+  }
+
   dynamic "master_authorized_networks_config" {
     for_each = local.master_authorized_networks_config
     content {

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -76,9 +76,16 @@ resource "google_container_cluster" "primary" {
   vertical_pod_autoscaling {
     enabled = var.enable_vertical_pod_autoscaling
   }
-  default_max_pods_per_node   = var.default_max_pods_per_node
-  enable_shielded_nodes       = var.enable_shielded_nodes
-  enable_binary_authorization = var.enable_binary_authorization
+  default_max_pods_per_node = var.default_max_pods_per_node
+  enable_shielded_nodes     = var.enable_shielded_nodes
+
+  dynamic "binary_authorization" {
+    for_each = var.enable_binary_authorization ? [var.enable_binary_authorization] : []
+    content {
+      evaluation_mode = "PROJECT_SINGLETON_POLICY_ENFORCE"
+    }
+  }
+
   dynamic "master_authorized_networks_config" {
     for_each = local.master_authorized_networks_config
     content {

--- a/test/integration/beta_cluster/controls/gcloud.rb
+++ b/test/integration/beta_cluster/controls/gcloud.rb
@@ -81,7 +81,7 @@ control "gcloud" do
 
       it "has the expected binaryAuthorization config" do
         expect(data['binaryAuthorization']).to eq({
-          "enabled" => true,
+          "evaluationMode" => "PROJECT_SINGLETON_POLICY_ENFORCE",
         })
       end
 

--- a/test/integration/safer_cluster/controls/gcloud.rb
+++ b/test/integration/safer_cluster/controls/gcloud.rb
@@ -76,7 +76,7 @@ control "gcloud" do
 
     it "has binary authorization" do
       expect(data['binaryAuthorization']).to eq({
-        "enabled" => true,
+        "evaluationMode" => "PROJECT_SINGLETON_POLICY_ENFORCE",
       })
     end
 

--- a/test/integration/simple_regional/controls/gcloud.rb
+++ b/test/integration/simple_regional/controls/gcloud.rb
@@ -70,7 +70,7 @@ control "gcloud" do
 
       it "has the expected binaryAuthorization config" do
         expect(data['binaryAuthorization']).to eq({
-          "enabled" => true,
+          "evaluationMode" => "PROJECT_SINGLETON_POLICY_ENFORCE",
         })
       end
     end


### PR DESCRIPTION
`enable_binary_authorization` is now deprecated in favor of the `binary_authorization` block. This preserves the module's interface, but updates the underlying behavior

Fixes #1331