### PR TITLE
fix: support explicit k8s version with unspecified release channel

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -69,7 +69,7 @@ resource "google_container_cluster" "primary" {
     disabled = var.disable_default_snat
   }
 {% endif %}
-  min_master_version = var.release_channel != null ? null : local.master_version
+  min_master_version = var.release_channel == null || var.release_channel == "UNSPECIFIED" ? local.master_version : null
 
 {% if beta_cluster and autopilot_cluster != true %}
   dynamic "cluster_telemetry" {

--- a/cluster.tf
+++ b/cluster.tf
@@ -50,7 +50,7 @@ resource "google_container_cluster" "primary" {
 
   subnetwork = "projects/${local.network_project_id}/regions/${local.region}/subnetworks/${var.subnetwork}"
 
-  min_master_version = var.release_channel != null ? null : local.master_version
+  min_master_version = var.release_channel == null || var.release_channel == "UNSPECIFIED" ? local.master_version : null
 
   logging_service    = var.logging_service
   monitoring_service = var.monitoring_service

--- a/examples/safer_cluster/README.md
+++ b/examples/safer_cluster/README.md
@@ -17,6 +17,7 @@ This example illustrates how to instantiate the opinionated Safer Cluster module
 | ca\_certificate | The cluster ca certificate (base64 encoded) |
 | client\_token | The bearer token for auth |
 | cluster\_name | Cluster name |
+| explicit\_k8s\_version | Explicit version used for cluster creation |
 | kubernetes\_endpoint | The cluster endpoint |
 | location | n/a |
 | master\_kubernetes\_version | Kubernetes version of the master |

--- a/examples/safer_cluster/outputs.tf
+++ b/examples/safer_cluster/outputs.tf
@@ -74,3 +74,8 @@ output "project_id" {
   description = "The project ID the cluster is in"
   value       = var.project_id
 }
+
+output "explicit_k8s_version" {
+  description = "Explicit version used for cluster creation"
+  value       = random_shuffle.version.result[0]
+}

--- a/examples/safer_cluster/versions.tf
+++ b/examples/safer_cluster/versions.tf
@@ -29,7 +29,8 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.0"
     }
   }
 }

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -51,7 +51,7 @@ resource "google_container_cluster" "primary" {
   default_snat_status {
     disabled = var.disable_default_snat
   }
-  min_master_version = var.release_channel != null ? null : local.master_version
+  min_master_version = var.release_channel == null || var.release_channel == "UNSPECIFIED" ? local.master_version : null
 
   logging_service    = var.logging_service
   monitoring_service = var.monitoring_service

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -51,7 +51,7 @@ resource "google_container_cluster" "primary" {
   default_snat_status {
     disabled = var.disable_default_snat
   }
-  min_master_version = var.release_channel != null ? null : local.master_version
+  min_master_version = var.release_channel == null || var.release_channel == "UNSPECIFIED" ? local.master_version : null
 
   logging_service    = var.logging_service
   monitoring_service = var.monitoring_service

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -59,7 +59,7 @@ resource "google_container_cluster" "primary" {
   default_snat_status {
     disabled = var.disable_default_snat
   }
-  min_master_version = var.release_channel != null ? null : local.master_version
+  min_master_version = var.release_channel == null || var.release_channel == "UNSPECIFIED" ? local.master_version : null
 
   dynamic "cluster_telemetry" {
     for_each = local.cluster_telemetry_type_is_set ? [1] : []

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -59,7 +59,7 @@ resource "google_container_cluster" "primary" {
   default_snat_status {
     disabled = var.disable_default_snat
   }
-  min_master_version = var.release_channel != null ? null : local.master_version
+  min_master_version = var.release_channel == null || var.release_channel == "UNSPECIFIED" ? local.master_version : null
 
   dynamic "cluster_telemetry" {
     for_each = local.cluster_telemetry_type_is_set ? [1] : []

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -59,7 +59,7 @@ resource "google_container_cluster" "primary" {
   default_snat_status {
     disabled = var.disable_default_snat
   }
-  min_master_version = var.release_channel != null ? null : local.master_version
+  min_master_version = var.release_channel == null || var.release_channel == "UNSPECIFIED" ? local.master_version : null
 
   dynamic "cluster_telemetry" {
     for_each = local.cluster_telemetry_type_is_set ? [1] : []

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -59,7 +59,7 @@ resource "google_container_cluster" "primary" {
   default_snat_status {
     disabled = var.disable_default_snat
   }
-  min_master_version = var.release_channel != null ? null : local.master_version
+  min_master_version = var.release_channel == null || var.release_channel == "UNSPECIFIED" ? local.master_version : null
 
   dynamic "cluster_telemetry" {
     for_each = local.cluster_telemetry_type_is_set ? [1] : []

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -50,7 +50,7 @@ resource "google_container_cluster" "primary" {
 
   subnetwork = "projects/${local.network_project_id}/regions/${local.region}/subnetworks/${var.subnetwork}"
 
-  min_master_version = var.release_channel != null ? null : local.master_version
+  min_master_version = var.release_channel == null || var.release_channel == "UNSPECIFIED" ? local.master_version : null
 
   logging_service    = var.logging_service
   monitoring_service = var.monitoring_service

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -50,7 +50,7 @@ resource "google_container_cluster" "primary" {
 
   subnetwork = "projects/${local.network_project_id}/regions/${local.region}/subnetworks/${var.subnetwork}"
 
-  min_master_version = var.release_channel != null ? null : local.master_version
+  min_master_version = var.release_channel == null || var.release_channel == "UNSPECIFIED" ? local.master_version : null
 
   logging_service    = var.logging_service
   monitoring_service = var.monitoring_service

--- a/test/fixtures/safer_cluster/outputs.tf
+++ b/test/fixtures/safer_cluster/outputs.tf
@@ -55,3 +55,7 @@ output "service_account" {
   description = "The service account to default running nodes as if not overridden in `node_pools`."
   value       = module.example.service_account
 }
+
+output "explicit_k8s_version" {
+  value = module.example.explicit_k8s_version
+}

--- a/test/integration/safer_cluster/controls/gcloud.rb
+++ b/test/integration/safer_cluster/controls/gcloud.rb
@@ -15,6 +15,7 @@
 project_id = attribute('project_id')
 location = attribute('location')
 cluster_name = attribute('cluster_name')
+explicit_version = attribute('explicit_k8s_version')
 
 control "gcloud" do
   title "Google Compute Engine GKE configuration"
@@ -33,6 +34,11 @@ control "gcloud" do
     describe "cluster" do
       it "is running" do
         expect(data['status']).to eq 'RUNNING'
+      end
+
+      it "has expected explicit version" do
+        expect(data['currentMasterVersion']).to eq explicit_version
+        expect(data['currentNodeVersion']).to eq explicit_version
       end
 
       it "is regional" do


### PR DESCRIPTION
fixes #1279

Add support for setting `kubernetes_version` when release_channel is set to `UNSPECIFIED`. Per [API](https://cloud.google.com/kubernetes-engine/docs/reference/rest/Shared.Types/Channel) `UNSPECIFIED` is equal to not setting a channel.  Also adds test to validate a custom specified version is used.