### PR TITLE
fix: add depends_on to asm module google_container_cluster data resource

### DIFF
--- a/modules/asm/main.tf
+++ b/modules/asm/main.tf
@@ -29,6 +29,8 @@ data "google_container_cluster" "asm" {
   project  = var.project_id
   name     = var.cluster_name
   location = var.cluster_location
+
+  depends_on = [var.module_depends_on]
 }
 
 resource "kubernetes_namespace" "system" {


### PR DESCRIPTION
Fixes https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1364