### PR TITLE
Allow enabling GKE backup agent for safer cluster variants

### DIFF
--- a/autogen/safer-cluster/main.tf.tmpl
+++ b/autogen/safer-cluster/main.tf.tmpl
@@ -151,9 +151,6 @@ module "gke" {
 
   cluster_dns_domain = var.cluster_dns_domain
 
-  config_connector = var.config_connector
-
-
   default_max_pods_per_node = var.default_max_pods_per_node
 
   database_encryption = var.database_encryption

--- a/autogen/safer-cluster/main.tf.tmpl
+++ b/autogen/safer-cluster/main.tf.tmpl
@@ -141,7 +141,8 @@ module "gke" {
 
   dns_cache = var.dns_cache
 
-  config_connector = var.config_connector
+  config_connector        = var.config_connector
+  gke_backup_agent_config = var.gke_backup_agent_config
 
   default_max_pods_per_node = var.default_max_pods_per_node
 

--- a/autogen/safer-cluster/variables.tf.tmpl
+++ b/autogen/safer-cluster/variables.tf.tmpl
@@ -400,6 +400,12 @@ variable "config_connector" {
   default     = false
 }
 
+variable "gke_backup_agent_config" {
+  type        = bool
+  description = "(Beta) Whether Backup for GKE agent is enabled for this cluster."
+  default     = false
+}
+
 variable "disable_default_snat" {
   type        = bool
   description = "Whether to disable the default SNAT to support the private use of public IP addresses"

--- a/modules/safer-cluster-update-variant/README.md
+++ b/modules/safer-cluster-update-variant/README.md
@@ -224,6 +224,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | `bool` | `true` | no |
+| gke\_backup\_agent\_config | (Beta) Whether Backup for GKE agent is enabled for this cluster. | `bool` | `false` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | `bool` | `true` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon. The addon allows whoever can create Ingress objects to expose an application to a public IP. Network policies or Gatekeeper policies should be used to verify that only authorized applications are exposed. | `bool` | `true` | no |

--- a/modules/safer-cluster-update-variant/main.tf
+++ b/modules/safer-cluster-update-variant/main.tf
@@ -137,7 +137,8 @@ module "gke" {
 
   dns_cache = var.dns_cache
 
-  config_connector = var.config_connector
+  config_connector        = var.config_connector
+  gke_backup_agent_config = var.gke_backup_agent_config
 
   default_max_pods_per_node = var.default_max_pods_per_node
 

--- a/modules/safer-cluster-update-variant/main.tf
+++ b/modules/safer-cluster-update-variant/main.tf
@@ -147,9 +147,6 @@ module "gke" {
 
   cluster_dns_domain = var.cluster_dns_domain
 
-  config_connector = var.config_connector
-
-
   default_max_pods_per_node = var.default_max_pods_per_node
 
   database_encryption = var.database_encryption

--- a/modules/safer-cluster-update-variant/variables.tf
+++ b/modules/safer-cluster-update-variant/variables.tf
@@ -400,6 +400,12 @@ variable "config_connector" {
   default     = false
 }
 
+variable "gke_backup_agent_config" {
+  type        = bool
+  description = "(Beta) Whether Backup for GKE agent is enabled for this cluster."
+  default     = false
+}
+
 variable "disable_default_snat" {
   type        = bool
   description = "Whether to disable the default SNAT to support the private use of public IP addresses"

--- a/modules/safer-cluster/README.md
+++ b/modules/safer-cluster/README.md
@@ -224,6 +224,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | `bool` | `true` | no |
+| gke\_backup\_agent\_config | (Beta) Whether Backup for GKE agent is enabled for this cluster. | `bool` | `false` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | `bool` | `true` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon. The addon allows whoever can create Ingress objects to expose an application to a public IP. Network policies or Gatekeeper policies should be used to verify that only authorized applications are exposed. | `bool` | `true` | no |

--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -137,7 +137,8 @@ module "gke" {
 
   dns_cache = var.dns_cache
 
-  config_connector = var.config_connector
+  config_connector        = var.config_connector
+  gke_backup_agent_config = var.gke_backup_agent_config
 
   default_max_pods_per_node = var.default_max_pods_per_node
 

--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -147,9 +147,6 @@ module "gke" {
 
   cluster_dns_domain = var.cluster_dns_domain
 
-  config_connector = var.config_connector
-
-
   default_max_pods_per_node = var.default_max_pods_per_node
 
   database_encryption = var.database_encryption

--- a/modules/safer-cluster/variables.tf
+++ b/modules/safer-cluster/variables.tf
@@ -400,6 +400,12 @@ variable "config_connector" {
   default     = false
 }
 
+variable "gke_backup_agent_config" {
+  type        = bool
+  description = "(Beta) Whether Backup for GKE agent is enabled for this cluster."
+  default     = false
+}
+
 variable "disable_default_snat" {
   type        = bool
   description = "Whether to disable the default SNAT to support the private use of public IP addresses"


### PR DESCRIPTION
Follow up for #1316