### PR TITLE
Cleaning Up readme

### DIFF
--- a/autogen/main/README.md
+++ b/autogen/main/README.md
@@ -88,9 +88,6 @@ module "gke" {
   cloudrun                   = true
   dns_cache                  = false
   {% endif %}
-  {% if autopilot_cluster %}
-  enable_autopilot           = true
-  {% endif %}
 
 {% if autopilot_cluster != true %}
   node_pools = [

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -46,11 +46,9 @@ module "gke" {
   ip_range_pods              = "us-central1-01-gke-01-pods"
   ip_range_services          = "us-central1-01-gke-01-services"
   horizontal_pod_autoscaling = true
-  filestore_csi_driver       = false
   enable_private_endpoint    = true
   enable_private_nodes       = true
   master_ipv4_cidr_block     = "10.0.0.0/28"
-  enable_autopilot           = true
 
 }
 ```

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -46,6 +46,7 @@ module "gke" {
   ip_range_pods              = "us-central1-01-gke-01-pods"
   ip_range_services          = "us-central1-01-gke-01-services"
   horizontal_pod_autoscaling = true
+  filestore_csi_driver       = false
   enable_private_endpoint    = true
   enable_private_nodes       = true
   master_ipv4_cidr_block     = "10.0.0.0/28"

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -43,6 +43,7 @@ module "gke" {
   ip_range_pods              = "us-central1-01-gke-01-pods"
   ip_range_services          = "us-central1-01-gke-01-services"
   horizontal_pod_autoscaling = true
+  filestore_csi_driver       = false
 
 }
 ```

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -43,8 +43,6 @@ module "gke" {
   ip_range_pods              = "us-central1-01-gke-01-pods"
   ip_range_services          = "us-central1-01-gke-01-services"
   horizontal_pod_autoscaling = true
-  filestore_csi_driver       = false
-  enable_autopilot           = true
 
 }
 ```


### PR DESCRIPTION
Cleaning Up Readme File to fix and remove the redundant reference for  enable_autopilot as functionality is already removed from Terraform code

Fixes Issue #1352