### PR TITLE
chore: remove deprecated workload component to prevent flakes

### DIFF
--- a/examples/simple_regional_beta/main.tf
+++ b/examples/simple_regional_beta/main.tf
@@ -52,7 +52,7 @@ module "gke" {
   enable_identity_service       = true
   release_channel               = "REGULAR"
   logging_enabled_components    = ["SYSTEM_COMPONENTS"]
-  monitoring_enabled_components = ["SYSTEM_COMPONENTS", "WORKLOADS"]
+  monitoring_enabled_components = ["SYSTEM_COMPONENTS"]
 
   # Disable workload identity
   identity_namespace = null

--- a/test/integration/beta_cluster/controls/gcloud.rb
+++ b/test/integration/beta_cluster/controls/gcloud.rb
@@ -112,7 +112,6 @@ control "gcloud" do
 
       it "has the expected monitoring config" do
         expect(data['monitoringConfig']['componentConfig']['enableComponents']).to match_array([
-          "WORKLOADS",
           "SYSTEM_COMPONENTS"
         ])
       end


### PR DESCRIPTION
CI seems to be flaking with `Error: googleapi: Error 400: Workload monitoring configuration is not supported for cluster version 1.24.2-gke.1900; a version above 1.20.0 and below 1.24.0 is required., badRequest`. This removes setting `WORKLOADS` component in example.