### PR TITLE
autoscaling location_policy is "BALANCED" by default

### DIFF
--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -536,8 +536,9 @@ resource "google_container_node_pool" "pools" {
   dynamic "autoscaling" {
     for_each = lookup(each.value, "autoscaling", true) ? [each.value] : []
     content {
-      min_node_count = lookup(autoscaling.value, "min_count", 1)
-      max_node_count = lookup(autoscaling.value, "max_count", 100)
+      min_node_count  = lookup(autoscaling.value, "min_count", 1)
+      max_node_count  = lookup(autoscaling.value, "max_count", 100)
+      location_policy = "BALANCED"
     }
   }
 


### PR DESCRIPTION
It wasn't possible for my infrastructure to converge without this change.