### PR TITLE
individual node pool labels

### DIFF
--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -374,6 +374,7 @@ resource "google_container_node_pool" "pools" {
       lookup(lookup(local.node_pools_labels, "default_values", {}), "node_pool", true) ? { "node_pool" = each.value["name"] } : {},
       local.node_pools_labels["all"],
       local.node_pools_labels[each.value["name"]],
+      lookup(each.value, "labels", {}),
     )
     metadata = merge(
       lookup(lookup(local.node_pools_metadata, "default_values", {}), "cluster_name", true) ? { "cluster_name" = var.name } : {},


### PR DESCRIPTION
current module only accepts the common labels for all node_pools. it would be great if we can have individual node pool specific labels.