### PR TITLE
Fix typo on k8s service's acronym to svc

### DIFF
--- a/examples/private_zonal_with_networking/variables.tf
+++ b/examples/private_zonal_with_networking/variables.tf
@@ -49,6 +49,6 @@ variable "ip_range_pods_name" {
 
 variable "ip_range_services_name" {
   description = "The secondary ip range to use for services"
-  default     = "ip-range-scv"
+  default     = "ip-range-svc"
 }
 

--- a/examples/simple_regional_with_networking/README.md
+++ b/examples/simple_regional_with_networking/README.md
@@ -9,7 +9,7 @@ This example illustrates how to create a VPC and a simple cluster.
 |------|-------------|------|---------|:--------:|
 | cluster\_name | The name for the GKE cluster | `string` | `"gke-on-vpc-cluster"` | no |
 | ip\_range\_pods\_name | The secondary ip range to use for pods | `string` | `"ip-range-pods"` | no |
-| ip\_range\_services\_name | The secondary ip range to use for services | `string` | `"ip-range-scv"` | no |
+| ip\_range\_services\_name | The secondary ip range to use for services | `string` | `"ip-range-svc"` | no |
 | network | The VPC network created to host the cluster in | `string` | `"gke-network"` | no |
 | project\_id | The project ID to host the cluster in | `any` | n/a | yes |
 | region | The region to host the cluster in | `string` | `"us-central1"` | no |

--- a/examples/simple_regional_with_networking/variables.tf
+++ b/examples/simple_regional_with_networking/variables.tf
@@ -45,6 +45,6 @@ variable "ip_range_pods_name" {
 
 variable "ip_range_services_name" {
   description = "The secondary ip range to use for services"
-  default     = "ip-range-scv"
+  default     = "ip-range-svc"
 }
 


### PR DESCRIPTION
No bugs or issue. Just updating acronyms for match with Kubernetes service: scv to svc