### PR TITLE
Make creation of istio-system namespace optional

### DIFF
--- a/modules/asm/README.md
+++ b/modules/asm/README.md
@@ -54,6 +54,7 @@ To deploy this config:
 | channel | The channel to use for this ASM installation. | `string` | `""` | no |
 | cluster\_location | The cluster location for this ASM installation. | `string` | n/a | yes |
 | cluster\_name | The unique name to identify the cluster in ASM. | `string` | n/a | yes |
+| create\_system\_namespace | Determines whether the module creates the istio-system namespace. | `bool` | `true` | no |
 | enable\_cni | Determines whether to enable CNI for this ASM installation. Required to use Managed Data Plane (MDP). | `bool` | `false` | no |
 | enable\_fleet\_registration | Determines whether the module registers the cluster to the fleet. | `bool` | `false` | no |
 | enable\_mesh\_feature | Determines whether the module enables the mesh feature on the fleet. | `bool` | `false` | no |

--- a/modules/asm/main.tf
+++ b/modules/asm/main.tf
@@ -34,6 +34,8 @@ data "google_container_cluster" "asm" {
 }
 
 resource "kubernetes_namespace" "system" {
+  count = var.create_system_namespace ? 1 : 0
+
   metadata {
     name = "istio-system"
   }
@@ -42,7 +44,7 @@ resource "kubernetes_namespace" "system" {
 resource "kubernetes_config_map" "asm_options" {
   metadata {
     name      = "asm-options"
-    namespace = kubernetes_namespace.system.metadata[0].name
+    namespace = try(kubernetes_namespace.system[0].metadata[0].name, "istio-system")
   }
 
   data = {

--- a/modules/asm/variables.tf
+++ b/modules/asm/variables.tf
@@ -98,3 +98,9 @@ variable "module_depends_on" {
   type        = list(any)
   default     = []
 }
+
+variable "create_system_namespace" {
+  description = "Determines whether the module creates the istio-system namespace."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This supports use-cases where the istio-system namespace is already created by existing terraform when adding this module. 

Terraform handles switching from a single resource to one with a `count` seamlessly, so that won't be an issue for anyone upgrading to this version.