### PR TITLE
chore: fix windows example to use containerd

### DIFF
--- a/examples/simple_windows_node_pool/main.tf
+++ b/examples/simple_windows_node_pool/main.tf
@@ -61,7 +61,7 @@ module "gke" {
       auto_upgrade = true
       node_count   = 1
       machine_type = "n2-standard-2"
-      image_type   = "WINDOWS_LTSC"
+      image_type   = "WINDOWS_LTSC_CONTAINERD"
     },
   ]
 }

--- a/test/integration/simple_windows_node_pool/controls/gcloud.rb
+++ b/test/integration/simple_windows_node_pool/controls/gcloud.rb
@@ -192,7 +192,7 @@ control "gcloud" do
             including(
               "name" => "win-pool-01",
               "config" => including(
-                "imageType" => "WINDOWS_LTSC",
+                "imageType" => "WINDOWS_LTSC_CONTAINERD",
               ),
             ),
           )


### PR DESCRIPTION
Windows example tests seem to be flaky. This swaps the example to use containerd variant. 
```
     module.this.module.gke.google_container_node_pool.windows_pools["win-pool-01"]: Creating...
       
       Error: error creating NodePool: googleapi: Error 400: Creation of node pools using node images based on Docker container runtimes is not supported in GKE v1.23. This is to prepare for the removal of Dockershim in Kubernetes v1.24. We recommend that you migrate to image types based on Containerd (examples). For more information, contact Cloud Support., badRequest
```