### PR TITLE
chore: test fixes

### DIFF
--- a/test/integration/beta_cluster/controls/gcloud.rb
+++ b/test/integration/beta_cluster/controls/gcloud.rb
@@ -45,7 +45,8 @@ control "gcloud" do
       end
 
       it "uses public nodes and master endpoint" do
-        expect(data['privateClusterConfig']).to eq nil
+        expect(data['privateClusterConfig']['enablePrivateEndpoint']).to eq nil
+        expect(data['privateClusterConfig']['enablePrivateNodes']).to eq nil
       end
 
       it "has the expected addon settings" do

--- a/test/integration/sandbox_enabled/controls/gcloud.rb
+++ b/test/integration/sandbox_enabled/controls/gcloud.rb
@@ -40,7 +40,8 @@ control "gcloud" do
       end
 
       it "uses public nodes and master endpoint" do
-        expect(data['privateClusterConfig']).to eq nil
+        expect(data['privateClusterConfig']['enablePrivateEndpoint']).to eq nil
+        expect(data['privateClusterConfig']['enablePrivateNodes']).to eq nil
       end
 
       it "has the expected addon settings" do

--- a/test/integration/simple_autopilot_public/controls/gcloud.rb
+++ b/test/integration/simple_autopilot_public/controls/gcloud.rb
@@ -44,7 +44,8 @@ control "gcloud" do
       end
 
       it "uses public nodes and master endpoint" do
-        expect(data['privateClusterConfig']).to eq nil
+        expect(data['privateClusterConfig']['enablePrivateEndpoint']).to eq nil
+        expect(data['privateClusterConfig']['enablePrivateNodes']).to eq nil
       end
 
       it "has the expected addon settings" do

--- a/test/integration/simple_regional/controls/gcloud.rb
+++ b/test/integration/simple_regional/controls/gcloud.rb
@@ -40,7 +40,8 @@ control "gcloud" do
       end
 
       it "uses public nodes and master endpoint" do
-        expect(data['privateClusterConfig']).to eq nil
+        expect(data['privateClusterConfig']['enablePrivateEndpoint']).to eq nil
+        expect(data['privateClusterConfig']['enablePrivateNodes']).to eq nil
       end
 
       it "has the expected addon settings" do

--- a/test/integration/simple_regional_with_kubeconfig/controls/gcloud.rb
+++ b/test/integration/simple_regional_with_kubeconfig/controls/gcloud.rb
@@ -40,7 +40,8 @@ control "gcloud" do
       end
 
       it "uses public nodes and master endpoint" do
-        expect(data['privateClusterConfig']).to eq nil
+        expect(data['privateClusterConfig']['enablePrivateEndpoint']).to eq nil
+        expect(data['privateClusterConfig']['enablePrivateNodes']).to eq nil
       end
 
       it "has the expected addon settings" do

--- a/test/integration/simple_regional_with_networking/controls/gcloud.rb
+++ b/test/integration/simple_regional_with_networking/controls/gcloud.rb
@@ -40,7 +40,8 @@ control "gcloud" do
       end
 
       it "uses public nodes and master endpoint" do
-        expect(data['privateClusterConfig']).to eq nil
+        expect(data['privateClusterConfig']['enablePrivateEndpoint']).to eq nil
+        expect(data['privateClusterConfig']['enablePrivateNodes']).to eq nil
       end
 
       it "has the expected addon settings" do

--- a/test/integration/simple_zonal/controls/gcloud.rb
+++ b/test/integration/simple_zonal/controls/gcloud.rb
@@ -45,7 +45,8 @@ control "gcloud" do
       end
 
       it "uses public nodes and master endpoint" do
-        expect(data['privateClusterConfig']).to eq nil
+        expect(data['privateClusterConfig']['enablePrivateEndpoint']).to eq nil
+        expect(data['privateClusterConfig']['enablePrivateNodes']).to eq nil
       end
 
       it "has the expected addon settings" do


### PR DESCRIPTION
API return for https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters#privateclusterconfig seems to have changed. Updated `uses public nodes and master endpoint` to explicitly validate  `enablePrivateEndpoint` and `enablePrivateNodes` are not set.