### PR TITLE
Fix: update variant - recreate node pools on max_pods_per_node or pod_range change

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -499,7 +499,9 @@ locals {
     "enable_integrity_monitoring",
     "local_ssd_count",
     "machine_type",
+    "max_pods_per_node",
     "min_cpu_platform",
+    "pod_range",
     "preemptible",
     "spot",
     "service_account",
@@ -510,8 +512,9 @@ locals {
 }
 
 # This keepers list is based on the terraform google provider schemaNodeConfig
-# resources where "ForceNew" is "true". schemaNodeConfig can be found in node_config.go at
-# https://github.com/terraform-providers/terraform-provider-google/blob/master/google/node_config.go#L22
+# resources where "ForceNew" is "true". schemaNodeConfig can be found in resource_container_node_pool.go at
+# https://github.com/hashicorp/terraform-provider-google/blob/main/google/resource_container_node_pool.go and node_config.go at
+# https://github.com/terraform-providers/terraform-provider-google/blob/main/google/node_config.go
 resource "random_id" "name" {
   for_each    = merge(local.node_pools, local.windows_node_pools)
   byte_length = 2

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -437,7 +437,9 @@ locals {
     "enable_integrity_monitoring",
     "local_ssd_count",
     "machine_type",
+    "max_pods_per_node",
     "min_cpu_platform",
+    "pod_range",
     "preemptible",
     "spot",
     "service_account",
@@ -448,8 +450,9 @@ locals {
 }
 
 # This keepers list is based on the terraform google provider schemaNodeConfig
-# resources where "ForceNew" is "true". schemaNodeConfig can be found in node_config.go at
-# https://github.com/terraform-providers/terraform-provider-google/blob/master/google/node_config.go#L22
+# resources where "ForceNew" is "true". schemaNodeConfig can be found in resource_container_node_pool.go at
+# https://github.com/hashicorp/terraform-provider-google/blob/main/google/resource_container_node_pool.go and node_config.go at
+# https://github.com/terraform-providers/terraform-provider-google/blob/main/google/node_config.go
 resource "random_id" "name" {
   for_each    = merge(local.node_pools, local.windows_node_pools)
   byte_length = 2

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -418,7 +418,9 @@ locals {
     "enable_integrity_monitoring",
     "local_ssd_count",
     "machine_type",
+    "max_pods_per_node",
     "min_cpu_platform",
+    "pod_range",
     "preemptible",
     "spot",
     "service_account",
@@ -429,8 +431,9 @@ locals {
 }
 
 # This keepers list is based on the terraform google provider schemaNodeConfig
-# resources where "ForceNew" is "true". schemaNodeConfig can be found in node_config.go at
-# https://github.com/terraform-providers/terraform-provider-google/blob/master/google/node_config.go#L22
+# resources where "ForceNew" is "true". schemaNodeConfig can be found in resource_container_node_pool.go at
+# https://github.com/hashicorp/terraform-provider-google/blob/main/google/resource_container_node_pool.go and node_config.go at
+# https://github.com/terraform-providers/terraform-provider-google/blob/main/google/node_config.go
 resource "random_id" "name" {
   for_each    = merge(local.node_pools, local.windows_node_pools)
   byte_length = 2

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -323,7 +323,9 @@ locals {
     "enable_integrity_monitoring",
     "local_ssd_count",
     "machine_type",
+    "max_pods_per_node",
     "min_cpu_platform",
+    "pod_range",
     "preemptible",
     "spot",
     "service_account",
@@ -334,8 +336,9 @@ locals {
 }
 
 # This keepers list is based on the terraform google provider schemaNodeConfig
-# resources where "ForceNew" is "true". schemaNodeConfig can be found in node_config.go at
-# https://github.com/terraform-providers/terraform-provider-google/blob/master/google/node_config.go#L22
+# resources where "ForceNew" is "true". schemaNodeConfig can be found in resource_container_node_pool.go at
+# https://github.com/hashicorp/terraform-provider-google/blob/main/google/resource_container_node_pool.go and node_config.go at
+# https://github.com/terraform-providers/terraform-provider-google/blob/main/google/node_config.go
 resource "random_id" "name" {
   for_each    = merge(local.node_pools, local.windows_node_pools)
   byte_length = 2


### PR DESCRIPTION
Adding missing keepers to allow max_pods_per_node or pod_range changes in update-variant