### PR TITLE
Enabled `filestore_csi_driver` option for autopilot-cluster

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -224,6 +224,10 @@ resource "google_container_cluster" "primary" {
       disabled = !var.horizontal_pod_autoscaling
     }
 
+    gcp_filestore_csi_driver_config {
+      enabled = var.filestore_csi_driver
+    }
+
 
     {% if autopilot_cluster != true %}
     network_policy_config {
@@ -232,10 +236,6 @@ resource "google_container_cluster" "primary" {
 
     dns_cache_config {
       enabled = var.dns_cache
-    }
-
-    gcp_filestore_csi_driver_config {
-      enabled = var.filestore_csi_driver
     }
     {% endif %}
     {% if beta_cluster and autopilot_cluster != true %}

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -96,6 +96,12 @@ variable "http_load_balancing" {
   default     = true
 }
 
+variable "filestore_csi_driver" {
+  type        = bool
+  description = "The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes"
+  default     = false
+}
+
 variable "service_external_ips" {
   type        = bool
   description = "Whether external ips specified by a service will be allowed in this cluster"
@@ -531,12 +537,6 @@ variable "initial_node_count" {
 variable "remove_default_node_pool" {
   type        = bool
   description = "Remove default node pool while setting up the cluster"
-  default     = false
-}
-
-variable "filestore_csi_driver" {
-  type        = bool
-  description = "The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes"
   default     = false
 }
 

--- a/cluster.tf
+++ b/cluster.tf
@@ -125,6 +125,10 @@ resource "google_container_cluster" "primary" {
       disabled = !var.horizontal_pod_autoscaling
     }
 
+    gcp_filestore_csi_driver_config {
+      enabled = var.filestore_csi_driver
+    }
+
 
     network_policy_config {
       disabled = !var.network_policy
@@ -132,10 +136,6 @@ resource "google_container_cluster" "primary" {
 
     dns_cache_config {
       enabled = var.dns_cache
-    }
-
-    gcp_filestore_csi_driver_config {
-      enabled = var.filestore_csi_driver
     }
   }
 

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -95,7 +95,6 @@ Then perform the following commands on the root folder:
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer and artifactregistry.reader roles. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
-| filestore\_csi\_driver | Enable filestore csi addon | `bool` | `false` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -90,6 +90,7 @@ Then perform the following commands on the root folder:
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
 | enable\_tpu | Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | `bool` | `false` | no |
+| filestore\_csi\_driver | The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes | `bool` | `false` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers. Either flag `add_master_webhook_firewall_rules` or `add_cluster_firewall_rules` (also adds egress rules) must be set to `true` for inbound-ports firewall rules to be applied. | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer and artifactregistry.reader roles. | `bool` | `false` | no |

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -90,6 +90,7 @@ Then perform the following commands on the root folder:
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
 | enable\_tpu | Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | `bool` | `false` | no |
+| filestore\_csi\_driver | Enable filestore csi addon | `bool` | `false` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers. Either flag `add_master_webhook_firewall_rules` or `add_cluster_firewall_rules` (also adds egress rules) must be set to `true` for inbound-ports firewall rules to be applied. | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer and artifactregistry.reader roles. | `bool` | `false` | no |

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -95,6 +95,7 @@ Then perform the following commands on the root folder:
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer and artifactregistry.reader roles. | `bool` | `false` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
+| filestore\_csi\_driver | Enable filestore csi addon | `bool` | `false` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -90,7 +90,6 @@ Then perform the following commands on the root folder:
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
 | enable\_tpu | Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | `bool` | `false` | no |
-| filestore\_csi\_driver | Enable filestore csi addon | `bool` | `false` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers. Either flag `add_master_webhook_firewall_rules` or `add_cluster_firewall_rules` (also adds egress rules) must be set to `true` for inbound-ports firewall rules to be applied. | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer and artifactregistry.reader roles. | `bool` | `false` | no |

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -110,6 +110,10 @@ resource "google_container_cluster" "primary" {
       disabled = !var.horizontal_pod_autoscaling
     }
 
+    gcp_filestore_csi_driver_config {
+      enabled = var.filestore_csi_driver
+    }
+
 
   }
 

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -110,6 +110,9 @@ resource "google_container_cluster" "primary" {
       disabled = !var.horizontal_pod_autoscaling
     }
 
+    gcp_filestore_csi_driver_config {
+      enabled = var.filestore_csi_driver
+    }
 
   }
 

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -110,9 +110,6 @@ resource "google_container_cluster" "primary" {
       disabled = !var.horizontal_pod_autoscaling
     }
 
-    gcp_filestore_csi_driver_config {
-      enabled = var.filestore_csi_driver
-    }
 
   }
 

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -96,6 +96,12 @@ variable "http_load_balancing" {
   default     = true
 }
 
+variable "filestore_csi_driver" {
+  type        = bool
+  description = "The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes"
+  default     = false
+}
+
 variable "service_external_ips" {
   type        = bool
   description = "Whether external ips specified by a service will be allowed in this cluster"

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -96,6 +96,12 @@ variable "http_load_balancing" {
   default     = true
 }
 
+variable "filestore_csi_driver" {
+  type        = bool
+  description = "Enable filestore csi addon"
+  default     = false
+}
+
 variable "service_external_ips" {
   type        = bool
   description = "Whether external ips specified by a service will be allowed in this cluster"

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -96,12 +96,6 @@ variable "http_load_balancing" {
   default     = true
 }
 
-variable "filestore_csi_driver" {
-  type        = bool
-  description = "Enable filestore csi addon"
-  default     = false
-}
-
 variable "service_external_ips" {
   type        = bool
   description = "Whether external ips specified by a service will be allowed in this cluster"

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -81,6 +81,7 @@ Then perform the following commands on the root folder:
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
 | enable\_tpu | Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | `bool` | `false` | no |
+| filestore\_csi\_driver | The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes | `bool` | `false` | no |
 | firewall\_inbound\_ports | List of TCP ports for admission/webhook controllers. Either flag `add_master_webhook_firewall_rules` or `add_cluster_firewall_rules` (also adds egress rules) must be set to `true` for inbound-ports firewall rules to be applied. | `list(string)` | <pre>[<br>  "8443",<br>  "9443",<br>  "15017"<br>]</pre> | no |
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer and artifactregistry.reader roles. | `bool` | `false` | no |

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -110,6 +110,10 @@ resource "google_container_cluster" "primary" {
       disabled = !var.horizontal_pod_autoscaling
     }
 
+    gcp_filestore_csi_driver_config {
+      enabled = var.filestore_csi_driver
+    }
+
 
   }
 

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -96,6 +96,12 @@ variable "http_load_balancing" {
   default     = true
 }
 
+variable "filestore_csi_driver" {
+  type        = bool
+  description = "The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes"
+  default     = false
+}
+
 variable "service_external_ips" {
   type        = bool
   description = "Whether external ips specified by a service will be allowed in this cluster"

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -187,6 +187,10 @@ resource "google_container_cluster" "primary" {
       disabled = !var.horizontal_pod_autoscaling
     }
 
+    gcp_filestore_csi_driver_config {
+      enabled = var.filestore_csi_driver
+    }
+
 
     network_policy_config {
       disabled = !var.network_policy
@@ -194,10 +198,6 @@ resource "google_container_cluster" "primary" {
 
     dns_cache_config {
       enabled = var.dns_cache
-    }
-
-    gcp_filestore_csi_driver_config {
-      enabled = var.filestore_csi_driver
     }
 
     istio_config {

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -96,6 +96,12 @@ variable "http_load_balancing" {
   default     = true
 }
 
+variable "filestore_csi_driver" {
+  type        = bool
+  description = "The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes"
+  default     = false
+}
+
 variable "service_external_ips" {
   type        = bool
   description = "Whether external ips specified by a service will be allowed in this cluster"
@@ -506,12 +512,6 @@ variable "initial_node_count" {
 variable "remove_default_node_pool" {
   type        = bool
   description = "Remove default node pool while setting up the cluster"
-  default     = false
-}
-
-variable "filestore_csi_driver" {
-  type        = bool
-  description = "The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes"
   default     = false
 }
 

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -187,6 +187,10 @@ resource "google_container_cluster" "primary" {
       disabled = !var.horizontal_pod_autoscaling
     }
 
+    gcp_filestore_csi_driver_config {
+      enabled = var.filestore_csi_driver
+    }
+
 
     network_policy_config {
       disabled = !var.network_policy
@@ -194,10 +198,6 @@ resource "google_container_cluster" "primary" {
 
     dns_cache_config {
       enabled = var.dns_cache
-    }
-
-    gcp_filestore_csi_driver_config {
-      enabled = var.filestore_csi_driver
     }
 
     istio_config {

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -96,6 +96,12 @@ variable "http_load_balancing" {
   default     = true
 }
 
+variable "filestore_csi_driver" {
+  type        = bool
+  description = "The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes"
+  default     = false
+}
+
 variable "service_external_ips" {
   type        = bool
   description = "Whether external ips specified by a service will be allowed in this cluster"
@@ -506,12 +512,6 @@ variable "initial_node_count" {
 variable "remove_default_node_pool" {
   type        = bool
   description = "Remove default node pool while setting up the cluster"
-  default     = false
-}
-
-variable "filestore_csi_driver" {
-  type        = bool
-  description = "The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes"
   default     = false
 }
 

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -187,6 +187,10 @@ resource "google_container_cluster" "primary" {
       disabled = !var.horizontal_pod_autoscaling
     }
 
+    gcp_filestore_csi_driver_config {
+      enabled = var.filestore_csi_driver
+    }
+
 
     network_policy_config {
       disabled = !var.network_policy
@@ -194,10 +198,6 @@ resource "google_container_cluster" "primary" {
 
     dns_cache_config {
       enabled = var.dns_cache
-    }
-
-    gcp_filestore_csi_driver_config {
-      enabled = var.filestore_csi_driver
     }
 
     istio_config {

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -96,6 +96,12 @@ variable "http_load_balancing" {
   default     = true
 }
 
+variable "filestore_csi_driver" {
+  type        = bool
+  description = "The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes"
+  default     = false
+}
+
 variable "service_external_ips" {
   type        = bool
   description = "Whether external ips specified by a service will be allowed in this cluster"
@@ -476,12 +482,6 @@ variable "initial_node_count" {
 variable "remove_default_node_pool" {
   type        = bool
   description = "Remove default node pool while setting up the cluster"
-  default     = false
-}
-
-variable "filestore_csi_driver" {
-  type        = bool
-  description = "The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes"
   default     = false
 }
 

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -187,6 +187,10 @@ resource "google_container_cluster" "primary" {
       disabled = !var.horizontal_pod_autoscaling
     }
 
+    gcp_filestore_csi_driver_config {
+      enabled = var.filestore_csi_driver
+    }
+
 
     network_policy_config {
       disabled = !var.network_policy
@@ -194,10 +198,6 @@ resource "google_container_cluster" "primary" {
 
     dns_cache_config {
       enabled = var.dns_cache
-    }
-
-    gcp_filestore_csi_driver_config {
-      enabled = var.filestore_csi_driver
     }
 
     istio_config {

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -96,6 +96,12 @@ variable "http_load_balancing" {
   default     = true
 }
 
+variable "filestore_csi_driver" {
+  type        = bool
+  description = "The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes"
+  default     = false
+}
+
 variable "service_external_ips" {
   type        = bool
   description = "Whether external ips specified by a service will be allowed in this cluster"
@@ -476,12 +482,6 @@ variable "initial_node_count" {
 variable "remove_default_node_pool" {
   type        = bool
   description = "Remove default node pool while setting up the cluster"
-  default     = false
-}
-
-variable "filestore_csi_driver" {
-  type        = bool
-  description = "The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes"
   default     = false
 }
 

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -125,6 +125,10 @@ resource "google_container_cluster" "primary" {
       disabled = !var.horizontal_pod_autoscaling
     }
 
+    gcp_filestore_csi_driver_config {
+      enabled = var.filestore_csi_driver
+    }
+
 
     network_policy_config {
       disabled = !var.network_policy
@@ -132,10 +136,6 @@ resource "google_container_cluster" "primary" {
 
     dns_cache_config {
       enabled = var.dns_cache
-    }
-
-    gcp_filestore_csi_driver_config {
-      enabled = var.filestore_csi_driver
     }
   }
 

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -96,6 +96,12 @@ variable "http_load_balancing" {
   default     = true
 }
 
+variable "filestore_csi_driver" {
+  type        = bool
+  description = "The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes"
+  default     = false
+}
+
 variable "service_external_ips" {
   type        = bool
   description = "Whether external ips specified by a service will be allowed in this cluster"
@@ -472,12 +478,6 @@ variable "initial_node_count" {
 variable "remove_default_node_pool" {
   type        = bool
   description = "Remove default node pool while setting up the cluster"
-  default     = false
-}
-
-variable "filestore_csi_driver" {
-  type        = bool
-  description = "The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes"
   default     = false
 }
 

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -125,6 +125,10 @@ resource "google_container_cluster" "primary" {
       disabled = !var.horizontal_pod_autoscaling
     }
 
+    gcp_filestore_csi_driver_config {
+      enabled = var.filestore_csi_driver
+    }
+
 
     network_policy_config {
       disabled = !var.network_policy
@@ -132,10 +136,6 @@ resource "google_container_cluster" "primary" {
 
     dns_cache_config {
       enabled = var.dns_cache
-    }
-
-    gcp_filestore_csi_driver_config {
-      enabled = var.filestore_csi_driver
     }
   }
 

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -96,6 +96,12 @@ variable "http_load_balancing" {
   default     = true
 }
 
+variable "filestore_csi_driver" {
+  type        = bool
+  description = "The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes"
+  default     = false
+}
+
 variable "service_external_ips" {
   type        = bool
   description = "Whether external ips specified by a service will be allowed in this cluster"
@@ -472,12 +478,6 @@ variable "initial_node_count" {
 variable "remove_default_node_pool" {
   type        = bool
   description = "Remove default node pool while setting up the cluster"
-  default     = false
-}
-
-variable "filestore_csi_driver" {
-  type        = bool
-  description = "The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes"
   default     = false
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -96,6 +96,12 @@ variable "http_load_balancing" {
   default     = true
 }
 
+variable "filestore_csi_driver" {
+  type        = bool
+  description = "The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes"
+  default     = false
+}
+
 variable "service_external_ips" {
   type        = bool
   description = "Whether external ips specified by a service will be allowed in this cluster"
@@ -442,12 +448,6 @@ variable "initial_node_count" {
 variable "remove_default_node_pool" {
   type        = bool
   description = "Remove default node pool while setting up the cluster"
-  default     = false
-}
-
-variable "filestore_csi_driver" {
-  type        = bool
-  description = "The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes"
   default     = false
 }
 


### PR DESCRIPTION
This option appears to have been added in #1166.
However, for some reason it was not enabled on the autopilot cluster, so I have fixed it so that it can be enabled.

Currently it appears to be possible to use Filestore CSI in an Autopilot cluster.
see: https://cloud.google.com/kubernetes-engine/docs/tutorials/stateful-workload?hl=ja
