### PR TITLE
chore: Delete Stale CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @terraform-google-modules/cft-admins @Jberlinsky @bharathkkb


### PR DESCRIPTION
Standardizing to /CODEOWNERS