### PR TITLE
fix: enable private nodes with specified pod ip range

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -659,7 +659,8 @@ resource "google_container_node_pool" "windows_pools" {
   dynamic "network_config" {
     for_each = length(lookup(each.value, "pod_range", "")) > 0  ? [each.value] : []
     content {
-      pod_range = lookup(network_config.value, "pod_range", null)
+      pod_range            = lookup(network_config.value, "pod_range", null)
+      enable_private_nodes = var.enable_private_nodes
     }
   }
   {% endif %}

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -568,7 +568,8 @@ resource "google_container_node_pool" "pools" {
   dynamic "network_config" {
     for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
     content {
-      pod_range = lookup(network_config.value, "pod_range", null)
+      pod_range            = lookup(network_config.value, "pod_range", null)
+      enable_private_nodes = var.enable_private_nodes
     }
   }
 
@@ -779,7 +780,8 @@ resource "google_container_node_pool" "windows_pools" {
   dynamic "network_config" {
     for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
     content {
-      pod_range = lookup(network_config.value, "pod_range", null)
+      pod_range            = lookup(network_config.value, "pod_range", null)
+      enable_private_nodes = var.enable_private_nodes
     }
   }
 

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -474,7 +474,8 @@ resource "google_container_node_pool" "pools" {
   dynamic "network_config" {
     for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
     content {
-      pod_range = lookup(network_config.value, "pod_range", null)
+      pod_range            = lookup(network_config.value, "pod_range", null)
+      enable_private_nodes = var.enable_private_nodes
     }
   }
 
@@ -684,7 +685,8 @@ resource "google_container_node_pool" "windows_pools" {
   dynamic "network_config" {
     for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
     content {
-      pod_range = lookup(network_config.value, "pod_range", null)
+      pod_range            = lookup(network_config.value, "pod_range", null)
+      enable_private_nodes = var.enable_private_nodes
     }
   }
 

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -549,7 +549,8 @@ resource "google_container_node_pool" "pools" {
   dynamic "network_config" {
     for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
     content {
-      pod_range = lookup(network_config.value, "pod_range", null)
+      pod_range            = lookup(network_config.value, "pod_range", null)
+      enable_private_nodes = var.enable_private_nodes
     }
   }
 
@@ -760,7 +761,8 @@ resource "google_container_node_pool" "windows_pools" {
   dynamic "network_config" {
     for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
     content {
-      pod_range = lookup(network_config.value, "pod_range", null)
+      pod_range            = lookup(network_config.value, "pod_range", null)
+      enable_private_nodes = var.enable_private_nodes
     }
   }
 

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -455,7 +455,8 @@ resource "google_container_node_pool" "pools" {
   dynamic "network_config" {
     for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
     content {
-      pod_range = lookup(network_config.value, "pod_range", null)
+      pod_range            = lookup(network_config.value, "pod_range", null)
+      enable_private_nodes = var.enable_private_nodes
     }
   }
 
@@ -665,7 +666,8 @@ resource "google_container_node_pool" "windows_pools" {
   dynamic "network_config" {
     for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
     content {
-      pod_range = lookup(network_config.value, "pod_range", null)
+      pod_range            = lookup(network_config.value, "pod_range", null)
+      enable_private_nodes = var.enable_private_nodes
     }
   }
 


### PR DESCRIPTION
_The second try, as there is something rotten in #1514 where terraform-google-kubernetes-engine-int-trigger not passing while not receiving any email what is wrong :man_shrugging:_ 
Fixes https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1493
enable_private_nodes attribute was introduced in google provider 4.45.0 and Google API now requires enable_private_nodes to be set on both cluster and node_pool when pod_ip_range is specified on the node_pool level.