### PR TITLE
chore: annotate sensitive output variable

### DIFF
--- a/examples/simple_autopilot_private/outputs.tf
+++ b/examples/simple_autopilot_private/outputs.tf
@@ -35,6 +35,7 @@ output "master_kubernetes_version" {
 }
 
 output "ca_certificate" {
+  sensitive   = true
   description = "The cluster ca certificate (base64 encoded)"
   value       = module.gke.ca_certificate
 }


### PR DESCRIPTION
`ca_certificate` output variable in simple autopilot example needs marking as sensitive