### PR TITLE
fix: allow using an empty list as value to `var.node_pools` to create a cluster with no node pools

### DIFF
--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -140,8 +140,6 @@ locals {
   cluster_zones    = sort(local.cluster_output_zones)
 
   // node pool ID is in the form projects/<project-id>/locations/<location>/clusters/<cluster-name>/nodePools/<nodepool-name>
-  cluster_name_parts_from_nodepool           = split("/", element(values(google_container_node_pool.pools)[*].id, 0))
-  cluster_name_computed                      = element(local.cluster_name_parts_from_nodepool, length(local.cluster_name_parts_from_nodepool) - 3)
   cluster_network_tag                        = "gke-${var.name}"
   cluster_ca_certificate                     = local.cluster_master_auth_map["cluster_ca_certificate"]
   cluster_master_version                     = local.cluster_output_master_version

--- a/modules/private-cluster/outputs.tf
+++ b/modules/private-cluster/outputs.tf
@@ -23,7 +23,7 @@ output "cluster_id" {
 
 output "name" {
   description = "Cluster name"
-  value       = local.cluster_name_computed
+  value       = google_container_cluster.primary.name
   depends_on = [
     /* Nominally, the cluster name is populated as soon as it is known to Terraform.
     * However, the cluster may not be in a usable state yet.  Therefore any


### PR DESCRIPTION
We'd like to be able to use the private-cluster module to create a cluster with no node pools associated. This change makes the `node_pool` argument on `google_container_cluster` null if the `node_pools` variable is explicitly set to an empty list.

Before this change setting `node_pools` to an empty list caused the module to error - my hope is that only altering the way the module behaves with `node_pools` empty will prevent this change from breaking existing implementations.

The `cluster_name_computed` local value has been removed as it was dependent on at least one node pool being configured. As it was only being used to populate the cluster name output I've used the name attribute of the `google_container_cluster` resource in its place.