### PR TITLE
fix: avoid TGP v4.49.0 for asm

### DIFF
--- a/modules/asm/versions.tf
+++ b/modules/asm/versions.tf
@@ -23,6 +23,12 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.0"
     }
+    google = {
+      source = "hashicorp/google"
+      # Avoid v4.49.0 for https://github.com/hashicorp/terraform-provider-google/issues/13507
+      version = ">= 4.47.0, != 4.49.0, < 5.0"
+    }
+  }
   }
 
   provider_meta "google" {


### PR DESCRIPTION
Fixes the issue presented in [#1533](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1533) for the ASM module which also relies on the `google_container_cluster` data provider. 