### PR TITLE
fix: node_metadata mapping for GCE_METADATA (#1542)

### DIFF
--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -126,7 +126,7 @@ locals {
 
   {% if autopilot_cluster != true %}
   // legacy mappings https://github.com/hashicorp/terraform-provider-google/pull/10238
-  old_node_metadata_config_mapping = { GKE_METADATA_SERVER = "GKE_METADATA", GCE_METADATA = "EXPOSE" }
+  old_node_metadata_config_mapping = { GKE_METADATA_SERVER = "GKE_METADATA", EXPOSE = "GCE_METADATA" }
 
   cluster_node_metadata_config = var.node_metadata == "UNSPECIFIED" ? [] : [{
     mode = lookup(local.old_node_metadata_config_mapping, var.node_metadata, var.node_metadata)

--- a/main.tf
+++ b/main.tf
@@ -92,7 +92,7 @@ locals {
   }]
 
   // legacy mappings https://github.com/hashicorp/terraform-provider-google/pull/10238
-  old_node_metadata_config_mapping = { GKE_METADATA_SERVER = "GKE_METADATA", GCE_METADATA = "EXPOSE" }
+  old_node_metadata_config_mapping = { GKE_METADATA_SERVER = "GKE_METADATA", EXPOSE = "GCE_METADATA" }
 
   cluster_node_metadata_config = var.node_metadata == "UNSPECIFIED" ? [] : [{
     mode = lookup(local.old_node_metadata_config_mapping, var.node_metadata, var.node_metadata)

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -105,7 +105,7 @@ locals {
   }]
 
   // legacy mappings https://github.com/hashicorp/terraform-provider-google/pull/10238
-  old_node_metadata_config_mapping = { GKE_METADATA_SERVER = "GKE_METADATA", GCE_METADATA = "EXPOSE" }
+  old_node_metadata_config_mapping = { GKE_METADATA_SERVER = "GKE_METADATA", EXPOSE = "GCE_METADATA" }
 
   cluster_node_metadata_config = var.node_metadata == "UNSPECIFIED" ? [] : [{
     mode = lookup(local.old_node_metadata_config_mapping, var.node_metadata, var.node_metadata)

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -105,7 +105,7 @@ locals {
   }]
 
   // legacy mappings https://github.com/hashicorp/terraform-provider-google/pull/10238
-  old_node_metadata_config_mapping = { GKE_METADATA_SERVER = "GKE_METADATA", GCE_METADATA = "EXPOSE" }
+  old_node_metadata_config_mapping = { GKE_METADATA_SERVER = "GKE_METADATA", EXPOSE = "GCE_METADATA" }
 
   cluster_node_metadata_config = var.node_metadata == "UNSPECIFIED" ? [] : [{
     mode = lookup(local.old_node_metadata_config_mapping, var.node_metadata, var.node_metadata)

--- a/modules/beta-public-cluster-update-variant/main.tf
+++ b/modules/beta-public-cluster-update-variant/main.tf
@@ -105,7 +105,7 @@ locals {
   }]
 
   // legacy mappings https://github.com/hashicorp/terraform-provider-google/pull/10238
-  old_node_metadata_config_mapping = { GKE_METADATA_SERVER = "GKE_METADATA", GCE_METADATA = "EXPOSE" }
+  old_node_metadata_config_mapping = { GKE_METADATA_SERVER = "GKE_METADATA", EXPOSE = "GCE_METADATA" }
 
   cluster_node_metadata_config = var.node_metadata == "UNSPECIFIED" ? [] : [{
     mode = lookup(local.old_node_metadata_config_mapping, var.node_metadata, var.node_metadata)

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -105,7 +105,7 @@ locals {
   }]
 
   // legacy mappings https://github.com/hashicorp/terraform-provider-google/pull/10238
-  old_node_metadata_config_mapping = { GKE_METADATA_SERVER = "GKE_METADATA", GCE_METADATA = "EXPOSE" }
+  old_node_metadata_config_mapping = { GKE_METADATA_SERVER = "GKE_METADATA", EXPOSE = "GCE_METADATA" }
 
   cluster_node_metadata_config = var.node_metadata == "UNSPECIFIED" ? [] : [{
     mode = lookup(local.old_node_metadata_config_mapping, var.node_metadata, var.node_metadata)

--- a/modules/private-cluster-update-variant/main.tf
+++ b/modules/private-cluster-update-variant/main.tf
@@ -92,7 +92,7 @@ locals {
   }]
 
   // legacy mappings https://github.com/hashicorp/terraform-provider-google/pull/10238
-  old_node_metadata_config_mapping = { GKE_METADATA_SERVER = "GKE_METADATA", GCE_METADATA = "EXPOSE" }
+  old_node_metadata_config_mapping = { GKE_METADATA_SERVER = "GKE_METADATA", EXPOSE = "GCE_METADATA" }
 
   cluster_node_metadata_config = var.node_metadata == "UNSPECIFIED" ? [] : [{
     mode = lookup(local.old_node_metadata_config_mapping, var.node_metadata, var.node_metadata)

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -92,7 +92,7 @@ locals {
   }]
 
   // legacy mappings https://github.com/hashicorp/terraform-provider-google/pull/10238
-  old_node_metadata_config_mapping = { GKE_METADATA_SERVER = "GKE_METADATA", GCE_METADATA = "EXPOSE" }
+  old_node_metadata_config_mapping = { GKE_METADATA_SERVER = "GKE_METADATA", EXPOSE = "GCE_METADATA" }
 
   cluster_node_metadata_config = var.node_metadata == "UNSPECIFIED" ? [] : [{
     mode = lookup(local.old_node_metadata_config_mapping, var.node_metadata, var.node_metadata)


### PR DESCRIPTION
This PR fixes the issue described in #1542: the legacy `EXPOSE` value for `node_metadata` should be mapped to the new `GCE_METADATA` value instead of the opposite, and `GCE_METADATA` should be left as is.