### PR TITLE
fix: support custom service account for autopilot

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -162,7 +162,7 @@ resource "google_container_cluster" "primary" {
   {% if autopilot_cluster == true %}
   cluster_autoscaling {
     dynamic "auto_provisioning_defaults" {
-      for_each = var.create_service_account ? [1] : []
+      for_each = (var.create_service_account || var.service_account != "") ? [1] : []
 
       content {
         service_account = local.service_account

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -71,7 +71,7 @@ resource "google_container_cluster" "primary" {
 
   cluster_autoscaling {
     dynamic "auto_provisioning_defaults" {
-      for_each = var.create_service_account ? [1] : []
+      for_each = (var.create_service_account || var.service_account != "") ? [1] : []
 
       content {
         service_account = local.service_account

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -71,7 +71,7 @@ resource "google_container_cluster" "primary" {
 
   cluster_autoscaling {
     dynamic "auto_provisioning_defaults" {
-      for_each = var.create_service_account ? [1] : []
+      for_each = (var.create_service_account || var.service_account != "") ? [1] : []
 
       content {
         service_account = local.service_account


### PR DESCRIPTION
This PR fixes service_account support for the Autopilot modules. Previously, the supplied was ignored contrary to documentation.