### PR TITLE
fix: remove datapath provider from Autopilot modules

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -298,8 +298,10 @@ resource "google_container_cluster" "primary" {
     }
     {% endif %}
   }
-
+  {% if autopilot_cluster != true %}
+  
   datapath_provider = var.datapath_provider
+  {% endif %}
 
   {% if beta_cluster %}
   networking_mode = "VPC_NATIVE"

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -119,8 +119,6 @@ resource "google_container_cluster" "primary" {
 
   }
 
-  datapath_provider = var.datapath_provider
-
   networking_mode = "VPC_NATIVE"
   ip_allocation_policy {
     cluster_secondary_range_name  = var.ip_range_pods

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -119,8 +119,6 @@ resource "google_container_cluster" "primary" {
 
   }
 
-  datapath_provider = var.datapath_provider
-
   networking_mode = "VPC_NATIVE"
   ip_allocation_policy {
     cluster_secondary_range_name  = var.ip_range_pods


### PR DESCRIPTION
You cannot set datapath for Autopilot clusters.

Fixes #1446