### PR TITLE
feat: allow setting network tags on autopilot clusters

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -222,6 +222,16 @@ resource "google_container_cluster" "primary" {
       }
     }
   }
+{% if autopilot_cluster %}
+  dynamic "node_pool_auto_config" {
+    for_each = length(var.network_tags) > 0 ? [1] : []
+    content {
+      network_tags {
+        tags = var.network_tags
+      }
+    }
+  }
+{% endif %}
 
   master_auth {
     client_certificate_config {

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -292,6 +292,13 @@ variable "node_pools_oauth_scopes" {
 }
 {% endif %}
 
+{% if autopilot_cluster %}
+variable "network_tags" {
+  description = "(Optional, Beta) - List of network tags applied to auto-provisioned node pools."
+  type = list(string)
+  default = []
+}
+{% endif %}
 variable "stub_domains" {
   type        = map(list(string))
   description = "Map of stub domains and their resolvers to forward DNS queries for a certain domain to an external DNS server"

--- a/examples/simple_autopilot_private/main.tf
+++ b/examples/simple_autopilot_private/main.tf
@@ -48,6 +48,7 @@ module "gke" {
   enable_private_endpoint         = true
   enable_private_nodes            = true
   master_ipv4_cidr_block          = "172.16.0.0/28"
+  network_tags                    = [local.cluster_type]
 
   master_authorized_networks = [
     {

--- a/examples/simple_autopilot_public/main.tf
+++ b/examples/simple_autopilot_public/main.tf
@@ -44,4 +44,5 @@ module "gke" {
   ip_range_services               = local.svc_range_name
   release_channel                 = "REGULAR"
   enable_vertical_pod_autoscaling = true
+  network_tags                    = [local.cluster_type]
 }

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -115,6 +115,7 @@ Then perform the following commands on the root folder:
 | name | The name of the cluster (required) | `string` | n/a | yes |
 | network | The VPC network to host the cluster in (required) | `string` | n/a | yes |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
+| network\_tags | (Optional, Beta) - List of network tags applied to auto-provisioned node pools. | `list(string)` | `[]` | no |
 | non\_masquerade\_cidrs | List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading. | `list(string)` | <pre>[<br>  "10.0.0.0/8",<br>  "172.16.0.0/12",<br>  "192.168.0.0/16"<br>]</pre> | no |
 | notification\_config\_topic | The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}. | `string` | `""` | no |
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -94,6 +94,14 @@ resource "google_container_cluster" "primary" {
       }
     }
   }
+  dynamic "node_pool_auto_config" {
+    for_each = length(var.network_tags) > 0 ? [1] : []
+    content {
+      network_tags {
+        tags = var.network_tags
+      }
+    }
+  }
 
   master_auth {
     client_certificate_config {

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -167,6 +167,11 @@ variable "enable_resource_consumption_export" {
 }
 
 
+variable "network_tags" {
+  description = "(Optional, Beta) - List of network tags applied to auto-provisioned node pools."
+  type        = list(string)
+  default     = []
+}
 variable "stub_domains" {
   type        = map(list(string))
   description = "Map of stub domains and their resolvers to forward DNS queries for a certain domain to an external DNS server"

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -104,6 +104,7 @@ Then perform the following commands on the root folder:
 | name | The name of the cluster (required) | `string` | n/a | yes |
 | network | The VPC network to host the cluster in (required) | `string` | n/a | yes |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
+| network\_tags | (Optional, Beta) - List of network tags applied to auto-provisioned node pools. | `list(string)` | `[]` | no |
 | non\_masquerade\_cidrs | List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading. | `list(string)` | <pre>[<br>  "10.0.0.0/8",<br>  "172.16.0.0/12",<br>  "192.168.0.0/16"<br>]</pre> | no |
 | notification\_config\_topic | The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}. | `string` | `""` | no |
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -94,6 +94,14 @@ resource "google_container_cluster" "primary" {
       }
     }
   }
+  dynamic "node_pool_auto_config" {
+    for_each = length(var.network_tags) > 0 ? [1] : []
+    content {
+      network_tags {
+        tags = var.network_tags
+      }
+    }
+  }
 
   master_auth {
     client_certificate_config {

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -167,6 +167,11 @@ variable "enable_resource_consumption_export" {
 }
 
 
+variable "network_tags" {
+  description = "(Optional, Beta) - List of network tags applied to auto-provisioned node pools."
+  type        = list(string)
+  default     = []
+}
 variable "stub_domains" {
   type        = map(list(string))
   description = "Map of stub domains and their resolvers to forward DNS queries for a certain domain to an external DNS server"

--- a/test/integration/simple_autopilot_private/simple_autopilot_private_test.go
+++ b/test/integration/simple_autopilot_private/simple_autopilot_private_test.go
@@ -54,6 +54,7 @@ func TestSimpleAutopilotPrivate(t *testing.T) {
 			g.JSONEq(assert, op, pth)
 		}
 		assert.Contains([]string{"RUNNING", "RECONCILING"}, op.Get("status").String())
+		assert.Contains(op.Get("nodePoolAutoConfig.networkTags.tags").String(), "simple-autopilot-private")
 	})
 
 	bpt.Test()

--- a/test/integration/simple_autopilot_public/simple_autopiliot_public_test.go
+++ b/test/integration/simple_autopilot_public/simple_autopiliot_public_test.go
@@ -54,7 +54,7 @@ func TestSimpleAutopilotPublic(t *testing.T) {
 			g.JSONEq(assert, op, pth)
 		}
 		assert.Contains([]string{"RUNNING", "RECONCILING"}, op.Get("status").String())
-
+		assert.Contains(op.Get("nodePoolAutoConfig.networkTags.tags").String(), "simple-autopilot-public")
 	})
 
 	bpt.Test()


### PR DESCRIPTION
* dynamically configure `node_pool_auto_config` block with `network_tags` nested block
* Addressing https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1496