### PR TITLE
fix: Workload Identity Module - Add required parameters to example snippet

### DIFF
--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -83,6 +83,8 @@ resource "kubernetes_service_account" "preexisting" {
 module "my-app-workload-identity" {
   source              = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
   use_existing_k8s_sa = true
+  cluster             = "my-k8s-cluster-name"
+  location            = "my-k8s-cluster-location"
   name                = kubernetes_service_account.preexisting.metadata[0].name
   namespace           = kubernetes_service_account.preexisting.metadata[0].namespace
   project_id          = var.project_id


### PR DESCRIPTION
Update example code snippet demonstrating use of existing Kubernetes SA to include the required parameters `cluster` and `location`. #1065 