### PR TITLE
Fix: Remove 1.23 restriction on workload identity module

### DIFF
--- a/examples/workload_identity/main.tf
+++ b/examples/workload_identity/main.tf
@@ -38,8 +38,6 @@ module "gke" {
   remove_default_node_pool = true
   service_account          = "create"
   node_metadata            = "GKE_METADATA"
-  # https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1313
-  kubernetes_version = "1.23"
   node_pools = [
     {
       name         = "wi-pool"

--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -14,8 +14,6 @@ The `terraform-google-workload-identity` can create service accounts for you,
 or you can use existing accounts; this applies for both the Google and
 Kubernetes accounts.
 
-Note: This module currently supports Kubernetes <= 1.23.
-
 ### Creating a Workload Identity
 
 ```hcl

--- a/modules/workload-identity/versions.tf
+++ b/modules/workload-identity/versions.tf
@@ -25,7 +25,7 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.0"
+      version = "~> 2.13"
     }
   }
 


### PR DESCRIPTION
The issue with hashicorp/kubernetes hanging creating service accounts was resolved in https://github.com/hashicorp/terraform-provider-kubernetes/pull/1792 in https://github.com/hashicorp/terraform-provider-kubernetes/releases/tag/v2.13.0

This reverts the temporary limitation of the workload identity module to 1.23 added in https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/1315 to resolve https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1313, and updates the minimum required version of hashicorp/kubernetes to 2.13.0 for the workload-identity module

Fixes https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1582

cc @bharathkkb @apeabody