### PR TITLE
feat: add enable_private_nodes options to node_pool network_config

### DIFF
--- a/autogen/main/README.md
+++ b/autogen/main/README.md
@@ -221,6 +221,9 @@ The node_pools variable takes the following parameters:
 {% if beta_cluster %}
 | placement_policy | Placement type to set for nodes in a node pool. Can be set as [COMPACT](https://cloud.google.com/kubernetes-engine/docs/how-to/compact-placement#overview) if desired | Optional |
 | pod_range |  The name of the secondary range for pod IPs. |  | Optional |
+{% if not private_cluster %}
+| enable_private_nodes |  Whether nodes have internal IP addresses only. |  | Optional |
+{% endif %}
 {% endif %}
 | node_count | The number of nodes in the nodepool when autoscaling is false. Otherwise defaults to 1. Only valid for non-autoscaling clusters |  | Required |
 | node_locations | The list of zones in which the cluster's nodes are located. Nodes must be in the region of their regional cluster or in the same region as their cluster's zone for zonal clusters. Defaults to cluster level node locations if nothing is specified | " " | Optional |

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -684,6 +684,8 @@ resource "google_container_node_pool" "windows_pools" {
       pod_range            = lookup(network_config.value, "pod_range", null)
       {% if private_cluster %}
       enable_private_nodes = var.enable_private_nodes
+      {% else %}
+      enable_private_nodes = lookup(network_config.value, "enable_private_nodes", null)
       {% endif %}
     }
   }

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -335,6 +335,7 @@ The node_pools variable takes the following parameters:
 | name | The name of the node pool |  | Required |
 | placement_policy | Placement type to set for nodes in a node pool. Can be set as [COMPACT](https://cloud.google.com/kubernetes-engine/docs/how-to/compact-placement#overview) if desired | Optional |
 | pod_range |  The name of the secondary range for pod IPs. |  | Optional |
+| enable_private_nodes |  Whether nodes have internal IP addresses only. |  | Optional |
 | node_count | The number of nodes in the nodepool when autoscaling is false. Otherwise defaults to 1. Only valid for non-autoscaling clusters |  | Required |
 | node_locations | The list of zones in which the cluster's nodes are located. Nodes must be in the region of their regional cluster or in the same region as their cluster's zone for zonal clusters. Defaults to cluster level node locations if nothing is specified | " " | Optional |
 | node_metadata | Options to expose the node metadata to the workload running on the node | | Optional |

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -565,7 +565,8 @@ resource "google_container_node_pool" "pools" {
   dynamic "network_config" {
     for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
     content {
-      pod_range = lookup(network_config.value, "pod_range", null)
+      pod_range            = lookup(network_config.value, "pod_range", null)
+      enable_private_nodes = lookup(network_config.value, "enable_private_nodes", null)
     }
   }
 
@@ -776,7 +777,8 @@ resource "google_container_node_pool" "windows_pools" {
   dynamic "network_config" {
     for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
     content {
-      pod_range = lookup(network_config.value, "pod_range", null)
+      pod_range            = lookup(network_config.value, "pod_range", null)
+      enable_private_nodes = lookup(network_config.value, "enable_private_nodes", null)
     }
   }
 

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -313,6 +313,7 @@ The node_pools variable takes the following parameters:
 | name | The name of the node pool |  | Required |
 | placement_policy | Placement type to set for nodes in a node pool. Can be set as [COMPACT](https://cloud.google.com/kubernetes-engine/docs/how-to/compact-placement#overview) if desired | Optional |
 | pod_range |  The name of the secondary range for pod IPs. |  | Optional |
+| enable_private_nodes |  Whether nodes have internal IP addresses only. |  | Optional |
 | node_count | The number of nodes in the nodepool when autoscaling is false. Otherwise defaults to 1. Only valid for non-autoscaling clusters |  | Required |
 | node_locations | The list of zones in which the cluster's nodes are located. Nodes must be in the region of their regional cluster or in the same region as their cluster's zone for zonal clusters. Defaults to cluster level node locations if nothing is specified | " " | Optional |
 | node_metadata | Options to expose the node metadata to the workload running on the node | | Optional |

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -471,7 +471,8 @@ resource "google_container_node_pool" "pools" {
   dynamic "network_config" {
     for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
     content {
-      pod_range = lookup(network_config.value, "pod_range", null)
+      pod_range            = lookup(network_config.value, "pod_range", null)
+      enable_private_nodes = lookup(network_config.value, "enable_private_nodes", null)
     }
   }
 
@@ -681,7 +682,8 @@ resource "google_container_node_pool" "windows_pools" {
   dynamic "network_config" {
     for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
     content {
-      pod_range = lookup(network_config.value, "pod_range", null)
+      pod_range            = lookup(network_config.value, "pod_range", null)
+      enable_private_nodes = lookup(network_config.value, "enable_private_nodes", null)
     }
   }
 


### PR DESCRIPTION
This PR adds the ability to set the enable_private_notes option in network_config for a pool of public cluster nodes.

We already had a cluster in which the nodes had public addresses. We wanted to change this property of the node without recreating the cluster. We would have to recreate the cluster, since the private_cluster_config property is immutable and we cannot use the module for a private cluster.