### PR TITLE
fix: set max firewall name to 36

### DIFF
--- a/autogen/main/firewall.tf.tmpl
+++ b/autogen/main/firewall.tf.tmpl
@@ -26,7 +26,7 @@
  *****************************************/
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -70,7 +70,7 @@ resource "google_compute_firewall" "intra_egress" {
  *****************************************/
 resource "google_compute_firewall" "tpu_egress" {
   count       = var.add_cluster_firewall_rules && var.enable_tpu ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-tpu-egress"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-tpu-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with TPUs"
   project     = local.network_project_id
   network     = var.network
@@ -105,7 +105,7 @@ resource "google_compute_firewall" "tpu_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -137,7 +137,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-all"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -166,7 +166,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-master"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -192,7 +192,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-vms"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -227,7 +227,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -254,7 +254,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/firewall.tf
+++ b/firewall.tf
@@ -26,7 +26,7 @@
  *****************************************/
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -63,7 +63,7 @@ resource "google_compute_firewall" "intra_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -93,7 +93,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-all"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -122,7 +122,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-master"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -148,7 +148,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-vms"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -183,7 +183,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -210,7 +210,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/modules/beta-autopilot-private-cluster/firewall.tf
+++ b/modules/beta-autopilot-private-cluster/firewall.tf
@@ -26,7 +26,7 @@
  *****************************************/
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -64,7 +64,7 @@ resource "google_compute_firewall" "intra_egress" {
  *****************************************/
 resource "google_compute_firewall" "tpu_egress" {
   count       = var.add_cluster_firewall_rules && var.enable_tpu ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-tpu-egress"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-tpu-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with TPUs"
   project     = local.network_project_id
   network     = var.network
@@ -93,7 +93,7 @@ resource "google_compute_firewall" "tpu_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -120,7 +120,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-all"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -149,7 +149,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-master"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -175,7 +175,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-vms"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -210,7 +210,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -237,7 +237,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/modules/beta-autopilot-public-cluster/firewall.tf
+++ b/modules/beta-autopilot-public-cluster/firewall.tf
@@ -26,7 +26,7 @@
  *****************************************/
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -67,7 +67,7 @@ resource "google_compute_firewall" "intra_egress" {
  *****************************************/
 resource "google_compute_firewall" "tpu_egress" {
   count       = var.add_cluster_firewall_rules && var.enable_tpu ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-tpu-egress"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-tpu-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with TPUs"
   project     = local.network_project_id
   network     = var.network
@@ -99,7 +99,7 @@ resource "google_compute_firewall" "tpu_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -129,7 +129,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-all"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -158,7 +158,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-master"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -184,7 +184,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-vms"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -219,7 +219,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -246,7 +246,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/modules/beta-private-cluster-update-variant/firewall.tf
+++ b/modules/beta-private-cluster-update-variant/firewall.tf
@@ -26,7 +26,7 @@
  *****************************************/
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -64,7 +64,7 @@ resource "google_compute_firewall" "intra_egress" {
  *****************************************/
 resource "google_compute_firewall" "tpu_egress" {
   count       = var.add_cluster_firewall_rules && var.enable_tpu ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-tpu-egress"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-tpu-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with TPUs"
   project     = local.network_project_id
   network     = var.network
@@ -93,7 +93,7 @@ resource "google_compute_firewall" "tpu_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -120,7 +120,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-all"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -149,7 +149,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-master"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -175,7 +175,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-vms"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -210,7 +210,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -237,7 +237,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/modules/beta-private-cluster/firewall.tf
+++ b/modules/beta-private-cluster/firewall.tf
@@ -26,7 +26,7 @@
  *****************************************/
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -64,7 +64,7 @@ resource "google_compute_firewall" "intra_egress" {
  *****************************************/
 resource "google_compute_firewall" "tpu_egress" {
   count       = var.add_cluster_firewall_rules && var.enable_tpu ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-tpu-egress"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-tpu-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with TPUs"
   project     = local.network_project_id
   network     = var.network
@@ -93,7 +93,7 @@ resource "google_compute_firewall" "tpu_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -120,7 +120,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-all"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -149,7 +149,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-master"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -175,7 +175,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-vms"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -210,7 +210,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -237,7 +237,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/modules/beta-public-cluster-update-variant/firewall.tf
+++ b/modules/beta-public-cluster-update-variant/firewall.tf
@@ -26,7 +26,7 @@
  *****************************************/
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -67,7 +67,7 @@ resource "google_compute_firewall" "intra_egress" {
  *****************************************/
 resource "google_compute_firewall" "tpu_egress" {
   count       = var.add_cluster_firewall_rules && var.enable_tpu ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-tpu-egress"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-tpu-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with TPUs"
   project     = local.network_project_id
   network     = var.network
@@ -99,7 +99,7 @@ resource "google_compute_firewall" "tpu_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -129,7 +129,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-all"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -158,7 +158,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-master"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -184,7 +184,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-vms"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -219,7 +219,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -246,7 +246,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/modules/beta-public-cluster/firewall.tf
+++ b/modules/beta-public-cluster/firewall.tf
@@ -26,7 +26,7 @@
  *****************************************/
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -67,7 +67,7 @@ resource "google_compute_firewall" "intra_egress" {
  *****************************************/
 resource "google_compute_firewall" "tpu_egress" {
   count       = var.add_cluster_firewall_rules && var.enable_tpu ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-tpu-egress"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-tpu-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with TPUs"
   project     = local.network_project_id
   network     = var.network
@@ -99,7 +99,7 @@ resource "google_compute_firewall" "tpu_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -129,7 +129,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-all"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -158,7 +158,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-master"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -184,7 +184,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-vms"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -219,7 +219,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -246,7 +246,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/modules/private-cluster-update-variant/firewall.tf
+++ b/modules/private-cluster-update-variant/firewall.tf
@@ -26,7 +26,7 @@
  *****************************************/
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -60,7 +60,7 @@ resource "google_compute_firewall" "intra_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -87,7 +87,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-all"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -116,7 +116,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-master"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -142,7 +142,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-vms"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -177,7 +177,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -204,7 +204,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/modules/private-cluster/firewall.tf
+++ b/modules/private-cluster/firewall.tf
@@ -26,7 +26,7 @@
  *****************************************/
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -60,7 +60,7 @@ resource "google_compute_firewall" "intra_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(25, length(var.name)))}-webhooks"
+  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -87,7 +87,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-all"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -116,7 +116,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-master"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -142,7 +142,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-vms"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -177,7 +177,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -204,7 +204,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(25, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/test/integration/safer_cluster/safer_cluster_test.go
+++ b/test/integration/safer_cluster/safer_cluster_test.go
@@ -63,8 +63,8 @@ func TestSaferCluster(t *testing.T) {
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)
 		}
-		gcloud.Runf(t, "compute firewall-rules --project %s describe gke-%s-intra-cluster-egress", projectId, clusterName[:25])
-		gcloud.Runf(t, "compute firewall-rules --project %s describe gke-%s-webhooks", projectId, clusterName[:25])
+		gcloud.Runf(t, "compute firewall-rules --project %s describe gke-%s-intra-cluster-egress", projectId, clusterName[:36])
+		gcloud.Runf(t, "compute firewall-rules --project %s describe gke-%s-webhooks", projectId, clusterName[:36])
 	})
 
 	bpt.Test()

--- a/test/integration/safer_cluster/safer_cluster_test.go
+++ b/test/integration/safer_cluster/safer_cluster_test.go
@@ -63,8 +63,8 @@ func TestSaferCluster(t *testing.T) {
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)
 		}
-		gcloud.Runf(t, "compute firewall-rules --project %s describe gke-%s-intra-cluster-egress", projectId, clusterName[:36])
-		gcloud.Runf(t, "compute firewall-rules --project %s describe gke-%s-webhooks", projectId, clusterName[:36])
+		gcloud.Runf(t, "compute firewall-rules --project %s describe gke-%s-intra-cluster-egress", projectId, clusterName)
+		gcloud.Runf(t, "compute firewall-rules --project %s describe gke-%s-webhooks", projectId, clusterName)
 	})
 
 	bpt.Test()


### PR DESCRIPTION
This, to be able to have longer and unique names.
The firewall API supports 63 charters
Solves #1527

https://cloud.google.com/compute/docs/reference/rest/v1/firewalls

```shell
# The longest name with the extra chars added by the module
echo gke--intra-cluster-egress |wc -c
26
# the max ammount of char - the number of chars the module creates
expr 63 - 26
37
# I picked 36 since it looks better then 37 :)
```
