### PR TITLE
fix: beta-autopilot cluster modules respect identity_namespace

### DIFF
--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -220,6 +220,13 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  dynamic "workload_identity_config" {
+    for_each = local.cluster_workload_identity_config
+
+    content {
+      workload_pool = workload_identity_config.value.workload_pool
+    }
+  }
 
   dynamic "authenticator_groups_config" {
     for_each = local.cluster_authenticator_security_group

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -294,9 +294,9 @@ variable "authenticator_security_group" {
 }
 
 variable "identity_namespace" {
-  description = "The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`)"
+  description = "The workload pool to attach all Kubernetes service accounts to. (Default value of `null` defaults to `[project_id].svc.id.goog` for autopilot clusters)"
   type        = string
-  default     = "enabled"
+  default     = null
 }
 
 variable "release_channel" {

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -201,6 +201,13 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  dynamic "workload_identity_config" {
+    for_each = local.cluster_workload_identity_config
+
+    content {
+      workload_pool = workload_identity_config.value.workload_pool
+    }
+  }
 
   dynamic "authenticator_groups_config" {
     for_each = local.cluster_authenticator_security_group

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -264,9 +264,9 @@ variable "authenticator_security_group" {
 }
 
 variable "identity_namespace" {
-  description = "The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`)"
+  description = "The workload pool to attach all Kubernetes service accounts to. (Default value of `null` defaults to `[project_id].svc.id.goog` for autopilot clusters)"
   type        = string
-  default     = "enabled"
+  default     = null
 }
 
 variable "release_channel" {


### PR DESCRIPTION
This change addresses #1646 by applying the existing `identity_namespace` variable on the `beta-autopilot-public-cluster` and `beta-autopilot-private-cluster` modules. This variable currently has no effect.