### PR TITLE
fix: policy bundles now use idx as resource name (bundles will be re-applied)

### DIFF
--- a/modules/acm/creds.tf
+++ b/modules/acm/creds.tf
@@ -30,12 +30,12 @@ resource "tls_private_key" "k8sop_creds" {
   rsa_bits  = 4096
 }
 
-# Wait for the ACM operator to create the namespace
+# Wait for ACM
 resource "time_sleep" "wait_acm" {
   count      = (var.create_ssh_key == true || var.ssh_auth_key != null || var.enable_policy_controller || var.enable_config_sync) ? 1 : 0
   depends_on = [google_gke_hub_feature_membership.main]
 
-  create_duration = "300s"
+  create_duration = (length(var.policy_bundles) > 0) ? "600s" : "300s"
 }
 
 resource "google_service_account_iam_binding" "ksa_iam" {

--- a/modules/acm/policy_bundles.tf
+++ b/modules/acm/policy_bundles.tf
@@ -18,12 +18,13 @@ module "policy_bundles" {
   source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
   version = "~> 3.1"
 
-  for_each                = toset(var.policy_bundles)
+  # Use index as name to avoid long url or special filesystem chars
+  for_each                = { for i, v in var.policy_bundles : i => v }
   project_id              = var.project_id
   cluster_name            = var.cluster_name
   cluster_location        = var.location
-  kubectl_create_command  = "kubectl apply -k ${each.key}"
-  kubectl_destroy_command = "kubectl delete -k ${each.key}"
+  kubectl_create_command  = "kubectl apply -k ${each.value}"
+  kubectl_destroy_command = "kubectl delete -k ${each.value}"
 
   module_depends_on = [time_sleep.wait_acm]
 }


### PR DESCRIPTION
The module name is used by the gcloud module in paths, so long uls or special characters could cause issues depending on the local filesystem.