### PR TITLE
feat: support configuring ACM git service account email

### DIFF
--- a/modules/acm/README.md
+++ b/modules/acm/README.md
@@ -86,6 +86,7 @@ data "google_client_config" "default" {}
 | enable\_mutation | Whether to enable mutations for ACM Policy Controller. | `bool` | `false` | no |
 | enable\_policy\_controller | Whether to enable the ACM Policy Controller on the cluster | `bool` | `true` | no |
 | enable\_referential\_rules | Enables referential constraints which reference another object in it definition and are therefore eventually consistent. | `bool` | `true` | no |
+| gcp\_service\_account\_email | The service account email for authentication when `secret_type` is `gcpServiceAccount`. | `string` | `null` | no |
 | hierarchy\_controller | Configurations for Hierarchy Controller. See [Hierarchy Controller docs](https://cloud.google.com/anthos-config-management/docs/how-to/installing-hierarchy-controller) for more details | `map(any)` | `null` | no |
 | https\_proxy | URL for the HTTPS proxy to be used when communicating with the Git repo. | `string` | `null` | no |
 | install\_template\_library | Whether to install the default Policy Controller template library | `bool` | `true` | no |

--- a/modules/acm/feature.tf
+++ b/modules/acm/feature.tf
@@ -45,12 +45,13 @@ resource "google_gke_hub_feature_membership" "main" {
         source_format = var.source_format != "" ? var.source_format : null
 
         git {
-          sync_repo   = var.sync_repo
-          policy_dir  = var.policy_dir != "" ? var.policy_dir : null
-          sync_branch = var.sync_branch != "" ? var.sync_branch : null
-          sync_rev    = var.sync_revision != "" ? var.sync_revision : null
-          secret_type = var.secret_type
-          https_proxy = var.https_proxy
+          sync_repo                 = var.sync_repo
+          policy_dir                = var.policy_dir != "" ? var.policy_dir : null
+          sync_branch               = var.sync_branch != "" ? var.sync_branch : null
+          sync_rev                  = var.sync_revision != "" ? var.sync_revision : null
+          secret_type               = var.secret_type
+          https_proxy               = var.https_proxy
+          gcp_service_account_email = var.gcp_service_account_email
         }
       }
     }

--- a/modules/acm/variables.tf
+++ b/modules/acm/variables.tf
@@ -109,6 +109,12 @@ variable "ssh_auth_key" {
   default     = null
 }
 
+variable "gcp_service_account_email" {
+  description = "The service account email for authentication when `secret_type` is `gcpServiceAccount`."
+  type        = string
+  default     = null
+}
+
 variable "enable_config_sync" {
   description = "Whether to enable the ACM Config Sync on the cluster"
   type        = bool


### PR DESCRIPTION
This PR exposes the `gcp_service_account_email` configuration setting. Without this, users cannot configure a Service Account to access the ACM Git repository.