### PR TITLE
fix: set CLOUD_DNS as provider for gke autopilot cluster

### DIFF
--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -75,6 +75,9 @@ Then perform the following commands on the root folder:
 | add\_master\_webhook\_firewall\_rules | Create master\_webhook firewall rules for ports defined in `firewall_inbound_ports` | `bool` | `false` | no |
 | add\_shadow\_firewall\_rules | Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled). | `bool` | `false` | no |
 | authenticator\_security\_group | The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com | `string` | `null` | no |
+| cluster\_dns\_domain | The suffix used for all cluster service records. Defaults to `cluster.local`. | `string` | `"cluster.local"` | no |
+| cluster\_dns\_provider | Which in-cluster DNS provider should be used. PROVIDER\_UNSPECIFIED or PLATFORM\_DEFAULT or CLOUD\_DNS (default). | `string` | `"CLOUD_DNS"` | no |
+| cluster\_dns\_scope | The scope of access to cluster DNS records. DNS\_SCOPE\_UNSPECIFIED or CLUSTER\_SCOPE (default) or VPC\_SCOPE. | `string` | `"CLUSTER_SCOPE"` | no |
 | cluster\_ipv4\_cidr | The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR. | `string` | `null` | no |
 | cluster\_resource\_labels | The GCE resource labels (a map of key/value pairs) to be applied to the cluster | `map(string)` | `{}` | no |
 | configure\_ip\_masq | Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server. | `bool` | `false` | no |

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -135,6 +135,13 @@ resource "google_container_cluster" "primary" {
     }
     workload_vulnerability_mode = var.workload_vulnerability_mode
   }
+
+  dns_config {
+    cluster_dns        = var.cluster_dns_provider
+    cluster_dns_domain = var.cluster_dns_domain
+    cluster_dns_scope  = var.cluster_dns_scope
+  }
+
   ip_allocation_policy {
     cluster_secondary_range_name  = var.ip_range_pods
     services_secondary_range_name = var.ip_range_services

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -405,6 +405,23 @@ variable "database_encryption" {
   }]
 }
 
+variable "cluster_dns_provider" {
+  type        = string
+  description = "Which in-cluster DNS provider should be used. PROVIDER_UNSPECIFIED or PLATFORM_DEFAULT or CLOUD_DNS (default)."
+  default     = "CLOUD_DNS"
+}
+
+variable "cluster_dns_scope" {
+  type        = string
+  description = "The scope of access to cluster DNS records. DNS_SCOPE_UNSPECIFIED or CLUSTER_SCOPE (default) or VPC_SCOPE."
+  default     = "CLUSTER_SCOPE"
+}
+
+variable "cluster_dns_domain" {
+  type        = string
+  description = "The suffix used for all cluster service records. Defaults to `cluster.local`."
+  default     = "cluster.local"
+}
 
 variable "timeouts" {
   type        = map(string)
@@ -415,4 +432,3 @@ variable "timeouts" {
     error_message = "Only create, update, delete timeouts can be specified."
   }
 }
-

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -69,6 +69,9 @@ Then perform the following commands on the root folder:
 | add\_master\_webhook\_firewall\_rules | Create master\_webhook firewall rules for ports defined in `firewall_inbound_ports` | `bool` | `false` | no |
 | add\_shadow\_firewall\_rules | Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled). | `bool` | `false` | no |
 | authenticator\_security\_group | The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com | `string` | `null` | no |
+| cluster\_dns\_domain | The suffix used for all cluster service records. Defaults to `cluster.local`. | `string` | `"cluster.local"` | no |
+| cluster\_dns\_provider | Which in-cluster DNS provider should be used. PROVIDER\_UNSPECIFIED or PLATFORM\_DEFAULT or CLOUD\_DNS (default). | `string` | `"CLOUD_DNS"` | no |
+| cluster\_dns\_scope | The scope of access to cluster DNS records. DNS\_SCOPE\_UNSPECIFIED or CLUSTER\_SCOPE (default) or VPC\_SCOPE. | `string` | `"CLUSTER_SCOPE"` | no |
 | cluster\_ipv4\_cidr | The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR. | `string` | `null` | no |
 | cluster\_resource\_labels | The GCE resource labels (a map of key/value pairs) to be applied to the cluster | `map(string)` | `{}` | no |
 | configure\_ip\_masq | Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server. | `bool` | `false` | no |

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -135,6 +135,13 @@ resource "google_container_cluster" "primary" {
     }
     workload_vulnerability_mode = var.workload_vulnerability_mode
   }
+
+  dns_config {
+    cluster_dns        = var.cluster_dns_provider
+    cluster_dns_domain = var.cluster_dns_domain
+    cluster_dns_scope  = var.cluster_dns_scope
+  }
+
   ip_allocation_policy {
     cluster_secondary_range_name  = var.ip_range_pods
     services_secondary_range_name = var.ip_range_services

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -375,6 +375,23 @@ variable "database_encryption" {
   }]
 }
 
+variable "cluster_dns_provider" {
+  type        = string
+  description = "Which in-cluster DNS provider should be used. PROVIDER_UNSPECIFIED or PLATFORM_DEFAULT or CLOUD_DNS (default)."
+  default     = "CLOUD_DNS"
+}
+
+variable "cluster_dns_scope" {
+  type        = string
+  description = "The scope of access to cluster DNS records. DNS_SCOPE_UNSPECIFIED or CLUSTER_SCOPE (default) or VPC_SCOPE."
+  default     = "CLUSTER_SCOPE"
+}
+
+variable "cluster_dns_domain" {
+  type        = string
+  description = "The suffix used for all cluster service records. Defaults to `cluster.local`."
+  default     = "cluster.local"
+}
 
 variable "timeouts" {
   type        = map(string)
@@ -385,4 +402,3 @@ variable "timeouts" {
     error_message = "Only create, update, delete timeouts can be specified."
   }
 }
-


### PR DESCRIPTION
> Starting in August 2023, the default DNS provider for your new GKE Autopilot
> clusters using version 1.25.9-gke.400 or later and 1.26.4-gke.500 or later
> becomes Cloud DNS, at no extra charge. This change will be gradual and
> expected to be completed by Aug 12th.

Without this change, the default setting `PROVIDER_UNSPECIFIED` for
`dns_config.cluster_dns` is used with the `google_container_cluster`
ressource.

Thus running terraform apply to update parts of an deployment will
always recreate the cluster:

```
- dns_config { # forces replacement
  - cluster_dns        = "CLOUD_DNS" -> null
  - cluster_dns_domain = "cluster.local" -> null
  - cluster_dns_scope  = "CLUSTER_SCOPE" -> null
}
```
