### PR TITLE
chore: don't run stale bot on forks

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   stale:
+    if: github.repository_owner == 'terraform-google-modules'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v8


### PR DESCRIPTION
Forks generally don't have open issues - this PR turns off the stale bot for them, to avoid useless action runs + the notifications arising from them.

Docs: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context