### PR TITLE
feat: mesh_certificates support

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Then perform the following commands on the root folder:
 | enable\_binary\_authorization | Enable BinAuthZ Admission controller | `bool` | `false` | no |
 | enable\_cost\_allocation | Enables Cost Allocation Feature and the cluster name and namespace of your GKE workloads appear in the labels field of the billing export to BigQuery | `bool` | `false` | no |
 | enable\_kubernetes\_alpha | Whether to enable Kubernetes Alpha features for this cluster. Note that when this option is enabled, the cluster cannot be upgraded and will be automatically deleted after 30 days. | `bool` | `false` | no |
+| enable\_mesh\_certificates | Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity. | `bool` | `false` | no |
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | `bool` | `true` | no |
@@ -237,6 +238,7 @@ Then perform the following commands on the root folder:
 | logging\_service | Logging service used |
 | master\_authorized\_networks\_config | Networks from which access to master is permitted |
 | master\_version | Current master kubernetes version |
+| mesh\_certificates\_config | Mesh certificates configuration |
 | min\_master\_version | Minimum master kubernetes version |
 | monitoring\_service | Monitoring service used |
 | name | Cluster name |

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -517,6 +517,16 @@ resource "google_container_cluster" "primary" {
   }
   {% endif %}
 
+  {% if autopilot_cluster != true %}
+  dynamic "mesh_certificates" {
+    for_each = local.cluster_mesh_certificates_config
+
+    content {
+      enable_certificates = mesh_certificates.value.enable_certificates
+    }
+  }
+  {% endif %}
+
   dynamic "authenticator_groups_config" {
     for_each = local.cluster_authenticator_security_group
     content {

--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -219,6 +219,12 @@ locals {
   cluster_workload_identity_config = ! local.workload_identity_enabled ? [] : var.identity_namespace == "enabled" ? [{
     workload_pool = "${var.project_id}.svc.id.goog" }] : [{ workload_pool = var.identity_namespace
   }]
+  {% if autopilot_cluster != true %}
+  cluster_mesh_certificates_config = local.workload_identity_enabled ? [{
+    enable_certificates = var.enable_mesh_certificates
+  }] : []
+  {% endif %}
+
 {% if beta_cluster %}
   # BETA features
   cluster_istio_enabled                    = ! local.cluster_output_istio_disabled

--- a/autogen/main/outputs.tf.tmpl
+++ b/autogen/main/outputs.tf.tmpl
@@ -171,6 +171,7 @@ output "identity_namespace" {
   ]
 }
 
+{% if autopilot_cluster != true %}
 output "mesh_certificates_config" {
   description = "Mesh certificates configuration"
   value       = local.cluster_mesh_certificates_config
@@ -178,6 +179,8 @@ output "mesh_certificates_config" {
     google_container_cluster.primary
   ]
 }
+{% endif %}
+
 {% if private_cluster %}
 
 output "master_ipv4_cidr_block" {

--- a/autogen/main/outputs.tf.tmpl
+++ b/autogen/main/outputs.tf.tmpl
@@ -170,6 +170,14 @@ output "identity_namespace" {
     google_container_cluster.primary
   ]
 }
+
+output "mesh_certificates_config" {
+  description = "Mesh certificates configuration"
+  value       = local.cluster_mesh_certificates_config
+  depends_on = [
+    google_container_cluster.primary
+  ]
+}
 {% if private_cluster %}
 
 output "master_ipv4_cidr_block" {

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -466,6 +466,14 @@ variable "identity_namespace" {
   default     = "enabled"
 }
 
+{% if autopilot_cluster != true %}
+variable "enable_mesh_certificates" {
+  type = bool
+  default = false
+  description = "Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity."
+}
+{% endif %}
+
 variable "release_channel" {
   type        = string
   description = "The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`."
@@ -762,7 +770,6 @@ variable "enable_pod_security_policy" {
   description = "enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. Pod Security Policy was removed from GKE clusters with version >= 1.25.0."
   default     = false
 }
-
 
 variable "enable_l4_ilb_subsetting" {
   type        = bool

--- a/autogen/safer-cluster/main.tf.tmpl
+++ b/autogen/safer-cluster/main.tf.tmpl
@@ -185,6 +185,9 @@ module "gke" {
   // We enable Workload Identity by default.
   identity_namespace = "${var.project_id}.svc.id.goog"
 
+  // Enabling mesh certificates requires Workload Identity
+  enable_mesh_certificates = var.enable_mesh_certificates
+
   authenticator_security_group = var.authenticator_security_group
 
   enable_shielded_nodes = var.enable_shielded_nodes

--- a/autogen/safer-cluster/outputs.tf.tmpl
+++ b/autogen/safer-cluster/outputs.tf.tmpl
@@ -122,3 +122,8 @@ output "peering_name" {
   description = "The name of the peering between this cluster and the Google owned VPC."
   value       = module.gke.peering_name
 }
+
+output "enable_mesh_certificates" {
+  description = "Mesh certificate configuration value"
+  value       = var.enable_mesh_certificates
+}

--- a/autogen/safer-cluster/variables.tf.tmpl
+++ b/autogen/safer-cluster/variables.tf.tmpl
@@ -484,3 +484,9 @@ variable "timeouts" {
     error_message = "Only create, update, delete timeouts can be specified."
   }
 }
+
+variable "enable_mesh_certificates" {
+  type = bool
+  default = false
+  description = "Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity."
+}

--- a/cluster.tf
+++ b/cluster.tf
@@ -359,6 +359,14 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  dynamic "mesh_certificates" {
+    for_each = local.cluster_mesh_certificates_config
+
+    content {
+      enable_certificates = mesh_certificates.value.enable_certificates
+    }
+  }
+
   dynamic "authenticator_groups_config" {
     for_each = local.cluster_authenticator_security_group
     content {

--- a/main.tf
+++ b/main.tf
@@ -162,6 +162,10 @@ locals {
   cluster_workload_identity_config = !local.workload_identity_enabled ? [] : var.identity_namespace == "enabled" ? [{
     workload_pool = "${var.project_id}.svc.id.goog" }] : [{ workload_pool = var.identity_namespace
   }]
+  cluster_mesh_certificates_config = local.workload_identity_enabled ? [{
+    enable_certificates = var.enable_mesh_certificates
+  }] : []
+
 
   cluster_maintenance_window_is_recurring = var.maintenance_recurrence != "" && var.maintenance_end_time != "" ? [1] : []
   cluster_maintenance_window_is_daily     = length(local.cluster_maintenance_window_is_recurring) > 0 ? [] : [1]

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -158,6 +158,7 @@ Then perform the following commands on the root folder:
 | master\_authorized\_networks\_config | Networks from which access to master is permitted |
 | master\_ipv4\_cidr\_block | The IP range in CIDR notation used for the hosted master network |
 | master\_version | Current master kubernetes version |
+| mesh\_certificates\_config | Mesh certificates configuration |
 | min\_master\_version | Minimum master kubernetes version |
 | monitoring\_service | Monitoring service used |
 | name | Cluster name |

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -158,7 +158,6 @@ Then perform the following commands on the root folder:
 | master\_authorized\_networks\_config | Networks from which access to master is permitted |
 | master\_ipv4\_cidr\_block | The IP range in CIDR notation used for the hosted master network |
 | master\_version | Current master kubernetes version |
-| mesh\_certificates\_config | Mesh certificates configuration |
 | min\_master\_version | Minimum master kubernetes version |
 | monitoring\_service | Monitoring service used |
 | name | Cluster name |

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -228,6 +228,7 @@ resource "google_container_cluster" "primary" {
   }
 
 
+
   dynamic "authenticator_groups_config" {
     for_each = local.cluster_authenticator_security_group
     content {

--- a/modules/beta-autopilot-private-cluster/main.tf
+++ b/modules/beta-autopilot-private-cluster/main.tf
@@ -121,6 +121,7 @@ locals {
   cluster_workload_identity_config = !local.workload_identity_enabled ? [] : var.identity_namespace == "enabled" ? [{
     workload_pool = "${var.project_id}.svc.id.goog" }] : [{ workload_pool = var.identity_namespace
   }]
+
   # BETA features
   cluster_istio_enabled                = !local.cluster_output_istio_disabled
   cluster_dns_cache_enabled            = var.dns_cache

--- a/modules/beta-autopilot-private-cluster/outputs.tf
+++ b/modules/beta-autopilot-private-cluster/outputs.tf
@@ -142,6 +142,14 @@ output "identity_namespace" {
   ]
 }
 
+output "mesh_certificates_config" {
+  description = "Mesh certificates configuration"
+  value       = local.cluster_mesh_certificates_config
+  depends_on = [
+    google_container_cluster.primary
+  ]
+}
+
 output "master_ipv4_cidr_block" {
   description = "The IP range in CIDR notation used for the hosted master network"
   value       = var.master_ipv4_cidr_block

--- a/modules/beta-autopilot-private-cluster/outputs.tf
+++ b/modules/beta-autopilot-private-cluster/outputs.tf
@@ -142,13 +142,7 @@ output "identity_namespace" {
   ]
 }
 
-output "mesh_certificates_config" {
-  description = "Mesh certificates configuration"
-  value       = local.cluster_mesh_certificates_config
-  depends_on = [
-    google_container_cluster.primary
-  ]
-}
+
 
 output "master_ipv4_cidr_block" {
   description = "The IP range in CIDR notation used for the hosted master network"

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -299,6 +299,7 @@ variable "identity_namespace" {
   default     = "enabled"
 }
 
+
 variable "release_channel" {
   type        = string
   description = "The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`."

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -146,6 +146,7 @@ Then perform the following commands on the root folder:
 | logging\_service | Logging service used |
 | master\_authorized\_networks\_config | Networks from which access to master is permitted |
 | master\_version | Current master kubernetes version |
+| mesh\_certificates\_config | Mesh certificates configuration |
 | min\_master\_version | Minimum master kubernetes version |
 | monitoring\_service | Monitoring service used |
 | name | Cluster name |

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -146,7 +146,6 @@ Then perform the following commands on the root folder:
 | logging\_service | Logging service used |
 | master\_authorized\_networks\_config | Networks from which access to master is permitted |
 | master\_version | Current master kubernetes version |
-| mesh\_certificates\_config | Mesh certificates configuration |
 | min\_master\_version | Minimum master kubernetes version |
 | monitoring\_service | Monitoring service used |
 | name | Cluster name |

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -209,6 +209,7 @@ resource "google_container_cluster" "primary" {
   }
 
 
+
   dynamic "authenticator_groups_config" {
     for_each = local.cluster_authenticator_security_group
     content {

--- a/modules/beta-autopilot-public-cluster/main.tf
+++ b/modules/beta-autopilot-public-cluster/main.tf
@@ -120,6 +120,7 @@ locals {
   cluster_workload_identity_config = !local.workload_identity_enabled ? [] : var.identity_namespace == "enabled" ? [{
     workload_pool = "${var.project_id}.svc.id.goog" }] : [{ workload_pool = var.identity_namespace
   }]
+
   # BETA features
   cluster_istio_enabled                = !local.cluster_output_istio_disabled
   cluster_dns_cache_enabled            = var.dns_cache

--- a/modules/beta-autopilot-public-cluster/outputs.tf
+++ b/modules/beta-autopilot-public-cluster/outputs.tf
@@ -142,13 +142,7 @@ output "identity_namespace" {
   ]
 }
 
-output "mesh_certificates_config" {
-  description = "Mesh certificates configuration"
-  value       = local.cluster_mesh_certificates_config
-  depends_on = [
-    google_container_cluster.primary
-  ]
-}
+
 
 output "cloudrun_enabled" {
   description = "Whether CloudRun enabled"

--- a/modules/beta-autopilot-public-cluster/outputs.tf
+++ b/modules/beta-autopilot-public-cluster/outputs.tf
@@ -142,6 +142,14 @@ output "identity_namespace" {
   ]
 }
 
+output "mesh_certificates_config" {
+  description = "Mesh certificates configuration"
+  value       = local.cluster_mesh_certificates_config
+  depends_on = [
+    google_container_cluster.primary
+  ]
+}
+
 output "cloudrun_enabled" {
   description = "Whether CloudRun enabled"
   value       = false

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -269,6 +269,7 @@ variable "identity_namespace" {
   default     = "enabled"
 }
 
+
 variable "release_channel" {
   type        = string
   description = "The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`."

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -194,6 +194,7 @@ Then perform the following commands on the root folder:
 | enable\_intranode\_visibility | Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network | `bool` | `false` | no |
 | enable\_kubernetes\_alpha | Whether to enable Kubernetes Alpha features for this cluster. Note that when this option is enabled, the cluster cannot be upgraded and will be automatically deleted after 30 days. | `bool` | `false` | no |
 | enable\_l4\_ilb\_subsetting | Enable L4 ILB Subsetting on the cluster | `bool` | `false` | no |
+| enable\_mesh\_certificates | Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity. | `bool` | `false` | no |
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_pod\_security\_policy | enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. Pod Security Policy was removed from GKE clusters with version >= 1.25.0. | `bool` | `false` | no |
 | enable\_private\_endpoint | (Beta) Whether the master's internal IP address is used as the cluster endpoint | `bool` | `false` | no |
@@ -295,6 +296,7 @@ Then perform the following commands on the root folder:
 | master\_authorized\_networks\_config | Networks from which access to master is permitted |
 | master\_ipv4\_cidr\_block | The IP range in CIDR notation used for the hosted master network |
 | master\_version | Current master kubernetes version |
+| mesh\_certificates\_config | Mesh certificates configuration |
 | min\_master\_version | Minimum master kubernetes version |
 | monitoring\_service | Monitoring service used |
 | name | Cluster name |

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -443,6 +443,14 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  dynamic "mesh_certificates" {
+    for_each = local.cluster_mesh_certificates_config
+
+    content {
+      enable_certificates = mesh_certificates.value.enable_certificates
+    }
+  }
+
   dynamic "authenticator_groups_config" {
     for_each = local.cluster_authenticator_security_group
     content {

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -181,6 +181,10 @@ locals {
   cluster_workload_identity_config = !local.workload_identity_enabled ? [] : var.identity_namespace == "enabled" ? [{
     workload_pool = "${var.project_id}.svc.id.goog" }] : [{ workload_pool = var.identity_namespace
   }]
+  cluster_mesh_certificates_config = local.workload_identity_enabled ? [{
+    enable_certificates = var.enable_mesh_certificates
+  }] : []
+
   # BETA features
   cluster_istio_enabled                = !local.cluster_output_istio_disabled
   cluster_dns_cache_enabled            = var.dns_cache

--- a/modules/beta-private-cluster-update-variant/outputs.tf
+++ b/modules/beta-private-cluster-update-variant/outputs.tf
@@ -169,6 +169,7 @@ output "mesh_certificates_config" {
   ]
 }
 
+
 output "master_ipv4_cidr_block" {
   description = "The IP range in CIDR notation used for the hosted master network"
   value       = var.master_ipv4_cidr_block

--- a/modules/beta-private-cluster-update-variant/outputs.tf
+++ b/modules/beta-private-cluster-update-variant/outputs.tf
@@ -161,6 +161,14 @@ output "identity_namespace" {
   ]
 }
 
+output "mesh_certificates_config" {
+  description = "Mesh certificates configuration"
+  value       = local.cluster_mesh_certificates_config
+  depends_on = [
+    google_container_cluster.primary
+  ]
+}
+
 output "master_ipv4_cidr_block" {
   description = "The IP range in CIDR notation used for the hosted master network"
   value       = var.master_ipv4_cidr_block

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -439,6 +439,12 @@ variable "identity_namespace" {
   default     = "enabled"
 }
 
+variable "enable_mesh_certificates" {
+  type        = bool
+  default     = false
+  description = "Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity."
+}
+
 variable "release_channel" {
   type        = string
   description = "The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`."
@@ -721,7 +727,6 @@ variable "enable_pod_security_policy" {
   description = "enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. Pod Security Policy was removed from GKE clusters with version >= 1.25.0."
   default     = false
 }
-
 
 variable "enable_l4_ilb_subsetting" {
   type        = bool

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -172,6 +172,7 @@ Then perform the following commands on the root folder:
 | enable\_intranode\_visibility | Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network | `bool` | `false` | no |
 | enable\_kubernetes\_alpha | Whether to enable Kubernetes Alpha features for this cluster. Note that when this option is enabled, the cluster cannot be upgraded and will be automatically deleted after 30 days. | `bool` | `false` | no |
 | enable\_l4\_ilb\_subsetting | Enable L4 ILB Subsetting on the cluster | `bool` | `false` | no |
+| enable\_mesh\_certificates | Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity. | `bool` | `false` | no |
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_pod\_security\_policy | enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. Pod Security Policy was removed from GKE clusters with version >= 1.25.0. | `bool` | `false` | no |
 | enable\_private\_endpoint | (Beta) Whether the master's internal IP address is used as the cluster endpoint | `bool` | `false` | no |
@@ -273,6 +274,7 @@ Then perform the following commands on the root folder:
 | master\_authorized\_networks\_config | Networks from which access to master is permitted |
 | master\_ipv4\_cidr\_block | The IP range in CIDR notation used for the hosted master network |
 | master\_version | Current master kubernetes version |
+| mesh\_certificates\_config | Mesh certificates configuration |
 | min\_master\_version | Minimum master kubernetes version |
 | monitoring\_service | Monitoring service used |
 | name | Cluster name |

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -443,6 +443,14 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  dynamic "mesh_certificates" {
+    for_each = local.cluster_mesh_certificates_config
+
+    content {
+      enable_certificates = mesh_certificates.value.enable_certificates
+    }
+  }
+
   dynamic "authenticator_groups_config" {
     for_each = local.cluster_authenticator_security_group
     content {

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -181,6 +181,10 @@ locals {
   cluster_workload_identity_config = !local.workload_identity_enabled ? [] : var.identity_namespace == "enabled" ? [{
     workload_pool = "${var.project_id}.svc.id.goog" }] : [{ workload_pool = var.identity_namespace
   }]
+  cluster_mesh_certificates_config = local.workload_identity_enabled ? [{
+    enable_certificates = var.enable_mesh_certificates
+  }] : []
+
   # BETA features
   cluster_istio_enabled                = !local.cluster_output_istio_disabled
   cluster_dns_cache_enabled            = var.dns_cache

--- a/modules/beta-private-cluster/outputs.tf
+++ b/modules/beta-private-cluster/outputs.tf
@@ -169,6 +169,7 @@ output "mesh_certificates_config" {
   ]
 }
 
+
 output "master_ipv4_cidr_block" {
   description = "The IP range in CIDR notation used for the hosted master network"
   value       = var.master_ipv4_cidr_block

--- a/modules/beta-private-cluster/outputs.tf
+++ b/modules/beta-private-cluster/outputs.tf
@@ -161,6 +161,14 @@ output "identity_namespace" {
   ]
 }
 
+output "mesh_certificates_config" {
+  description = "Mesh certificates configuration"
+  value       = local.cluster_mesh_certificates_config
+  depends_on = [
+    google_container_cluster.primary
+  ]
+}
+
 output "master_ipv4_cidr_block" {
   description = "The IP range in CIDR notation used for the hosted master network"
   value       = var.master_ipv4_cidr_block

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -439,6 +439,12 @@ variable "identity_namespace" {
   default     = "enabled"
 }
 
+variable "enable_mesh_certificates" {
+  type        = bool
+  default     = false
+  description = "Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity."
+}
+
 variable "release_channel" {
   type        = string
   description = "The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`."
@@ -721,7 +727,6 @@ variable "enable_pod_security_policy" {
   description = "enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. Pod Security Policy was removed from GKE clusters with version >= 1.25.0."
   default     = false
 }
-
 
 variable "enable_l4_ilb_subsetting" {
   type        = bool

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -187,6 +187,7 @@ Then perform the following commands on the root folder:
 | enable\_intranode\_visibility | Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network | `bool` | `false` | no |
 | enable\_kubernetes\_alpha | Whether to enable Kubernetes Alpha features for this cluster. Note that when this option is enabled, the cluster cannot be upgraded and will be automatically deleted after 30 days. | `bool` | `false` | no |
 | enable\_l4\_ilb\_subsetting | Enable L4 ILB Subsetting on the cluster | `bool` | `false` | no |
+| enable\_mesh\_certificates | Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity. | `bool` | `false` | no |
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_pod\_security\_policy | enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. Pod Security Policy was removed from GKE clusters with version >= 1.25.0. | `bool` | `false` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
@@ -283,6 +284,7 @@ Then perform the following commands on the root folder:
 | logging\_service | Logging service used |
 | master\_authorized\_networks\_config | Networks from which access to master is permitted |
 | master\_version | Current master kubernetes version |
+| mesh\_certificates\_config | Mesh certificates configuration |
 | min\_master\_version | Minimum master kubernetes version |
 | monitoring\_service | Monitoring service used |
 | name | Cluster name |

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -424,6 +424,14 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  dynamic "mesh_certificates" {
+    for_each = local.cluster_mesh_certificates_config
+
+    content {
+      enable_certificates = mesh_certificates.value.enable_certificates
+    }
+  }
+
   dynamic "authenticator_groups_config" {
     for_each = local.cluster_authenticator_security_group
     content {

--- a/modules/beta-public-cluster-update-variant/main.tf
+++ b/modules/beta-public-cluster-update-variant/main.tf
@@ -180,6 +180,10 @@ locals {
   cluster_workload_identity_config = !local.workload_identity_enabled ? [] : var.identity_namespace == "enabled" ? [{
     workload_pool = "${var.project_id}.svc.id.goog" }] : [{ workload_pool = var.identity_namespace
   }]
+  cluster_mesh_certificates_config = local.workload_identity_enabled ? [{
+    enable_certificates = var.enable_mesh_certificates
+  }] : []
+
   # BETA features
   cluster_istio_enabled                = !local.cluster_output_istio_disabled
   cluster_dns_cache_enabled            = var.dns_cache

--- a/modules/beta-public-cluster-update-variant/outputs.tf
+++ b/modules/beta-public-cluster-update-variant/outputs.tf
@@ -161,6 +161,14 @@ output "identity_namespace" {
   ]
 }
 
+output "mesh_certificates_config" {
+  description = "Mesh certificates configuration"
+  value       = local.cluster_mesh_certificates_config
+  depends_on = [
+    google_container_cluster.primary
+  ]
+}
+
 output "cloudrun_enabled" {
   description = "Whether CloudRun enabled"
   value       = local.cluster_cloudrun_enabled

--- a/modules/beta-public-cluster-update-variant/outputs.tf
+++ b/modules/beta-public-cluster-update-variant/outputs.tf
@@ -169,6 +169,7 @@ output "mesh_certificates_config" {
   ]
 }
 
+
 output "cloudrun_enabled" {
   description = "Whether CloudRun enabled"
   value       = local.cluster_cloudrun_enabled

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -409,6 +409,12 @@ variable "identity_namespace" {
   default     = "enabled"
 }
 
+variable "enable_mesh_certificates" {
+  type        = bool
+  default     = false
+  description = "Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity."
+}
+
 variable "release_channel" {
   type        = string
   description = "The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`."
@@ -691,7 +697,6 @@ variable "enable_pod_security_policy" {
   description = "enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. Pod Security Policy was removed from GKE clusters with version >= 1.25.0."
   default     = false
 }
-
 
 variable "enable_l4_ilb_subsetting" {
   type        = bool

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -165,6 +165,7 @@ Then perform the following commands on the root folder:
 | enable\_intranode\_visibility | Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network | `bool` | `false` | no |
 | enable\_kubernetes\_alpha | Whether to enable Kubernetes Alpha features for this cluster. Note that when this option is enabled, the cluster cannot be upgraded and will be automatically deleted after 30 days. | `bool` | `false` | no |
 | enable\_l4\_ilb\_subsetting | Enable L4 ILB Subsetting on the cluster | `bool` | `false` | no |
+| enable\_mesh\_certificates | Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity. | `bool` | `false` | no |
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_pod\_security\_policy | enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. Pod Security Policy was removed from GKE clusters with version >= 1.25.0. | `bool` | `false` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
@@ -261,6 +262,7 @@ Then perform the following commands on the root folder:
 | logging\_service | Logging service used |
 | master\_authorized\_networks\_config | Networks from which access to master is permitted |
 | master\_version | Current master kubernetes version |
+| mesh\_certificates\_config | Mesh certificates configuration |
 | min\_master\_version | Minimum master kubernetes version |
 | monitoring\_service | Monitoring service used |
 | name | Cluster name |

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -424,6 +424,14 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  dynamic "mesh_certificates" {
+    for_each = local.cluster_mesh_certificates_config
+
+    content {
+      enable_certificates = mesh_certificates.value.enable_certificates
+    }
+  }
+
   dynamic "authenticator_groups_config" {
     for_each = local.cluster_authenticator_security_group
     content {

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -180,6 +180,10 @@ locals {
   cluster_workload_identity_config = !local.workload_identity_enabled ? [] : var.identity_namespace == "enabled" ? [{
     workload_pool = "${var.project_id}.svc.id.goog" }] : [{ workload_pool = var.identity_namespace
   }]
+  cluster_mesh_certificates_config = local.workload_identity_enabled ? [{
+    enable_certificates = var.enable_mesh_certificates
+  }] : []
+
   # BETA features
   cluster_istio_enabled                = !local.cluster_output_istio_disabled
   cluster_dns_cache_enabled            = var.dns_cache

--- a/modules/beta-public-cluster/outputs.tf
+++ b/modules/beta-public-cluster/outputs.tf
@@ -161,6 +161,14 @@ output "identity_namespace" {
   ]
 }
 
+output "mesh_certificates_config" {
+  description = "Mesh certificates configuration"
+  value       = local.cluster_mesh_certificates_config
+  depends_on = [
+    google_container_cluster.primary
+  ]
+}
+
 output "cloudrun_enabled" {
   description = "Whether CloudRun enabled"
   value       = local.cluster_cloudrun_enabled

--- a/modules/beta-public-cluster/outputs.tf
+++ b/modules/beta-public-cluster/outputs.tf
@@ -169,6 +169,7 @@ output "mesh_certificates_config" {
   ]
 }
 
+
 output "cloudrun_enabled" {
   description = "Whether CloudRun enabled"
   value       = local.cluster_cloudrun_enabled

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -409,6 +409,12 @@ variable "identity_namespace" {
   default     = "enabled"
 }
 
+variable "enable_mesh_certificates" {
+  type        = bool
+  default     = false
+  description = "Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity."
+}
+
 variable "release_channel" {
   type        = string
   description = "The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`."
@@ -691,7 +697,6 @@ variable "enable_pod_security_policy" {
   description = "enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. Pod Security Policy was removed from GKE clusters with version >= 1.25.0."
   default     = false
 }
-
 
 variable "enable_l4_ilb_subsetting" {
   type        = bool

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -183,6 +183,7 @@ Then perform the following commands on the root folder:
 | enable\_binary\_authorization | Enable BinAuthZ Admission controller | `bool` | `false` | no |
 | enable\_cost\_allocation | Enables Cost Allocation Feature and the cluster name and namespace of your GKE workloads appear in the labels field of the billing export to BigQuery | `bool` | `false` | no |
 | enable\_kubernetes\_alpha | Whether to enable Kubernetes Alpha features for this cluster. Note that when this option is enabled, the cluster cannot be upgraded and will be automatically deleted after 30 days. | `bool` | `false` | no |
+| enable\_mesh\_certificates | Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity. | `bool` | `false` | no |
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_private\_endpoint | (Beta) Whether the master's internal IP address is used as the cluster endpoint | `bool` | `false` | no |
 | enable\_private\_nodes | (Beta) Whether nodes have internal IP addresses only | `bool` | `false` | no |
@@ -271,6 +272,7 @@ Then perform the following commands on the root folder:
 | master\_authorized\_networks\_config | Networks from which access to master is permitted |
 | master\_ipv4\_cidr\_block | The IP range in CIDR notation used for the hosted master network |
 | master\_version | Current master kubernetes version |
+| mesh\_certificates\_config | Mesh certificates configuration |
 | min\_master\_version | Minimum master kubernetes version |
 | monitoring\_service | Monitoring service used |
 | name | Cluster name |

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -378,6 +378,14 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  dynamic "mesh_certificates" {
+    for_each = local.cluster_mesh_certificates_config
+
+    content {
+      enable_certificates = mesh_certificates.value.enable_certificates
+    }
+  }
+
   dynamic "authenticator_groups_config" {
     for_each = local.cluster_authenticator_security_group
     content {

--- a/modules/private-cluster-update-variant/main.tf
+++ b/modules/private-cluster-update-variant/main.tf
@@ -163,6 +163,10 @@ locals {
   cluster_workload_identity_config = !local.workload_identity_enabled ? [] : var.identity_namespace == "enabled" ? [{
     workload_pool = "${var.project_id}.svc.id.goog" }] : [{ workload_pool = var.identity_namespace
   }]
+  cluster_mesh_certificates_config = local.workload_identity_enabled ? [{
+    enable_certificates = var.enable_mesh_certificates
+  }] : []
+
 
   cluster_maintenance_window_is_recurring = var.maintenance_recurrence != "" && var.maintenance_end_time != "" ? [1] : []
   cluster_maintenance_window_is_daily     = length(local.cluster_maintenance_window_is_recurring) > 0 ? [] : [1]

--- a/modules/private-cluster-update-variant/outputs.tf
+++ b/modules/private-cluster-update-variant/outputs.tf
@@ -169,6 +169,7 @@ output "mesh_certificates_config" {
   ]
 }
 
+
 output "master_ipv4_cidr_block" {
   description = "The IP range in CIDR notation used for the hosted master network"
   value       = var.master_ipv4_cidr_block

--- a/modules/private-cluster-update-variant/outputs.tf
+++ b/modules/private-cluster-update-variant/outputs.tf
@@ -161,6 +161,14 @@ output "identity_namespace" {
   ]
 }
 
+output "mesh_certificates_config" {
+  description = "Mesh certificates configuration"
+  value       = local.cluster_mesh_certificates_config
+  depends_on = [
+    google_container_cluster.primary
+  ]
+}
+
 output "master_ipv4_cidr_block" {
   description = "The IP range in CIDR notation used for the hosted master network"
   value       = var.master_ipv4_cidr_block

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -431,6 +431,12 @@ variable "identity_namespace" {
   default     = "enabled"
 }
 
+variable "enable_mesh_certificates" {
+  type        = bool
+  default     = false
+  description = "Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity."
+}
+
 variable "release_channel" {
   type        = string
   description = "The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`."

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -161,6 +161,7 @@ Then perform the following commands on the root folder:
 | enable\_binary\_authorization | Enable BinAuthZ Admission controller | `bool` | `false` | no |
 | enable\_cost\_allocation | Enables Cost Allocation Feature and the cluster name and namespace of your GKE workloads appear in the labels field of the billing export to BigQuery | `bool` | `false` | no |
 | enable\_kubernetes\_alpha | Whether to enable Kubernetes Alpha features for this cluster. Note that when this option is enabled, the cluster cannot be upgraded and will be automatically deleted after 30 days. | `bool` | `false` | no |
+| enable\_mesh\_certificates | Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity. | `bool` | `false` | no |
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_private\_endpoint | (Beta) Whether the master's internal IP address is used as the cluster endpoint | `bool` | `false` | no |
 | enable\_private\_nodes | (Beta) Whether nodes have internal IP addresses only | `bool` | `false` | no |
@@ -249,6 +250,7 @@ Then perform the following commands on the root folder:
 | master\_authorized\_networks\_config | Networks from which access to master is permitted |
 | master\_ipv4\_cidr\_block | The IP range in CIDR notation used for the hosted master network |
 | master\_version | Current master kubernetes version |
+| mesh\_certificates\_config | Mesh certificates configuration |
 | min\_master\_version | Minimum master kubernetes version |
 | monitoring\_service | Monitoring service used |
 | name | Cluster name |

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -378,6 +378,14 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  dynamic "mesh_certificates" {
+    for_each = local.cluster_mesh_certificates_config
+
+    content {
+      enable_certificates = mesh_certificates.value.enable_certificates
+    }
+  }
+
   dynamic "authenticator_groups_config" {
     for_each = local.cluster_authenticator_security_group
     content {

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -163,6 +163,10 @@ locals {
   cluster_workload_identity_config = !local.workload_identity_enabled ? [] : var.identity_namespace == "enabled" ? [{
     workload_pool = "${var.project_id}.svc.id.goog" }] : [{ workload_pool = var.identity_namespace
   }]
+  cluster_mesh_certificates_config = local.workload_identity_enabled ? [{
+    enable_certificates = var.enable_mesh_certificates
+  }] : []
+
 
   cluster_maintenance_window_is_recurring = var.maintenance_recurrence != "" && var.maintenance_end_time != "" ? [1] : []
   cluster_maintenance_window_is_daily     = length(local.cluster_maintenance_window_is_recurring) > 0 ? [] : [1]

--- a/modules/private-cluster/outputs.tf
+++ b/modules/private-cluster/outputs.tf
@@ -169,6 +169,7 @@ output "mesh_certificates_config" {
   ]
 }
 
+
 output "master_ipv4_cidr_block" {
   description = "The IP range in CIDR notation used for the hosted master network"
   value       = var.master_ipv4_cidr_block

--- a/modules/private-cluster/outputs.tf
+++ b/modules/private-cluster/outputs.tf
@@ -161,6 +161,14 @@ output "identity_namespace" {
   ]
 }
 
+output "mesh_certificates_config" {
+  description = "Mesh certificates configuration"
+  value       = local.cluster_mesh_certificates_config
+  depends_on = [
+    google_container_cluster.primary
+  ]
+}
+
 output "master_ipv4_cidr_block" {
   description = "The IP range in CIDR notation used for the hosted master network"
   value       = var.master_ipv4_cidr_block

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -431,6 +431,12 @@ variable "identity_namespace" {
   default     = "enabled"
 }
 
+variable "enable_mesh_certificates" {
+  type        = bool
+  default     = false
+  description = "Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity."
+}
+
 variable "release_channel" {
   type        = string
   description = "The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`."

--- a/modules/safer-cluster-update-variant/README.md
+++ b/modules/safer-cluster-update-variant/README.md
@@ -219,6 +219,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | dns\_cache | (Beta) The status of the NodeLocal DNSCache addon. | `bool` | `false` | no |
 | enable\_cost\_allocation | Enables Cost Allocation Feature and the cluster name and namespace of your GKE workloads appear in the labels field of the billing export to BigQuery | `bool` | `false` | no |
 | enable\_intranode\_visibility | Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network | `bool` | `false` | no |
+| enable\_mesh\_certificates | Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity. | `bool` | `false` | no |
 | enable\_pod\_security\_policy | enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. | `bool` | `false` | no |
 | enable\_private\_endpoint | When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled. When false, either endpoint can be used. This field only applies to private clusters, when enable\_private\_nodes is true | `bool` | `true` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster. | `bool` | `true` | no |
@@ -278,6 +279,7 @@ For simplicity, we suggest using `roles/container.admin` and
 |------|-------------|
 | ca\_certificate | Cluster ca certificate (base64 encoded) |
 | cluster\_id | Cluster ID |
+| enable\_mesh\_certificates | Mesh certificate configuration value |
 | endpoint | Cluster endpoint |
 | horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |
 | http\_load\_balancing\_enabled | Whether http load balancing enabled |

--- a/modules/safer-cluster-update-variant/main.tf
+++ b/modules/safer-cluster-update-variant/main.tf
@@ -181,6 +181,9 @@ module "gke" {
   // We enable Workload Identity by default.
   identity_namespace = "${var.project_id}.svc.id.goog"
 
+  // Enabling mesh certificates requires Workload Identity
+  enable_mesh_certificates = var.enable_mesh_certificates
+
   authenticator_security_group = var.authenticator_security_group
 
   enable_shielded_nodes = var.enable_shielded_nodes

--- a/modules/safer-cluster-update-variant/outputs.tf
+++ b/modules/safer-cluster-update-variant/outputs.tf
@@ -122,3 +122,8 @@ output "peering_name" {
   description = "The name of the peering between this cluster and the Google owned VPC."
   value       = module.gke.peering_name
 }
+
+output "enable_mesh_certificates" {
+  description = "Mesh certificate configuration value"
+  value       = var.enable_mesh_certificates
+}

--- a/modules/safer-cluster-update-variant/variables.tf
+++ b/modules/safer-cluster-update-variant/variables.tf
@@ -484,3 +484,9 @@ variable "timeouts" {
     error_message = "Only create, update, delete timeouts can be specified."
   }
 }
+
+variable "enable_mesh_certificates" {
+  type        = bool
+  default     = false
+  description = "Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity."
+}

--- a/modules/safer-cluster/README.md
+++ b/modules/safer-cluster/README.md
@@ -219,6 +219,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | dns\_cache | (Beta) The status of the NodeLocal DNSCache addon. | `bool` | `false` | no |
 | enable\_cost\_allocation | Enables Cost Allocation Feature and the cluster name and namespace of your GKE workloads appear in the labels field of the billing export to BigQuery | `bool` | `false` | no |
 | enable\_intranode\_visibility | Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network | `bool` | `false` | no |
+| enable\_mesh\_certificates | Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity. | `bool` | `false` | no |
 | enable\_pod\_security\_policy | enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. | `bool` | `false` | no |
 | enable\_private\_endpoint | When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled. When false, either endpoint can be used. This field only applies to private clusters, when enable\_private\_nodes is true | `bool` | `true` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster. | `bool` | `true` | no |
@@ -278,6 +279,7 @@ For simplicity, we suggest using `roles/container.admin` and
 |------|-------------|
 | ca\_certificate | Cluster ca certificate (base64 encoded) |
 | cluster\_id | Cluster ID |
+| enable\_mesh\_certificates | Mesh certificate configuration value |
 | endpoint | Cluster endpoint |
 | horizontal\_pod\_autoscaling\_enabled | Whether horizontal pod autoscaling enabled |
 | http\_load\_balancing\_enabled | Whether http load balancing enabled |

--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -181,6 +181,9 @@ module "gke" {
   // We enable Workload Identity by default.
   identity_namespace = "${var.project_id}.svc.id.goog"
 
+  // Enabling mesh certificates requires Workload Identity
+  enable_mesh_certificates = var.enable_mesh_certificates
+
   authenticator_security_group = var.authenticator_security_group
 
   enable_shielded_nodes = var.enable_shielded_nodes

--- a/modules/safer-cluster/outputs.tf
+++ b/modules/safer-cluster/outputs.tf
@@ -122,3 +122,8 @@ output "peering_name" {
   description = "The name of the peering between this cluster and the Google owned VPC."
   value       = module.gke.peering_name
 }
+
+output "enable_mesh_certificates" {
+  description = "Mesh certificate configuration value"
+  value       = var.enable_mesh_certificates
+}

--- a/modules/safer-cluster/variables.tf
+++ b/modules/safer-cluster/variables.tf
@@ -484,3 +484,9 @@ variable "timeouts" {
     error_message = "Only create, update, delete timeouts can be specified."
   }
 }
+
+variable "enable_mesh_certificates" {
+  type        = bool
+  default     = false
+  description = "Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity."
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -168,3 +168,4 @@ output "mesh_certificates_config" {
     google_container_cluster.primary
   ]
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -160,3 +160,11 @@ output "identity_namespace" {
     google_container_cluster.primary
   ]
 }
+
+output "mesh_certificates_config" {
+  description = "Mesh certificates configuration"
+  value       = local.cluster_mesh_certificates_config
+  depends_on = [
+    google_container_cluster.primary
+  ]
+}

--- a/test/integration/safer_cluster/safer_cluster_test.go
+++ b/test/integration/safer_cluster/safer_cluster_test.go
@@ -52,6 +52,7 @@ func TestSaferCluster(t *testing.T) {
 			"networkConfig.datapathProvider",
 			"binaryAuthorization.evaluationMode",
 			"legacyAbac",
+			"meshCertificates.enableCertificates",
 			"nodePools.autoscaling",
 			"nodePools.config.machineType",
 			"nodePools.config.diskSizeGb",

--- a/test/integration/safer_cluster/testdata/TestSaferCluster.json
+++ b/test/integration/safer_cluster/testdata/TestSaferCluster.json
@@ -90,6 +90,9 @@
     ],
     "enabled": true
   },
+  "meshCertificates": {
+    "enableCertificates": false
+  },
   "monitoringConfig": {
     "componentConfig": {
       "enableComponents": [

--- a/variables.tf
+++ b/variables.tf
@@ -401,6 +401,12 @@ variable "identity_namespace" {
   default     = "enabled"
 }
 
+variable "enable_mesh_certificates" {
+  type        = bool
+  default     = false
+  description = "Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity."
+}
+
 variable "release_channel" {
   type        = string
   description = "The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. Defaults to `REGULAR`."


### PR DESCRIPTION
Implements feature request from https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1691 (quoted below) to add `enable_mesh_certificates` configuration option, including to safer-cluster.  

Defaults to `false` / not enabled, which is the default behavior for clusters without it set.  Not sure whether to call this a breaking change due to overwriting if value was set to `true` with another module or gcloud command.
 
Happy to take feedback.


<blockquote><h2>TL;DR</h2>

 In order to use mTLS service security with Traffic Director "Mesh certificates" must be enabled on the cluster. Add the ability for all cluster modules in this repository to enable this functionality with a variable.
 
<h2>Terraform Resources</h2>

 The documentation for `google_container_cluster` with the `mesh_certificates` block
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#enable_certificates

Instructions for `--enable-mesh-certificates` on GKE cluster in the Traffic Director documentation for setting up mTLS certificates
https://cloud.google.com/traffic-director/docs/security-envoy-setup#create-cluster

<h2>Detailed design</h2>

This could look like exposing an module variable to configure the underlying `google_container_cluster` terraform resource.

<pre>
mesh_certificates {
  enable_certificates = var.enable_mesh_certificates
}
</pre>
</blockquote>

