### PR TITLE
feat(private-cluster): expose network_config per node-pool option

### DIFF
--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -572,6 +572,15 @@ resource "google_container_node_pool" "pools" {
     delete = lookup(var.timeouts, "delete", "45m")
   }
 
+  dynamic "network_config" {
+    for_each = lookup(each.value, "create_pod_range", false) || lookup(each.value, "pod_ipv4_cidr_block", null) != null ? [each.value] : []
+
+    content {
+      create_pod_range = lookup(network_config.value, "create_pod_range", false)
+      pod_ipv4_cidr_block = lookup(network_config.value, "pod_ipv4_cidr_block", "")
+    }
+  }
+
 }
 resource "google_container_node_pool" "windows_pools" {
   provider = google

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -578,6 +578,7 @@ resource "google_container_node_pool" "pools" {
     content {
       create_pod_range = lookup(network_config.value, "create_pod_range", false)
       pod_ipv4_cidr_block = lookup(network_config.value, "pod_ipv4_cidr_block", "")
+      enable_private_nodes = lookup(network_config.value, "enable_private_nodes", false)
     }
   }
 


### PR DESCRIPTION
Add a possibility to use CIDR for a specific node pool. This is useful for security concerns to use in firewall rules.

![image](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/assets/10716628/e23c88ee-88c9-4ea6-bbd1-d0c371fddfb8)

Sample result:

![image](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/assets/10716628/19e14c86-277c-49e8-b6fc-dd8309a8ef17)

https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/container_node_pool#network_config

