### PR TITLE
chore: uses random_string for test setup

### DIFF
--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -47,11 +47,12 @@ module "gke-project-1" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 14.0"
 
-  name              = "ci-gke-${random_id.random_project_id_suffix.hex}"
-  random_project_id = true
-  org_id            = var.org_id
-  folder_id         = var.folder_id
-  billing_account   = var.billing_account
+  name                     = "ci-gke-${random_id.random_project_id_suffix.hex}"
+  random_project_id        = true
+  random_project_id_length = 4
+  org_id                   = var.org_id
+  folder_id                = var.folder_id
+  billing_account          = var.billing_account
   # due to https://github.com/hashicorp/terraform-provider-google/issues/9505 for AP
   default_service_account = "keep"
 


### PR DESCRIPTION
* use `random_string` for a larger collusion domain https://github.com/terraform-google-modules/terraform-google-project-factory/pull/735