### PR TITLE
pinning asm kubectl version to ~> 3.1.0

### DIFF
--- a/modules/asm/main.tf
+++ b/modules/asm/main.tf
@@ -57,7 +57,7 @@ resource "kubernetes_config_map" "asm_options" {
 
 module "cpr" {
   source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
-  version = "~> 3.1"
+  version = "~> 3.1.0"
 
   project_id       = var.project_id
   cluster_name     = var.cluster_name


### PR DESCRIPTION
The 3.2 update of the kubectl_wrapper module being used in the asm module is breaking downstream build pipelines

https://github.com/terraform-google-modules/terraform-google-gcloud/issues/163