### PR TITLE
chore: update test regions

### DIFF
--- a/test/fixtures/simple_regional/example.tf
+++ b/test/fixtures/simple_regional/example.tf
@@ -19,7 +19,7 @@ module "example" {
 
   project_id                     = var.project_ids[0]
   cluster_name_suffix            = "-${random_string.suffix.result}"
-  region                         = var.region
+  region                         = "us-west1"
   network                        = google_compute_network.main.name
   subnetwork                     = google_compute_subnetwork.main.name
   ip_range_pods                  = google_compute_subnetwork.main.secondary_ip_range[0].range_name

--- a/test/fixtures/simple_regional/network.tf
+++ b/test/fixtures/simple_regional/network.tf
@@ -32,7 +32,7 @@ resource "google_compute_network" "main" {
 resource "google_compute_subnetwork" "main" {
   name          = "cft-gke-test-${random_string.suffix.result}"
   ip_cidr_range = "10.0.0.0/17"
-  region        = var.region
+  region        = "us-west1"
   network       = google_compute_network.main.self_link
 
   secondary_ip_range {

--- a/test/integration/simple_regional/testdata/TestSimpleRegional.json
+++ b/test/integration/simple_regional/testdata/TestSimpleRegional.json
@@ -45,12 +45,12 @@
   "id": "8e4011253bcb4fbc943f88ae797f124f0f001ed95cc94b229231d68b8a44e20b",
   "initialClusterVersion": "1.27.3-gke.100",
   "instanceGroupUrls": [
-    "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-central1-a/instanceGroupManagers/gke-simple-regional-clus-default-pool-209983a6-grp",
-    "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-central1-c/instanceGroupManagers/gke-simple-regional-clus-default-pool-6094c28c-grp",
-    "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-central1-f/instanceGroupManagers/gke-simple-regional-clus-default-pool-a9225012-grp",
-    "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-central1-a/instanceGroupManagers/gke-simple-regional--default-node-poo-8fb4fd0f-grp",
-    "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-central1-c/instanceGroupManagers/gke-simple-regional--default-node-poo-24ffed9f-grp",
-    "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-central1-f/instanceGroupManagers/gke-simple-regional--default-node-poo-1d2dc357-grp"
+    "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-west1-a/instanceGroupManagers/gke-simple-regional-clus-default-pool-209983a6-grp",
+    "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-west1-c/instanceGroupManagers/gke-simple-regional-clus-default-pool-6094c28c-grp",
+    "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-west1-f/instanceGroupManagers/gke-simple-regional-clus-default-pool-a9225012-grp",
+    "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-west1-a/instanceGroupManagers/gke-simple-regional--default-node-poo-8fb4fd0f-grp",
+    "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-west1-c/instanceGroupManagers/gke-simple-regional--default-node-poo-24ffed9f-grp",
+    "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-west1-f/instanceGroupManagers/gke-simple-regional--default-node-poo-1d2dc357-grp"
   ],
   "ipAllocationPolicy": {
     "clusterIpv4Cidr": "192.168.0.0/18",
@@ -66,11 +66,11 @@
   },
   "labelFingerprint": "a9dc16a7",
   "legacyAbac": {},
-  "location": "us-central1",
+  "location": "us-west1",
   "locations": [
-    "us-central1-a",
-    "us-central1-c",
-    "us-central1-f"
+    "us-west1-a",
+    "us-west1-c",
+    "us-west1-f"
   ],
   "loggingConfig": {
     "componentConfig": {
@@ -116,7 +116,7 @@
     "defaultSnatStatus": {},
     "network": "projects/PROJECT_ID/global/networks/cft-gke-test-44kc",
     "serviceExternalIpsConfig": {},
-    "subnetwork": "projects/PROJECT_ID/regions/us-central1/subnetworks/cft-gke-test-44kc"
+    "subnetwork": "projects/PROJECT_ID/regions/us-west1/subnetworks/cft-gke-test-44kc"
   },
   "nodeConfig": {
     "diskSizeGb": 100,
@@ -192,14 +192,14 @@
       },
       "etag": "3bb00743-9dbf-4e92-9512-1e64fb8f1b8a",
       "instanceGroupUrls": [
-        "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-central1-a/instanceGroupManagers/gke-simple-regional-clus-default-pool-209983a6-grp",
-        "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-central1-c/instanceGroupManagers/gke-simple-regional-clus-default-pool-6094c28c-grp",
-        "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-central1-f/instanceGroupManagers/gke-simple-regional-clus-default-pool-a9225012-grp"
+        "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-west1-a/instanceGroupManagers/gke-simple-regional-clus-default-pool-209983a6-grp",
+        "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-west1-c/instanceGroupManagers/gke-simple-regional-clus-default-pool-6094c28c-grp",
+        "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-west1-f/instanceGroupManagers/gke-simple-regional-clus-default-pool-a9225012-grp"
       ],
       "locations": [
-        "us-central1-a",
-        "us-central1-c",
-        "us-central1-f"
+        "us-west1-a",
+        "us-west1-c",
+        "us-west1-f"
       ],
       "management": {
         "autoRepair": true,
@@ -216,7 +216,7 @@
         "podRange": "cft-gke-test-pods-44kc"
       },
       "podIpv4CidrSize": 24,
-      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/CLUSTER_NAME/nodePools/default-pool",
+      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-west1/clusters/CLUSTER_NAME/nodePools/default-pool",
       "status": "RUNNING",
       "upgradeSettings": {
         "maxSurge": 1,
@@ -269,14 +269,14 @@
       "etag": "c1cb03bd-8b4e-4a06-9c4e-213b87aa86a3",
       "initialNodeCount": 1,
       "instanceGroupUrls": [
-        "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-central1-a/instanceGroupManagers/gke-simple-regional--default-node-poo-8fb4fd0f-grp",
-        "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-central1-c/instanceGroupManagers/gke-simple-regional--default-node-poo-24ffed9f-grp",
-        "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-central1-f/instanceGroupManagers/gke-simple-regional--default-node-poo-1d2dc357-grp"
+        "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-west1-a/instanceGroupManagers/gke-simple-regional--default-node-poo-8fb4fd0f-grp",
+        "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-west1-c/instanceGroupManagers/gke-simple-regional--default-node-poo-24ffed9f-grp",
+        "https://www.googleapis.com/compute/v1/projects/PROJECT_ID/zones/us-west1-f/instanceGroupManagers/gke-simple-regional--default-node-poo-1d2dc357-grp"
       ],
       "locations": [
-        "us-central1-a",
-        "us-central1-c",
-        "us-central1-f"
+        "us-west1-a",
+        "us-west1-c",
+        "us-west1-f"
       ],
       "management": {
         "autoRepair": true,
@@ -293,7 +293,7 @@
         "podRange": "cft-gke-test-pods-44kc"
       },
       "podIpv4CidrSize": 24,
-      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/CLUSTER_NAME/nodePools/default-node-pool",
+      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-west1/clusters/CLUSTER_NAME/nodePools/default-node-pool",
       "status": "RUNNING",
       "upgradeSettings": {
         "maxSurge": 1,
@@ -316,7 +316,7 @@
     "mode": "BASIC",
     "vulnerabilityMode": "VULNERABILITY_MODE_UNSPECIFIED"
   },
-  "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/CLUSTER_NAME",
+  "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-west1/clusters/CLUSTER_NAME",
   "servicesIpv4Cidr": "192.168.64.0/18",
   "shieldedNodes": {
     "enabled": true
@@ -327,5 +327,5 @@
   "workloadIdentityConfig": {
     "workloadPool": "PROJECT_ID.svc.id.goog"
   },
-  "zone": "us-central1"
+  "zone": "us-west1"
 }


### PR DESCRIPTION
Tests seem to be failing with `Error: googleapi: Error 403: You cannot create more than 3 clusters in location us-central1; to create more than 3, you must request an increase of your Google Compute Engine quota for region us-central1 to 25 CPUs or more.`