### PR TITLE
chore: Configure tinyproxy to always restart if killed.

### DIFF
--- a/examples/safer_cluster_iap_bastion/templates/startup-script.tftpl
+++ b/examples/safer_cluster_iap_bastion/templates/startup-script.tftpl
@@ -4,3 +4,4 @@ sudo mkdir -p /etc/systemd/system/tinyproxy.service.d/
 echo -e '[Service]\nRestart=always' | sudo tee /etc/systemd/system/tinyproxy.service.d/override.conf
 sudo systemctl daemon-reload
 sudo systemctl restart tinyproxy
+

--- a/examples/safer_cluster_iap_bastion/templates/startup-script.tftpl
+++ b/examples/safer_cluster_iap_bastion/templates/startup-script.tftpl
@@ -1,2 +1,6 @@
 sudo apt-get update -y
 sudo apt-get install -y tinyproxy
+sudo mkdir -p /etc/systemd/system/tinyproxy.service.d/
+echo -e '[Service]\nRestart=always' | sudo tee /etc/systemd/system/tinyproxy.service.d/override.conf
+sudo systemctl daemon-reload
+sudo systemctl restart tinyproxy


### PR DESCRIPTION
See https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/730#issuecomment-770431179

This uses an override rather than modifying the package owned configuration, which is cleaner and won't be affected by package upgrades.