### PR TITLE
chore: update advancedDatapathObservabilityConfig in CI

### DIFF
--- a/test/integration/beta_cluster/testdata/TestBetaCluster.json
+++ b/test/integration/beta_cluster/testdata/TestBetaCluster.json
@@ -100,7 +100,7 @@
   },
   "monitoringConfig": {
     "advancedDatapathObservabilityConfig": {
-      "relayMode": "DISABLED"
+      "enableRelay": false
     },
     "componentConfig": {
       "enableComponents": [

--- a/test/integration/simple_regional/testdata/TestSimpleRegional.json
+++ b/test/integration/simple_regional/testdata/TestSimpleRegional.json
@@ -98,7 +98,7 @@
   },
   "monitoringConfig": {
     "advancedDatapathObservabilityConfig": {
-      "relayMode": "DISABLED"
+      "enableRelay": false
     },
     "componentConfig": {
       "enableComponents": [


### PR DESCRIPTION
```
        	Error:      	Not equal: 
        	            	expected: "{\n    \"advancedDatapathObservabilityConfig\": {\n      \"relayMode\": \"DISABLED\"\n    },\n    \"componentConfig\": {\n      \"enableComponents\": [\n        \"SYSTEM_COMPONENTS\"\n      ]\n    },\n    \"managedPrometheusConfig\": {}\n  }"
        	            	actual  : "{\n    \"advancedDatapathObservabilityConfig\": {\n      \"enableRelay\": false\n    },\n    \"componentConfig\": {\n      \"enableComponents\": [\n        \"SYSTEM_COMPONENTS\"\n      ]\n    },\n    \"managedPrometheusConfig\": {}\n  }"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -2,3 +2,3 @@
        	            	     "advancedDatapathObservabilityConfig": {
        	            	-      "relayMode": "DISABLED"
        	            	+      "enableRelay": false
        	            	     },
        	Test:       	TestBetaCluster
        	Messages:   	expected monitoringConfig to match fixture {
        	            	    "advancedDatapathObservabilityConfig": {
        	            	      "relayMode": "DISABLED"
        	            	    },
        	            	    "componentConfig": {
        	            	      "enableComponents": [
        	            	        "SYSTEM_COMPONENTS"
        	            	      ]
        	            	    },
        	            	    "managedPrometheusConfig": {}
        	            	  }
```