### PR TITLE
feat: workload-identity: Allow passing Google Service Account display_name and description 

### DIFF
--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -103,6 +103,8 @@ already bear the `"iam.gke.io/gcp-service-account"` annotation.
 | annotate\_k8s\_sa | Annotate the kubernetes service account with 'iam.gke.io/gcp-service-account' annotation. Valid in cases when an existing SA is used. | `bool` | `true` | no |
 | automount\_service\_account\_token | Enable automatic mounting of the service account token | `bool` | `false` | no |
 | cluster\_name | Cluster name. Required if using existing KSA. | `string` | `""` | no |
+| gcp\_sa\_description | The Service Google service account desciption; if null, will be left out | `string` | `null` | no |
+| gcp\_sa\_display\_name | The Google service account display name; if null, a default string will be used | `string` | `null` | no |
 | gcp\_sa\_name | Name for the Google service account; overrides `var.name`. | `string` | `null` | no |
 | impersonate\_service\_account | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `""` | no |
 | k8s\_sa\_name | Name for the Kubernetes service account; overrides `var.name`. `cluster_name` and `location` must be set when this input is specified. | `string` | `null` | no |

--- a/modules/workload-identity/main.tf
+++ b/modules/workload-identity/main.tf
@@ -43,7 +43,8 @@ resource "google_service_account" "cluster_service_account" {
   count = var.use_existing_gcp_sa ? 0 : 1
 
   account_id   = local.gcp_given_name
-  display_name = substr("GCP SA bound to K8S SA ${local.k8s_sa_project_id}[${local.k8s_given_name}]", 0, 100)
+  display_name = coalesce(var.gcp_sa_display_name, substr("GCP SA bound to K8S SA ${local.k8s_sa_project_id}[${local.k8s_given_name}]", 0, 100))
+  description  = var.gcp_sa_description
   project      = var.project_id
 }
 

--- a/modules/workload-identity/variables.tf
+++ b/modules/workload-identity/variables.tf
@@ -134,6 +134,6 @@ variable "gcp_sa_description" {
 
   validation {
     condition     = var.gcp_sa_description == null ? true : length(var.gcp_sa_description) <= 256
-    error_message = "The Google service account display name must be at most 100 characters"
+    error_message = "The Google service account description must be at most 256 characters"
   }
 }

--- a/modules/workload-identity/variables.tf
+++ b/modules/workload-identity/variables.tf
@@ -113,3 +113,27 @@ variable "additional_projects" {
   type        = map(list(string))
   default     = {}
 }
+
+variable "gcp_sa_display_name" {
+  description = "The Google service account display name; if null, a default string will be used"
+  type        = string
+  nullable    = true
+  default     = null
+
+  validation {
+    condition     = var.gcp_sa_display_name == null ? true : length(var.gcp_sa_display_name) <= 100
+    error_message = "The Google service account display name must be at most 100 characters"
+  }
+}
+
+variable "gcp_sa_description" {
+  description = "The Service Google service account desciption; if null, will be left out"
+  type        = string
+  nullable    = true
+  default     = null
+
+  validation {
+    condition     = var.gcp_sa_description == null ? true : length(var.gcp_sa_description) <= 256
+    error_message = "The Google service account display name must be at most 100 characters"
+  }
+}


### PR DESCRIPTION
Straightforward change to allow passing `display_name` and `description` to the Service Account created by workload identity (as input variables `gcp_sa_display_name` and `gcp_sa_description`).

If these are not given (they default to null), the behaviour is the same as before.

Use case: we want to implement some conventions around service account display_name and description for all service accounts to follow (e.g. document how they were created). Without this change, this is only possible by moving the google service account terraform resource outside of the workload-identity module, which is cumbersome state juggling for existing service accounts.

I am not exactly sure what kind of tests are needed here, please advise.