### PR TITLE
feat!: Update least privilege default service account

### DIFF
--- a/autogen/main/sa.tf.tmpl
+++ b/autogen/main/sa.tf.tmpl
@@ -45,31 +45,10 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-log_writer" {
+resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
-  role    = "roles/logging.logWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-log_writer[0].project
-  role    = "roles/monitoring.metricWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-metric_writer[0].project
-  role    = "roles/monitoring.viewer"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
-  role    = "roles/stackdriver.resourceMetadata.writer"
+  role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 

--- a/docs/upgrading_to_v30.0.md
+++ b/docs/upgrading_to_v30.0.md
@@ -4,4 +4,5 @@ release.
 
 ### Default cluster service account permissions modified
 
-When `create_service_account` is `true`, the service account will now be created with the `Logs Writer`, `Monitoring Metric Writer`, `Monitoring Viewer` and `Stackdriver Resource Metadata Writer` roles instead of the deprecated `Kubernetes Engine Node Service Account` role.
+When `create_service_account` is `true`, the service account will now be created with `Kubernetes Engine Default Node Service Account` role instead of `Kubernetes Engine Node Service Account` roles which is deprecated now.
+This is the Google recommended least privileged role to be used for the service account attached to the GKE Nodes.

--- a/modules/beta-autopilot-private-cluster/sa.tf
+++ b/modules/beta-autopilot-private-cluster/sa.tf
@@ -45,31 +45,10 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-log_writer" {
+resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
-  role    = "roles/logging.logWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-log_writer[0].project
-  role    = "roles/monitoring.metricWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-metric_writer[0].project
-  role    = "roles/monitoring.viewer"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
-  role    = "roles/stackdriver.resourceMetadata.writer"
+  role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 

--- a/modules/beta-autopilot-public-cluster/sa.tf
+++ b/modules/beta-autopilot-public-cluster/sa.tf
@@ -45,31 +45,10 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-log_writer" {
+resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
-  role    = "roles/logging.logWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-log_writer[0].project
-  role    = "roles/monitoring.metricWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-metric_writer[0].project
-  role    = "roles/monitoring.viewer"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
-  role    = "roles/stackdriver.resourceMetadata.writer"
+  role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 

--- a/modules/beta-private-cluster-update-variant/sa.tf
+++ b/modules/beta-private-cluster-update-variant/sa.tf
@@ -45,31 +45,10 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-log_writer" {
+resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
-  role    = "roles/logging.logWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-log_writer[0].project
-  role    = "roles/monitoring.metricWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-metric_writer[0].project
-  role    = "roles/monitoring.viewer"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
-  role    = "roles/stackdriver.resourceMetadata.writer"
+  role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 

--- a/modules/beta-private-cluster/sa.tf
+++ b/modules/beta-private-cluster/sa.tf
@@ -45,31 +45,10 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-log_writer" {
+resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
-  role    = "roles/logging.logWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-log_writer[0].project
-  role    = "roles/monitoring.metricWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-metric_writer[0].project
-  role    = "roles/monitoring.viewer"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
-  role    = "roles/stackdriver.resourceMetadata.writer"
+  role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 

--- a/modules/beta-public-cluster-update-variant/sa.tf
+++ b/modules/beta-public-cluster-update-variant/sa.tf
@@ -45,31 +45,10 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-log_writer" {
+resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
-  role    = "roles/logging.logWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-log_writer[0].project
-  role    = "roles/monitoring.metricWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-metric_writer[0].project
-  role    = "roles/monitoring.viewer"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
-  role    = "roles/stackdriver.resourceMetadata.writer"
+  role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 

--- a/modules/beta-public-cluster/sa.tf
+++ b/modules/beta-public-cluster/sa.tf
@@ -45,31 +45,10 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-log_writer" {
+resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
-  role    = "roles/logging.logWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-log_writer[0].project
-  role    = "roles/monitoring.metricWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-metric_writer[0].project
-  role    = "roles/monitoring.viewer"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
-  role    = "roles/stackdriver.resourceMetadata.writer"
+  role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 

--- a/modules/private-cluster-update-variant/sa.tf
+++ b/modules/private-cluster-update-variant/sa.tf
@@ -45,31 +45,10 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-log_writer" {
+resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
-  role    = "roles/logging.logWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-log_writer[0].project
-  role    = "roles/monitoring.metricWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-metric_writer[0].project
-  role    = "roles/monitoring.viewer"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
-  role    = "roles/stackdriver.resourceMetadata.writer"
+  role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 

--- a/modules/private-cluster/sa.tf
+++ b/modules/private-cluster/sa.tf
@@ -45,31 +45,10 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-log_writer" {
+resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
-  role    = "roles/logging.logWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-log_writer[0].project
-  role    = "roles/monitoring.metricWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-metric_writer[0].project
-  role    = "roles/monitoring.viewer"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
-  role    = "roles/stackdriver.resourceMetadata.writer"
+  role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 

--- a/sa.tf
+++ b/sa.tf
@@ -45,31 +45,10 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-log_writer" {
+resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
-  role    = "roles/logging.logWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-log_writer[0].project
-  role    = "roles/monitoring.metricWriter"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-monitoring_viewer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-metric_writer[0].project
-  role    = "roles/monitoring.viewer"
-  member  = google_service_account.cluster_service_account[0].member
-}
-
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
-  count   = var.create_service_account ? 1 : 0
-  project = google_project_iam_member.cluster_service_account-monitoring_viewer[0].project
-  role    = "roles/stackdriver.resourceMetadata.writer"
+  role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 


### PR DESCRIPTION
This update follows changes from #1757 and reverts #1827.

The role `roles/container.nodeServiceAccount` is deprecated now and it is replaced with new `roles/container.defaultNodeServiceAccount` role. Unfortunately this is not yet documented in Google docs.

As the scope of the new role is smaller than the old one, this should be considered breaking change.