### PR TITLE
fix(firewal-rules): add possibility to configure unique fw names within project

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Then perform the following commands on the root folder:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | add\_cluster\_firewall\_rules | Create additional firewall rules | `bool` | `false` | no |
+| add\_firewall\_rule\_name\_unique\_suffix | Create additional firewall rule unique suffix | `bool` | `false` | no |
 | add\_master\_webhook\_firewall\_rules | Create master\_webhook firewall rules for ports defined in `firewall_inbound_ports` | `bool` | `false` | no |
 | add\_shadow\_firewall\_rules | Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled). | `bool` | `false` | no |
 | additional\_ip\_range\_pods | List of _names_ of the additional secondary subnet ip ranges to use for pods | `list(string)` | `[]` | no |

--- a/autogen/main/firewall.tf.tmpl
+++ b/autogen/main/firewall.tf.tmpl
@@ -24,9 +24,25 @@
   Required for clusters when VPCs enforce
   a default-deny egress rule
  *****************************************/
+locals {
+  rule_name_base = (
+    var.add_firewall_rule_name_unique_suffix ?
+    "${substr(var.name, 0, min(31, length(var.name)))}-${random_string.google_compute_firewall_suffix[0].result}" :
+    substr(var.name, 0, min(36, length(var.name)))
+  )
+}
+
+resource "random_string" "google_compute_firewall_suffix" {
+  count   = var.add_firewall_rule_name_unique_suffix ? 1 : 0
+  upper   = false
+  lower   = true
+  special = false
+  length  = 4
+}
+
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${local.rule_name_base}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -105,7 +121,7 @@ resource "google_compute_firewall" "tpu_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
+  name        = "gke-${local.rule_name_base}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -137,7 +153,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
+  name        = "gke-shadow-${local.rule_name_base}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -166,7 +182,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
+  name        = "gke-shadow-${local.rule_name_base}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -192,7 +208,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
+  name        = "gke-shadow-${local.rule_name_base}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -227,7 +243,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -254,7 +270,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -510,6 +510,12 @@ variable "add_master_webhook_firewall_rules" {
   default     = false
 }
 
+variable "add_firewall_rule_name_unique_suffix" {
+  type        = bool
+  description = "Create additional firewall rule unique suffix"
+  default     = false
+}
+
 variable "firewall_priority" {
   type        = number
   description = "Priority rule for firewall rules"

--- a/firewall.tf
+++ b/firewall.tf
@@ -24,9 +24,25 @@
   Required for clusters when VPCs enforce
   a default-deny egress rule
  *****************************************/
+locals {
+  rule_name_base = (
+    var.add_firewall_rule_name_unique_suffix ?
+    "${substr(var.name, 0, min(31, length(var.name)))}-${random_string.google_compute_firewall_suffix[0].result}" :
+    substr(var.name, 0, min(36, length(var.name)))
+  )
+}
+
+resource "random_string" "google_compute_firewall_suffix" {
+  count   = var.add_firewall_rule_name_unique_suffix ? 1 : 0
+  upper   = false
+  lower   = true
+  special = false
+  length  = 4
+}
+
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${local.rule_name_base}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -63,7 +79,7 @@ resource "google_compute_firewall" "intra_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
+  name        = "gke-${local.rule_name_base}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -93,7 +109,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
+  name        = "gke-shadow-${local.rule_name_base}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -122,7 +138,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
+  name        = "gke-shadow-${local.rule_name_base}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -148,7 +164,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
+  name        = "gke-shadow-${local.rule_name_base}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -183,7 +199,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -210,7 +226,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -72,6 +72,7 @@ Then perform the following commands on the root folder:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | add\_cluster\_firewall\_rules | Create additional firewall rules | `bool` | `false` | no |
+| add\_firewall\_rule\_name\_unique\_suffix | Create additional firewall rule unique suffix | `bool` | `false` | no |
 | add\_master\_webhook\_firewall\_rules | Create master\_webhook firewall rules for ports defined in `firewall_inbound_ports` | `bool` | `false` | no |
 | add\_shadow\_firewall\_rules | Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled). | `bool` | `false` | no |
 | additional\_ip\_range\_pods | List of _names_ of the additional secondary subnet ip ranges to use for pods | `list(string)` | `[]` | no |

--- a/modules/beta-autopilot-private-cluster/firewall.tf
+++ b/modules/beta-autopilot-private-cluster/firewall.tf
@@ -24,9 +24,25 @@
   Required for clusters when VPCs enforce
   a default-deny egress rule
  *****************************************/
+locals {
+  rule_name_base = (
+    var.add_firewall_rule_name_unique_suffix ?
+    "${substr(var.name, 0, min(31, length(var.name)))}-${random_string.google_compute_firewall_suffix[0].result}" :
+    substr(var.name, 0, min(36, length(var.name)))
+  )
+}
+
+resource "random_string" "google_compute_firewall_suffix" {
+  count   = var.add_firewall_rule_name_unique_suffix ? 1 : 0
+  upper   = false
+  lower   = true
+  special = false
+  length  = 4
+}
+
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${local.rule_name_base}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -93,7 +109,7 @@ resource "google_compute_firewall" "tpu_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
+  name        = "gke-${local.rule_name_base}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -120,7 +136,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
+  name        = "gke-shadow-${local.rule_name_base}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -149,7 +165,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
+  name        = "gke-shadow-${local.rule_name_base}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -175,7 +191,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
+  name        = "gke-shadow-${local.rule_name_base}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -210,7 +226,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -237,7 +253,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -336,6 +336,12 @@ variable "add_master_webhook_firewall_rules" {
   default     = false
 }
 
+variable "add_firewall_rule_name_unique_suffix" {
+  type        = bool
+  description = "Create additional firewall rule unique suffix"
+  default     = false
+}
+
 variable "firewall_priority" {
   type        = number
   description = "Priority rule for firewall rules"

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -66,6 +66,7 @@ Then perform the following commands on the root folder:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | add\_cluster\_firewall\_rules | Create additional firewall rules | `bool` | `false` | no |
+| add\_firewall\_rule\_name\_unique\_suffix | Create additional firewall rule unique suffix | `bool` | `false` | no |
 | add\_master\_webhook\_firewall\_rules | Create master\_webhook firewall rules for ports defined in `firewall_inbound_ports` | `bool` | `false` | no |
 | add\_shadow\_firewall\_rules | Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled). | `bool` | `false` | no |
 | additional\_ip\_range\_pods | List of _names_ of the additional secondary subnet ip ranges to use for pods | `list(string)` | `[]` | no |

--- a/modules/beta-autopilot-public-cluster/firewall.tf
+++ b/modules/beta-autopilot-public-cluster/firewall.tf
@@ -24,9 +24,25 @@
   Required for clusters when VPCs enforce
   a default-deny egress rule
  *****************************************/
+locals {
+  rule_name_base = (
+    var.add_firewall_rule_name_unique_suffix ?
+    "${substr(var.name, 0, min(31, length(var.name)))}-${random_string.google_compute_firewall_suffix[0].result}" :
+    substr(var.name, 0, min(36, length(var.name)))
+  )
+}
+
+resource "random_string" "google_compute_firewall_suffix" {
+  count   = var.add_firewall_rule_name_unique_suffix ? 1 : 0
+  upper   = false
+  lower   = true
+  special = false
+  length  = 4
+}
+
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${local.rule_name_base}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -99,7 +115,7 @@ resource "google_compute_firewall" "tpu_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
+  name        = "gke-${local.rule_name_base}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -129,7 +145,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
+  name        = "gke-shadow-${local.rule_name_base}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -158,7 +174,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
+  name        = "gke-shadow-${local.rule_name_base}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -184,7 +200,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
+  name        = "gke-shadow-${local.rule_name_base}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -219,7 +235,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -246,7 +262,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -306,6 +306,12 @@ variable "add_master_webhook_firewall_rules" {
   default     = false
 }
 
+variable "add_firewall_rule_name_unique_suffix" {
+  type        = bool
+  description = "Create additional firewall rule unique suffix"
+  default     = false
+}
+
 variable "firewall_priority" {
   type        = number
   description = "Priority rule for firewall rules"

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -165,6 +165,7 @@ Then perform the following commands on the root folder:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | add\_cluster\_firewall\_rules | Create additional firewall rules | `bool` | `false` | no |
+| add\_firewall\_rule\_name\_unique\_suffix | Create additional firewall rule unique suffix | `bool` | `false` | no |
 | add\_master\_webhook\_firewall\_rules | Create master\_webhook firewall rules for ports defined in `firewall_inbound_ports` | `bool` | `false` | no |
 | add\_shadow\_firewall\_rules | Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled). | `bool` | `false` | no |
 | additional\_ip\_range\_pods | List of _names_ of the additional secondary subnet ip ranges to use for pods | `list(string)` | `[]` | no |

--- a/modules/beta-private-cluster-update-variant/firewall.tf
+++ b/modules/beta-private-cluster-update-variant/firewall.tf
@@ -24,9 +24,25 @@
   Required for clusters when VPCs enforce
   a default-deny egress rule
  *****************************************/
+locals {
+  rule_name_base = (
+    var.add_firewall_rule_name_unique_suffix ?
+    "${substr(var.name, 0, min(31, length(var.name)))}-${random_string.google_compute_firewall_suffix[0].result}" :
+    substr(var.name, 0, min(36, length(var.name)))
+  )
+}
+
+resource "random_string" "google_compute_firewall_suffix" {
+  count   = var.add_firewall_rule_name_unique_suffix ? 1 : 0
+  upper   = false
+  lower   = true
+  special = false
+  length  = 4
+}
+
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${local.rule_name_base}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -93,7 +109,7 @@ resource "google_compute_firewall" "tpu_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
+  name        = "gke-${local.rule_name_base}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -120,7 +136,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
+  name        = "gke-shadow-${local.rule_name_base}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -149,7 +165,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
+  name        = "gke-shadow-${local.rule_name_base}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -175,7 +191,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
+  name        = "gke-shadow-${local.rule_name_base}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -210,7 +226,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -237,7 +253,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -481,6 +481,12 @@ variable "add_master_webhook_firewall_rules" {
   default     = false
 }
 
+variable "add_firewall_rule_name_unique_suffix" {
+  type        = bool
+  description = "Create additional firewall rule unique suffix"
+  default     = false
+}
+
 variable "firewall_priority" {
   type        = number
   description = "Priority rule for firewall rules"

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -143,6 +143,7 @@ Then perform the following commands on the root folder:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | add\_cluster\_firewall\_rules | Create additional firewall rules | `bool` | `false` | no |
+| add\_firewall\_rule\_name\_unique\_suffix | Create additional firewall rule unique suffix | `bool` | `false` | no |
 | add\_master\_webhook\_firewall\_rules | Create master\_webhook firewall rules for ports defined in `firewall_inbound_ports` | `bool` | `false` | no |
 | add\_shadow\_firewall\_rules | Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled). | `bool` | `false` | no |
 | additional\_ip\_range\_pods | List of _names_ of the additional secondary subnet ip ranges to use for pods | `list(string)` | `[]` | no |

--- a/modules/beta-private-cluster/firewall.tf
+++ b/modules/beta-private-cluster/firewall.tf
@@ -24,9 +24,25 @@
   Required for clusters when VPCs enforce
   a default-deny egress rule
  *****************************************/
+locals {
+  rule_name_base = (
+    var.add_firewall_rule_name_unique_suffix ?
+    "${substr(var.name, 0, min(31, length(var.name)))}-${random_string.google_compute_firewall_suffix[0].result}" :
+    substr(var.name, 0, min(36, length(var.name)))
+  )
+}
+
+resource "random_string" "google_compute_firewall_suffix" {
+  count   = var.add_firewall_rule_name_unique_suffix ? 1 : 0
+  upper   = false
+  lower   = true
+  special = false
+  length  = 4
+}
+
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${local.rule_name_base}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -93,7 +109,7 @@ resource "google_compute_firewall" "tpu_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
+  name        = "gke-${local.rule_name_base}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -120,7 +136,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
+  name        = "gke-shadow-${local.rule_name_base}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -149,7 +165,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
+  name        = "gke-shadow-${local.rule_name_base}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -175,7 +191,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
+  name        = "gke-shadow-${local.rule_name_base}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -210,7 +226,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -237,7 +253,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -481,6 +481,12 @@ variable "add_master_webhook_firewall_rules" {
   default     = false
 }
 
+variable "add_firewall_rule_name_unique_suffix" {
+  type        = bool
+  description = "Create additional firewall rule unique suffix"
+  default     = false
+}
+
 variable "firewall_priority" {
   type        = number
   description = "Priority rule for firewall rules"

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -159,6 +159,7 @@ Then perform the following commands on the root folder:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | add\_cluster\_firewall\_rules | Create additional firewall rules | `bool` | `false` | no |
+| add\_firewall\_rule\_name\_unique\_suffix | Create additional firewall rule unique suffix | `bool` | `false` | no |
 | add\_master\_webhook\_firewall\_rules | Create master\_webhook firewall rules for ports defined in `firewall_inbound_ports` | `bool` | `false` | no |
 | add\_shadow\_firewall\_rules | Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled). | `bool` | `false` | no |
 | additional\_ip\_range\_pods | List of _names_ of the additional secondary subnet ip ranges to use for pods | `list(string)` | `[]` | no |

--- a/modules/beta-public-cluster-update-variant/firewall.tf
+++ b/modules/beta-public-cluster-update-variant/firewall.tf
@@ -24,9 +24,25 @@
   Required for clusters when VPCs enforce
   a default-deny egress rule
  *****************************************/
+locals {
+  rule_name_base = (
+    var.add_firewall_rule_name_unique_suffix ?
+    "${substr(var.name, 0, min(31, length(var.name)))}-${random_string.google_compute_firewall_suffix[0].result}" :
+    substr(var.name, 0, min(36, length(var.name)))
+  )
+}
+
+resource "random_string" "google_compute_firewall_suffix" {
+  count   = var.add_firewall_rule_name_unique_suffix ? 1 : 0
+  upper   = false
+  lower   = true
+  special = false
+  length  = 4
+}
+
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${local.rule_name_base}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -99,7 +115,7 @@ resource "google_compute_firewall" "tpu_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
+  name        = "gke-${local.rule_name_base}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -129,7 +145,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
+  name        = "gke-shadow-${local.rule_name_base}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -158,7 +174,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
+  name        = "gke-shadow-${local.rule_name_base}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -184,7 +200,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
+  name        = "gke-shadow-${local.rule_name_base}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -219,7 +235,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -246,7 +262,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -451,6 +451,12 @@ variable "add_master_webhook_firewall_rules" {
   default     = false
 }
 
+variable "add_firewall_rule_name_unique_suffix" {
+  type        = bool
+  description = "Create additional firewall rule unique suffix"
+  default     = false
+}
+
 variable "firewall_priority" {
   type        = number
   description = "Priority rule for firewall rules"

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -137,6 +137,7 @@ Then perform the following commands on the root folder:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | add\_cluster\_firewall\_rules | Create additional firewall rules | `bool` | `false` | no |
+| add\_firewall\_rule\_name\_unique\_suffix | Create additional firewall rule unique suffix | `bool` | `false` | no |
 | add\_master\_webhook\_firewall\_rules | Create master\_webhook firewall rules for ports defined in `firewall_inbound_ports` | `bool` | `false` | no |
 | add\_shadow\_firewall\_rules | Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled). | `bool` | `false` | no |
 | additional\_ip\_range\_pods | List of _names_ of the additional secondary subnet ip ranges to use for pods | `list(string)` | `[]` | no |

--- a/modules/beta-public-cluster/firewall.tf
+++ b/modules/beta-public-cluster/firewall.tf
@@ -24,9 +24,25 @@
   Required for clusters when VPCs enforce
   a default-deny egress rule
  *****************************************/
+locals {
+  rule_name_base = (
+    var.add_firewall_rule_name_unique_suffix ?
+    "${substr(var.name, 0, min(31, length(var.name)))}-${random_string.google_compute_firewall_suffix[0].result}" :
+    substr(var.name, 0, min(36, length(var.name)))
+  )
+}
+
+resource "random_string" "google_compute_firewall_suffix" {
+  count   = var.add_firewall_rule_name_unique_suffix ? 1 : 0
+  upper   = false
+  lower   = true
+  special = false
+  length  = 4
+}
+
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${local.rule_name_base}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -99,7 +115,7 @@ resource "google_compute_firewall" "tpu_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
+  name        = "gke-${local.rule_name_base}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -129,7 +145,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
+  name        = "gke-shadow-${local.rule_name_base}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -158,7 +174,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
+  name        = "gke-shadow-${local.rule_name_base}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -184,7 +200,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
+  name        = "gke-shadow-${local.rule_name_base}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -219,7 +235,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -246,7 +262,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -451,6 +451,12 @@ variable "add_master_webhook_firewall_rules" {
   default     = false
 }
 
+variable "add_firewall_rule_name_unique_suffix" {
+  type        = bool
+  description = "Create additional firewall rule unique suffix"
+  default     = false
+}
+
 variable "firewall_priority" {
   type        = number
   description = "Priority rule for firewall rules"

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -161,6 +161,7 @@ Then perform the following commands on the root folder:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | add\_cluster\_firewall\_rules | Create additional firewall rules | `bool` | `false` | no |
+| add\_firewall\_rule\_name\_unique\_suffix | Create additional firewall rule unique suffix | `bool` | `false` | no |
 | add\_master\_webhook\_firewall\_rules | Create master\_webhook firewall rules for ports defined in `firewall_inbound_ports` | `bool` | `false` | no |
 | add\_shadow\_firewall\_rules | Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled). | `bool` | `false` | no |
 | additional\_ip\_range\_pods | List of _names_ of the additional secondary subnet ip ranges to use for pods | `list(string)` | `[]` | no |

--- a/modules/private-cluster-update-variant/firewall.tf
+++ b/modules/private-cluster-update-variant/firewall.tf
@@ -24,9 +24,25 @@
   Required for clusters when VPCs enforce
   a default-deny egress rule
  *****************************************/
+locals {
+  rule_name_base = (
+    var.add_firewall_rule_name_unique_suffix ?
+    "${substr(var.name, 0, min(31, length(var.name)))}-${random_string.google_compute_firewall_suffix[0].result}" :
+    substr(var.name, 0, min(36, length(var.name)))
+  )
+}
+
+resource "random_string" "google_compute_firewall_suffix" {
+  count   = var.add_firewall_rule_name_unique_suffix ? 1 : 0
+  upper   = false
+  lower   = true
+  special = false
+  length  = 4
+}
+
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${local.rule_name_base}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -60,7 +76,7 @@ resource "google_compute_firewall" "intra_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
+  name        = "gke-${local.rule_name_base}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -87,7 +103,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
+  name        = "gke-shadow-${local.rule_name_base}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -116,7 +132,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
+  name        = "gke-shadow-${local.rule_name_base}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -142,7 +158,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
+  name        = "gke-shadow-${local.rule_name_base}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -177,7 +193,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -204,7 +220,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -473,6 +473,12 @@ variable "add_master_webhook_firewall_rules" {
   default     = false
 }
 
+variable "add_firewall_rule_name_unique_suffix" {
+  type        = bool
+  description = "Create additional firewall rule unique suffix"
+  default     = false
+}
+
 variable "firewall_priority" {
   type        = number
   description = "Priority rule for firewall rules"

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -139,6 +139,7 @@ Then perform the following commands on the root folder:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | add\_cluster\_firewall\_rules | Create additional firewall rules | `bool` | `false` | no |
+| add\_firewall\_rule\_name\_unique\_suffix | Create additional firewall rule unique suffix | `bool` | `false` | no |
 | add\_master\_webhook\_firewall\_rules | Create master\_webhook firewall rules for ports defined in `firewall_inbound_ports` | `bool` | `false` | no |
 | add\_shadow\_firewall\_rules | Create GKE shadow firewall (the same as default firewall rules with firewall logs enabled). | `bool` | `false` | no |
 | additional\_ip\_range\_pods | List of _names_ of the additional secondary subnet ip ranges to use for pods | `list(string)` | `[]` | no |

--- a/modules/private-cluster/firewall.tf
+++ b/modules/private-cluster/firewall.tf
@@ -24,9 +24,25 @@
   Required for clusters when VPCs enforce
   a default-deny egress rule
  *****************************************/
+locals {
+  rule_name_base = (
+    var.add_firewall_rule_name_unique_suffix ?
+    "${substr(var.name, 0, min(31, length(var.name)))}-${random_string.google_compute_firewall_suffix[0].result}" :
+    substr(var.name, 0, min(36, length(var.name)))
+  )
+}
+
+resource "random_string" "google_compute_firewall_suffix" {
+  count   = var.add_firewall_rule_name_unique_suffix ? 1 : 0
+  upper   = false
+  lower   = true
+  special = false
+  length  = 4
+}
+
 resource "google_compute_firewall" "intra_egress" {
   count       = var.add_cluster_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-intra-cluster-egress"
+  name        = "gke-${local.rule_name_base}-intra-cluster-egress"
   description = "Managed by terraform gke module: Allow pods to communicate with each other and the master"
   project     = local.network_project_id
   network     = var.network
@@ -60,7 +76,7 @@ resource "google_compute_firewall" "intra_egress" {
  *****************************************/
 resource "google_compute_firewall" "master_webhooks" {
   count       = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules ? 1 : 0
-  name        = "gke-${substr(var.name, 0, min(36, length(var.name)))}-webhooks"
+  name        = "gke-${local.rule_name_base}-webhooks"
   description = "Managed by terraform gke module: Allow master to hit pods for admission controllers/webhooks"
   project     = local.network_project_id
   network     = var.network
@@ -87,7 +103,7 @@ resource "google_compute_firewall" "master_webhooks" {
 resource "google_compute_firewall" "shadow_allow_pods" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-all"
+  name        = "gke-shadow-${local.rule_name_base}-all"
   description = "Managed by terraform gke module: A shadow firewall rule to match the default rule allowing pod communication."
   project     = local.network_project_id
   network     = var.network
@@ -116,7 +132,7 @@ resource "google_compute_firewall" "shadow_allow_pods" {
 resource "google_compute_firewall" "shadow_allow_master" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-master"
+  name        = "gke-shadow-${local.rule_name_base}-master"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -142,7 +158,7 @@ resource "google_compute_firewall" "shadow_allow_master" {
 resource "google_compute_firewall" "shadow_allow_nodes" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-vms"
+  name        = "gke-shadow-${local.rule_name_base}-vms"
   description = "Managed by Terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes communication."
   project     = local.network_project_id
   network     = var.network
@@ -177,7 +193,7 @@ resource "google_compute_firewall" "shadow_allow_nodes" {
 resource "google_compute_firewall" "shadow_allow_inkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-inkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-inkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default rule allowing worker nodes & pods communication to kubelet."
   project     = local.network_project_id
   network     = var.network
@@ -204,7 +220,7 @@ resource "google_compute_firewall" "shadow_allow_inkubelet" {
 resource "google_compute_firewall" "shadow_deny_exkubelet" {
   count = var.add_shadow_firewall_rules ? 1 : 0
 
-  name        = "gke-shadow-${substr(var.name, 0, min(36, length(var.name)))}-exkubelet"
+  name        = "gke-shadow-${local.rule_name_base}-exkubelet"
   description = "Managed by terraform GKE module: A shadow firewall rule to match the default deny rule to kubelet."
   project     = local.network_project_id
   network     = var.network

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -473,6 +473,12 @@ variable "add_master_webhook_firewall_rules" {
   default     = false
 }
 
+variable "add_firewall_rule_name_unique_suffix" {
+  type        = bool
+  description = "Create additional firewall rule unique suffix"
+  default     = false
+}
+
 variable "firewall_priority" {
   type        = number
   description = "Priority rule for firewall rules"

--- a/variables.tf
+++ b/variables.tf
@@ -443,6 +443,12 @@ variable "add_master_webhook_firewall_rules" {
   default     = false
 }
 
+variable "add_firewall_rule_name_unique_suffix" {
+  type        = bool
+  description = "Create additional firewall rule unique suffix"
+  default     = false
+}
+
 variable "firewall_priority" {
   type        = number
   description = "Priority rule for firewall rules"


### PR DESCRIPTION
When creating multiple private clusters within same project with the same name (in different regions) - module tries to create non-unique global firewall rules (fw rule name is based on cluster name). This PR is making it possible to generate unique fw names for multiple such clusters within the project in non breaking fashion.