### PR TITLE
Allow to define the default bootdisk key

### DIFF
--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -73,10 +73,11 @@ resource "google_container_cluster" "primary" {
 
   cluster_autoscaling {
     dynamic "auto_provisioning_defaults" {
-      for_each = (var.create_service_account || var.service_account != "") ? [1] : []
+      for_each = (var.create_service_account || var.service_account != "" || var.auto_provisioning_defaults_boot_disk_kms_key  != null ) ? [1] : []
 
       content {
-        service_account = local.service_account
+        service_account   = local.service_account
+        boot_disk_kms_key = var.auto_provisioning_defaults_boot_disk_kms_key
       }
     }
   }

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -443,6 +443,11 @@ variable "database_encryption" {
   }]
 }
 
+variable "auto_provisioning_defaults_boot_disk_kms_key" {
+  description = "The default key for boot_disks when creating new nodes. This is the key_name of a CloudKMS key."
+  type        = string
+  default     = ""
+}
 
 variable "timeouts" {
   type        = map(string)


### PR DESCRIPTION
In environments where disks are encrypted by a customer provided key the autopilot setting needs to set
the defaults of the boot-disk encryption. Allow to provide this setting.