### PR TITLE
feat: enable_private_nodes on nodepool lvl withour pod_range

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -724,7 +724,7 @@ resource "google_container_node_pool" "windows_pools" {
   }
 
   dynamic "network_config" {
-    for_each = length(lookup(each.value, "pod_range", "")) > 0  ? [each.value] : []
+    for_each = length(lookup(each.value, "pod_range", "")) + length(lookup(each.value, "enable_private_nodes", "")) > 0 ? [each.value] : []
     content {
       pod_range            = lookup(network_config.value, "pod_range", null)
       {% if private_cluster %}

--- a/cluster.tf
+++ b/cluster.tf
@@ -458,7 +458,7 @@ resource "google_container_node_pool" "pools" {
   }
 
   dynamic "network_config" {
-    for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
+    for_each = length(lookup(each.value, "pod_range", "")) + length(lookup(each.value, "enable_private_nodes", "")) > 0 ? [each.value] : []
     content {
       pod_range            = lookup(network_config.value, "pod_range", null)
       enable_private_nodes = lookup(network_config.value, "enable_private_nodes", null)
@@ -667,7 +667,7 @@ resource "google_container_node_pool" "windows_pools" {
   }
 
   dynamic "network_config" {
-    for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
+    for_each = length(lookup(each.value, "pod_range", "")) + length(lookup(each.value, "enable_private_nodes", "")) > 0 ? [each.value] : []
     content {
       pod_range            = lookup(network_config.value, "pod_range", null)
       enable_private_nodes = lookup(network_config.value, "enable_private_nodes", null)

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -618,7 +618,7 @@ resource "google_container_node_pool" "pools" {
   }
 
   dynamic "network_config" {
-    for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
+    for_each = length(lookup(each.value, "pod_range", "")) + length(lookup(each.value, "enable_private_nodes", "")) > 0 ? [each.value] : []
     content {
       pod_range            = lookup(network_config.value, "pod_range", null)
       enable_private_nodes = var.enable_private_nodes
@@ -853,7 +853,7 @@ resource "google_container_node_pool" "windows_pools" {
   }
 
   dynamic "network_config" {
-    for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
+    for_each = length(lookup(each.value, "pod_range", "")) + length(lookup(each.value, "enable_private_nodes", "")) > 0 ? [each.value] : []
     content {
       pod_range            = lookup(network_config.value, "pod_range", null)
       enable_private_nodes = var.enable_private_nodes

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -543,7 +543,7 @@ resource "google_container_node_pool" "pools" {
   }
 
   dynamic "network_config" {
-    for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
+    for_each = length(lookup(each.value, "pod_range", "")) + length(lookup(each.value, "enable_private_nodes", "")) > 0 ? [each.value] : []
     content {
       pod_range            = lookup(network_config.value, "pod_range", null)
       enable_private_nodes = var.enable_private_nodes
@@ -777,7 +777,7 @@ resource "google_container_node_pool" "windows_pools" {
   }
 
   dynamic "network_config" {
-    for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
+    for_each = length(lookup(each.value, "pod_range", "")) + length(lookup(each.value, "enable_private_nodes", "")) > 0 ? [each.value] : []
     content {
       pod_range            = lookup(network_config.value, "pod_range", null)
       enable_private_nodes = var.enable_private_nodes

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -599,7 +599,7 @@ resource "google_container_node_pool" "pools" {
   }
 
   dynamic "network_config" {
-    for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
+    for_each = length(lookup(each.value, "pod_range", "")) + length(lookup(each.value, "enable_private_nodes", "")) > 0 ? [each.value] : []
     content {
       pod_range            = lookup(network_config.value, "pod_range", null)
       enable_private_nodes = lookup(network_config.value, "enable_private_nodes", null)
@@ -834,7 +834,7 @@ resource "google_container_node_pool" "windows_pools" {
   }
 
   dynamic "network_config" {
-    for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
+    for_each = length(lookup(each.value, "pod_range", "")) + length(lookup(each.value, "enable_private_nodes", "")) > 0 ? [each.value] : []
     content {
       pod_range            = lookup(network_config.value, "pod_range", null)
       enable_private_nodes = lookup(network_config.value, "enable_private_nodes", null)

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -524,7 +524,7 @@ resource "google_container_node_pool" "pools" {
   }
 
   dynamic "network_config" {
-    for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
+    for_each = length(lookup(each.value, "pod_range", "")) + length(lookup(each.value, "enable_private_nodes", "")) > 0 ? [each.value] : []
     content {
       pod_range            = lookup(network_config.value, "pod_range", null)
       enable_private_nodes = lookup(network_config.value, "enable_private_nodes", null)
@@ -758,7 +758,7 @@ resource "google_container_node_pool" "windows_pools" {
   }
 
   dynamic "network_config" {
-    for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
+    for_each = length(lookup(each.value, "pod_range", "")) + length(lookup(each.value, "enable_private_nodes", "")) > 0 ? [each.value] : []
     content {
       pod_range            = lookup(network_config.value, "pod_range", null)
       enable_private_nodes = lookup(network_config.value, "enable_private_nodes", null)

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -552,7 +552,7 @@ resource "google_container_node_pool" "pools" {
   }
 
   dynamic "network_config" {
-    for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
+    for_each = length(lookup(each.value, "pod_range", "")) + length(lookup(each.value, "enable_private_nodes", "")) > 0 ? [each.value] : []
     content {
       pod_range            = lookup(network_config.value, "pod_range", null)
       enable_private_nodes = var.enable_private_nodes
@@ -762,7 +762,7 @@ resource "google_container_node_pool" "windows_pools" {
   }
 
   dynamic "network_config" {
-    for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
+    for_each = length(lookup(each.value, "pod_range", "")) + length(lookup(each.value, "enable_private_nodes", "")) > 0 ? [each.value] : []
     content {
       pod_range            = lookup(network_config.value, "pod_range", null)
       enable_private_nodes = var.enable_private_nodes

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -477,7 +477,7 @@ resource "google_container_node_pool" "pools" {
   }
 
   dynamic "network_config" {
-    for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
+    for_each = length(lookup(each.value, "pod_range", "")) + length(lookup(each.value, "enable_private_nodes", "")) > 0 ? [each.value] : []
     content {
       pod_range            = lookup(network_config.value, "pod_range", null)
       enable_private_nodes = var.enable_private_nodes
@@ -686,7 +686,7 @@ resource "google_container_node_pool" "windows_pools" {
   }
 
   dynamic "network_config" {
-    for_each = length(lookup(each.value, "pod_range", "")) > 0 ? [each.value] : []
+    for_each = length(lookup(each.value, "pod_range", "")) + length(lookup(each.value, "enable_private_nodes", "")) > 0 ? [each.value] : []
     content {
       pod_range            = lookup(network_config.value, "pod_range", null)
       enable_private_nodes = var.enable_private_nodes


### PR DESCRIPTION
I would like to add possibility to set enable_private_nodes on nodepool lvl without the need to define a pod_range. 