### PR TITLE
feat: add enable_relay to datapathv2 observability config

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Then perform the following commands on the root folder:
 | master\_authorized\_networks | List of master authorized networks. If none are provided, disallow external access (except the cluster node IPs, which GKE automatically whitelists). | `list(object({ cidr_block = string, display_name = string }))` | `[]` | no |
 | monitoring\_enable\_managed\_prometheus | Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled. | `bool` | `false` | no |
 | monitoring\_enable\_observability\_metrics | Whether or not the advanced datapath metrics are enabled. | `bool` | `false` | no |
+| monitoring\_enable\_observability\_relay | Whether or not the advanced datapath observability relay is enabled. | `bool` | `false` | no |
 | monitoring\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, WORKLOADS (provider version >= 3.89.0). Empty list is default GKE configuration. | `list(string)` | `[]` | no |
 | monitoring\_observability\_metrics\_relay\_mode | Mode used to make advanced datapath metrics relay available. | `string` | `null` | no |
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -126,6 +126,7 @@ resource "google_container_cluster" "primary" {
       }
       advanced_datapath_observability_config {
         enable_metrics = var.monitoring_enable_observability_metrics
+        enable_relay   = var.monitoring_enable_observability_relay
         relay_mode     = var.monitoring_observability_metrics_relay_mode
       }
     }

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -746,6 +746,12 @@ variable "monitoring_enable_observability_metrics" {
   default     = false
 }
 
+variable "monitoring_enable_observability_relay" {
+  type        = bool
+  description = "Whether or not the advanced datapath observability relay is enabled."
+  default     = false
+}
+
 variable "monitoring_observability_metrics_relay_mode" {
   type        = string
   description = "Mode used to make advanced datapath metrics relay available."

--- a/cluster.tf
+++ b/cluster.tf
@@ -99,6 +99,7 @@ resource "google_container_cluster" "primary" {
       }
       advanced_datapath_observability_config {
         enable_metrics = var.monitoring_enable_observability_metrics
+        enable_relay   = var.monitoring_enable_observability_relay
         relay_mode     = var.monitoring_observability_metrics_relay_mode
       }
     }

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -241,6 +241,7 @@ Then perform the following commands on the root folder:
 | master\_ipv4\_cidr\_block | (Beta) The IP range in CIDR notation to use for the hosted master network | `string` | `"10.0.0.0/28"` | no |
 | monitoring\_enable\_managed\_prometheus | Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled. | `bool` | `false` | no |
 | monitoring\_enable\_observability\_metrics | Whether or not the advanced datapath metrics are enabled. | `bool` | `false` | no |
+| monitoring\_enable\_observability\_relay | Whether or not the advanced datapath observability relay is enabled. | `bool` | `false` | no |
 | monitoring\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, WORKLOADS (provider version >= 3.89.0). Empty list is default GKE configuration. | `list(string)` | `[]` | no |
 | monitoring\_observability\_metrics\_relay\_mode | Mode used to make advanced datapath metrics relay available. | `string` | `null` | no |
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -105,6 +105,7 @@ resource "google_container_cluster" "primary" {
       }
       advanced_datapath_observability_config {
         enable_metrics = var.monitoring_enable_observability_metrics
+        enable_relay   = var.monitoring_enable_observability_relay
         relay_mode     = var.monitoring_observability_metrics_relay_mode
       }
     }

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -712,6 +712,12 @@ variable "monitoring_enable_observability_metrics" {
   default     = false
 }
 
+variable "monitoring_enable_observability_relay" {
+  type        = bool
+  description = "Whether or not the advanced datapath observability relay is enabled."
+  default     = false
+}
+
 variable "monitoring_observability_metrics_relay_mode" {
   type        = string
   description = "Mode used to make advanced datapath metrics relay available."

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -219,6 +219,7 @@ Then perform the following commands on the root folder:
 | master\_ipv4\_cidr\_block | (Beta) The IP range in CIDR notation to use for the hosted master network | `string` | `"10.0.0.0/28"` | no |
 | monitoring\_enable\_managed\_prometheus | Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled. | `bool` | `false` | no |
 | monitoring\_enable\_observability\_metrics | Whether or not the advanced datapath metrics are enabled. | `bool` | `false` | no |
+| monitoring\_enable\_observability\_relay | Whether or not the advanced datapath observability relay is enabled. | `bool` | `false` | no |
 | monitoring\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, WORKLOADS (provider version >= 3.89.0). Empty list is default GKE configuration. | `list(string)` | `[]` | no |
 | monitoring\_observability\_metrics\_relay\_mode | Mode used to make advanced datapath metrics relay available. | `string` | `null` | no |
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -105,6 +105,7 @@ resource "google_container_cluster" "primary" {
       }
       advanced_datapath_observability_config {
         enable_metrics = var.monitoring_enable_observability_metrics
+        enable_relay   = var.monitoring_enable_observability_relay
         relay_mode     = var.monitoring_observability_metrics_relay_mode
       }
     }

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -712,6 +712,12 @@ variable "monitoring_enable_observability_metrics" {
   default     = false
 }
 
+variable "monitoring_enable_observability_relay" {
+  type        = bool
+  description = "Whether or not the advanced datapath observability relay is enabled."
+  default     = false
+}
+
 variable "monitoring_observability_metrics_relay_mode" {
   type        = string
   description = "Mode used to make advanced datapath metrics relay available."

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -230,6 +230,7 @@ Then perform the following commands on the root folder:
 | master\_authorized\_networks | List of master authorized networks. If none are provided, disallow external access (except the cluster node IPs, which GKE automatically whitelists). | `list(object({ cidr_block = string, display_name = string }))` | `[]` | no |
 | monitoring\_enable\_managed\_prometheus | Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled. | `bool` | `false` | no |
 | monitoring\_enable\_observability\_metrics | Whether or not the advanced datapath metrics are enabled. | `bool` | `false` | no |
+| monitoring\_enable\_observability\_relay | Whether or not the advanced datapath observability relay is enabled. | `bool` | `false` | no |
 | monitoring\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, WORKLOADS (provider version >= 3.89.0). Empty list is default GKE configuration. | `list(string)` | `[]` | no |
 | monitoring\_observability\_metrics\_relay\_mode | Mode used to make advanced datapath metrics relay available. | `string` | `null` | no |
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -105,6 +105,7 @@ resource "google_container_cluster" "primary" {
       }
       advanced_datapath_observability_config {
         enable_metrics = var.monitoring_enable_observability_metrics
+        enable_relay   = var.monitoring_enable_observability_relay
         relay_mode     = var.monitoring_observability_metrics_relay_mode
       }
     }

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -682,6 +682,12 @@ variable "monitoring_enable_observability_metrics" {
   default     = false
 }
 
+variable "monitoring_enable_observability_relay" {
+  type        = bool
+  description = "Whether or not the advanced datapath observability relay is enabled."
+  default     = false
+}
+
 variable "monitoring_observability_metrics_relay_mode" {
   type        = string
   description = "Mode used to make advanced datapath metrics relay available."

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -208,6 +208,7 @@ Then perform the following commands on the root folder:
 | master\_authorized\_networks | List of master authorized networks. If none are provided, disallow external access (except the cluster node IPs, which GKE automatically whitelists). | `list(object({ cidr_block = string, display_name = string }))` | `[]` | no |
 | monitoring\_enable\_managed\_prometheus | Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled. | `bool` | `false` | no |
 | monitoring\_enable\_observability\_metrics | Whether or not the advanced datapath metrics are enabled. | `bool` | `false` | no |
+| monitoring\_enable\_observability\_relay | Whether or not the advanced datapath observability relay is enabled. | `bool` | `false` | no |
 | monitoring\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, WORKLOADS (provider version >= 3.89.0). Empty list is default GKE configuration. | `list(string)` | `[]` | no |
 | monitoring\_observability\_metrics\_relay\_mode | Mode used to make advanced datapath metrics relay available. | `string` | `null` | no |
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -105,6 +105,7 @@ resource "google_container_cluster" "primary" {
       }
       advanced_datapath_observability_config {
         enable_metrics = var.monitoring_enable_observability_metrics
+        enable_relay   = var.monitoring_enable_observability_relay
         relay_mode     = var.monitoring_observability_metrics_relay_mode
       }
     }

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -682,6 +682,12 @@ variable "monitoring_enable_observability_metrics" {
   default     = false
 }
 
+variable "monitoring_enable_observability_relay" {
+  type        = bool
+  description = "Whether or not the advanced datapath observability relay is enabled."
+  default     = false
+}
+
 variable "monitoring_observability_metrics_relay_mode" {
   type        = string
   description = "Mode used to make advanced datapath metrics relay available."

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -225,6 +225,7 @@ Then perform the following commands on the root folder:
 | master\_ipv4\_cidr\_block | (Beta) The IP range in CIDR notation to use for the hosted master network | `string` | `"10.0.0.0/28"` | no |
 | monitoring\_enable\_managed\_prometheus | Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled. | `bool` | `false` | no |
 | monitoring\_enable\_observability\_metrics | Whether or not the advanced datapath metrics are enabled. | `bool` | `false` | no |
+| monitoring\_enable\_observability\_relay | Whether or not the advanced datapath observability relay is enabled. | `bool` | `false` | no |
 | monitoring\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, WORKLOADS (provider version >= 3.89.0). Empty list is default GKE configuration. | `list(string)` | `[]` | no |
 | monitoring\_observability\_metrics\_relay\_mode | Mode used to make advanced datapath metrics relay available. | `string` | `null` | no |
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -99,6 +99,7 @@ resource "google_container_cluster" "primary" {
       }
       advanced_datapath_observability_config {
         enable_metrics = var.monitoring_enable_observability_metrics
+        enable_relay   = var.monitoring_enable_observability_relay
         relay_mode     = var.monitoring_observability_metrics_relay_mode
       }
     }

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -688,6 +688,12 @@ variable "monitoring_enable_observability_metrics" {
   default     = false
 }
 
+variable "monitoring_enable_observability_relay" {
+  type        = bool
+  description = "Whether or not the advanced datapath observability relay is enabled."
+  default     = false
+}
+
 variable "monitoring_observability_metrics_relay_mode" {
   type        = string
   description = "Mode used to make advanced datapath metrics relay available."

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -203,6 +203,7 @@ Then perform the following commands on the root folder:
 | master\_ipv4\_cidr\_block | (Beta) The IP range in CIDR notation to use for the hosted master network | `string` | `"10.0.0.0/28"` | no |
 | monitoring\_enable\_managed\_prometheus | Configuration for Managed Service for Prometheus. Whether or not the managed collection is enabled. | `bool` | `false` | no |
 | monitoring\_enable\_observability\_metrics | Whether or not the advanced datapath metrics are enabled. | `bool` | `false` | no |
+| monitoring\_enable\_observability\_relay | Whether or not the advanced datapath observability relay is enabled. | `bool` | `false` | no |
 | monitoring\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, WORKLOADS (provider version >= 3.89.0). Empty list is default GKE configuration. | `list(string)` | `[]` | no |
 | monitoring\_observability\_metrics\_relay\_mode | Mode used to make advanced datapath metrics relay available. | `string` | `null` | no |
 | monitoring\_service | The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none | `string` | `"monitoring.googleapis.com/kubernetes"` | no |

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -99,6 +99,7 @@ resource "google_container_cluster" "primary" {
       }
       advanced_datapath_observability_config {
         enable_metrics = var.monitoring_enable_observability_metrics
+        enable_relay   = var.monitoring_enable_observability_relay
         relay_mode     = var.monitoring_observability_metrics_relay_mode
       }
     }

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -688,6 +688,12 @@ variable "monitoring_enable_observability_metrics" {
   default     = false
 }
 
+variable "monitoring_enable_observability_relay" {
+  type        = bool
+  description = "Whether or not the advanced datapath observability relay is enabled."
+  default     = false
+}
+
 variable "monitoring_observability_metrics_relay_mode" {
   type        = string
   description = "Mode used to make advanced datapath metrics relay available."

--- a/variables.tf
+++ b/variables.tf
@@ -658,6 +658,12 @@ variable "monitoring_enable_observability_metrics" {
   default     = false
 }
 
+variable "monitoring_enable_observability_relay" {
+  type        = bool
+  description = "Whether or not the advanced datapath observability relay is enabled."
+  default     = false
+}
+
 variable "monitoring_observability_metrics_relay_mode" {
   type        = string
   description = "Mode used to make advanced datapath metrics relay available."


### PR DESCRIPTION
Adds in the `enable_relay` option into `advanced_datapath_observability_config` https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#advanced_datapath_observability_config

Defaulted to false.