### PR TITLE
Enable external identity providers to authenticate to GKE

### DIFF
--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -243,6 +243,8 @@ Then perform the following commands on the root folder:
 | upstream\_nameservers | If specified, the values replace the nameservers taken by default from the node’s /etc/resolv.conf | `list(string)` | `[]` | no |
 | windows\_node\_pools | List of maps containing Windows node pools | `list(map(string))` | `[]` | no |
 | zones | The zones to host the cluster in (optional if regional cluster / required if zonal) | `list(string)` | `[]` | no |
+| enable_identity_service | Enable external identity providers to authenticate to GKE | `bool` | `false` | no |
+
 
 ## Outputs
 

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -160,12 +160,6 @@ resource "google_container_cluster" "primary" {
     }
   }
 
-  dynamic "identity_service_config" {
-    for_each = var.enable_identity_service ? [var.enable_identity_service] : []
-    content {
-      enabled = identity_service_config.value
-    }
-  }
   master_auth {
     client_certificate_config {
       issue_client_certificate = var.issue_client_certificate

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -160,6 +160,12 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  dynamic "identity_service_config" {
+    for_each = var.enable_identity_service ? [var.enable_identity_service] : []
+    content {
+      enabled = identity_service_config.value
+    }
+  }
   master_auth {
     client_certificate_config {
       issue_client_certificate = var.issue_client_certificate

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -727,8 +727,3 @@ variable "fleet_project" {
   type        = string
   default     = null
 }
-variable "enable_identity_service" {
-  type        = bool
-  description = "Enable the Identity Service component, which allows customers to use external identity providers with the K8S API."
-  default     = false
-}

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -727,3 +727,8 @@ variable "fleet_project" {
   type        = string
   default     = null
 }
+variable "enable_identity_service" {
+  type        = bool
+  description = "Enable the Identity Service component, which allows customers to use external identity providers with the K8S API."
+  default     = false
+}

--- a/modules/private-cluster/versions.tf
+++ b/modules/private-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.9.0, < 6"
+      version = ">= 5.21.0, < 6"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/private-cluster/versions.tf
+++ b/modules/private-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.21.0, < 6"
+      version = ">= 5.9.0, < 6"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
feat: added option for external identity providers to authenticate to GKE "enable_identity_service" and a new version of google provider for private-cluster module