### PR TITLE
feat: Add secondary_boot_disks to node_pool configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ The node_pools variable takes the following parameters:
 | value | The value for the taint | | Required |
 | version | The Kubernetes version for the nodes in this pool. Should only be set if auto_upgrade is false | " " | Optional |
 | location_policy | [Location policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#location_policy) specifies the algorithm used when scaling-up the node pool. Location policy is supported only in 1.24.1+ clusters. | " " | Optional |
-| secondary_boot_disks | Parameters for secondary boot disks to preload container images and data on new nodes. Structure is [documented here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
+| secondary_boot_disk | Image of a secondary boot disk to preload container images and data on new nodes. For detail see [documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
 
 ## windows_node_pools variable
 The windows_node_pools variable takes the same parameters as [node_pools](#node\_pools-variable) but is reserved for provisioning Windows based node pools only. This variable is introduced to satisfy a [specific requirement](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#create_a_cluster_and_node_pools) for the presence of at least one linux based node pool in the cluster before a windows based node pool can be created.

--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ The node_pools variable takes the following parameters:
 | value | The value for the taint | | Required |
 | version | The Kubernetes version for the nodes in this pool. Should only be set if auto_upgrade is false | " " | Optional |
 | location_policy | [Location policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#location_policy) specifies the algorithm used when scaling-up the node pool. Location policy is supported only in 1.24.1+ clusters. | " " | Optional |
+| secondary_boot_disks | Parameters for secondary boot disks to preload container images and data on new nodes. Structure is [documented here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
 
 ## windows_node_pools variable
 The windows_node_pools variable takes the same parameters as [node_pools](#node\_pools-variable) but is reserved for provisioning Windows based node pools only. This variable is introduced to satisfy a [specific requirement](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#create_a_cluster_and_node_pools) for the presence of at least one linux based node pool in the cluster before a windows based node pool can be created.

--- a/autogen/main/README.md
+++ b/autogen/main/README.md
@@ -250,7 +250,7 @@ The node_pools variable takes the following parameters:
 | value | The value for the taint | | Required |
 | version | The Kubernetes version for the nodes in this pool. Should only be set if auto_upgrade is false | " " | Optional |
 | location_policy | [Location policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#location_policy) specifies the algorithm used when scaling-up the node pool. Location policy is supported only in 1.24.1+ clusters. | " " | Optional |
-| secondary_boot_disks | Parameters for secondary boot disks to preload container images and data on new nodes. Structure is [documented here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
+| secondary_boot_disk | Image of a secondary boot disk to preload container images and data on new nodes. For detail see [documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
 
 ## windows_node_pools variable
 The windows_node_pools variable takes the same parameters as [node_pools](#node\_pools-variable) but is reserved for provisioning Windows based node pools only. This variable is introduced to satisfy a [specific requirement](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#create_a_cluster_and_node_pools) for the presence of at least one linux based node pool in the cluster before a windows based node pool can be created.

--- a/autogen/main/README.md
+++ b/autogen/main/README.md
@@ -250,6 +250,7 @@ The node_pools variable takes the following parameters:
 | value | The value for the taint | | Required |
 | version | The Kubernetes version for the nodes in this pool. Should only be set if auto_upgrade is false | " " | Optional |
 | location_policy | [Location policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#location_policy) specifies the algorithm used when scaling-up the node pool. Location policy is supported only in 1.24.1+ clusters. | " " | Optional |
+| secondary_boot_disks | Parameters for secondary boot disks to preload container images and data on new nodes. Structure is [documented here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
 
 ## windows_node_pools variable
 The windows_node_pools variable takes the same parameters as [node_pools](#node\_pools-variable) but is reserved for provisioning Windows based node pools only. This variable is introduced to satisfy a [specific requirement](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#create_a_cluster_and_node_pools) for the presence of at least one linux based node pool in the cluster before a windows based node pool can be created.

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -857,7 +857,7 @@ resource "google_container_node_pool" "windows_pools" {
     }
 
     dynamic "secondary_boot_disks" {
-      for_each = lookup(each.value, "secondary_boot_disks", [])
+      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
       content {
         disk_image = secondary_boot_disks.value.disk_image
         mode = secondary_boot_disks.value.mode

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -856,11 +856,12 @@ resource "google_container_node_pool" "windows_pools" {
       }
     }
 
+    # Supports a single secondary boot disk because `map(any)` must have the same values type.
     dynamic "secondary_boot_disks" {
-      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
+      for_each = lookup(each.value, "secondary_boot_disk", "") != "" ? [each.value.secondary_boot_disk] : []
       content {
-        disk_image = secondary_boot_disks.value.disk_image
-        mode = secondary_boot_disks.value.mode
+        disk_image = secondary_boot_disks.value
+        mode = "CONTAINER_IMAGE_CACHE"
       }
     }
 

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -856,6 +856,14 @@ resource "google_container_node_pool" "windows_pools" {
       }
     }
 
+    dynamic "secondary_boot_disks" {
+      for_each = lookup(each.value, "secondary_boot_disks", [])
+      content {
+        disk_image = secondary_boot_disks.value.disk_image
+        mode = secondary_boot_disks.value.mode
+      }
+    }
+
     service_account = lookup(
       each.value,
       "service_account",

--- a/cluster.tf
+++ b/cluster.tf
@@ -574,6 +574,14 @@ resource "google_container_node_pool" "pools" {
       }
     }
 
+    dynamic "secondary_boot_disks" {
+      for_each = lookup(each.value, "secondary_boot_disks", [])
+      content {
+        disk_image = secondary_boot_disks.value.disk_image
+        mode       = secondary_boot_disks.value.mode
+      }
+    }
+
     service_account = lookup(
       each.value,
       "service_account",
@@ -787,6 +795,14 @@ resource "google_container_node_pool" "windows_pools" {
       for_each = lookup(each.value, "local_nvme_ssd_count", 0) > 0 ? [each.value.local_nvme_ssd_count] : []
       content {
         local_ssd_count = local_nvme_ssd_block_config.value
+      }
+    }
+
+    dynamic "secondary_boot_disks" {
+      for_each = lookup(each.value, "secondary_boot_disks", [])
+      content {
+        disk_image = secondary_boot_disks.value.disk_image
+        mode       = secondary_boot_disks.value.mode
       }
     }
 

--- a/cluster.tf
+++ b/cluster.tf
@@ -574,11 +574,12 @@ resource "google_container_node_pool" "pools" {
       }
     }
 
+    # Supports a single secondary boot disk because `map(any)` must have the same values type.
     dynamic "secondary_boot_disks" {
-      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
+      for_each = lookup(each.value, "secondary_boot_disk", "") != "" ? [each.value.secondary_boot_disk] : []
       content {
-        disk_image = secondary_boot_disks.value.disk_image
-        mode       = secondary_boot_disks.value.mode
+        disk_image = secondary_boot_disks.value
+        mode       = "CONTAINER_IMAGE_CACHE"
       }
     }
 
@@ -798,11 +799,12 @@ resource "google_container_node_pool" "windows_pools" {
       }
     }
 
+    # Supports a single secondary boot disk because `map(any)` must have the same values type.
     dynamic "secondary_boot_disks" {
-      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
+      for_each = lookup(each.value, "secondary_boot_disk", "") != "" ? [each.value.secondary_boot_disk] : []
       content {
-        disk_image = secondary_boot_disks.value.disk_image
-        mode       = secondary_boot_disks.value.mode
+        disk_image = secondary_boot_disks.value
+        mode       = "CONTAINER_IMAGE_CACHE"
       }
     }
 

--- a/cluster.tf
+++ b/cluster.tf
@@ -575,7 +575,7 @@ resource "google_container_node_pool" "pools" {
     }
 
     dynamic "secondary_boot_disks" {
-      for_each = lookup(each.value, "secondary_boot_disks", [])
+      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
       content {
         disk_image = secondary_boot_disks.value.disk_image
         mode       = secondary_boot_disks.value.mode
@@ -799,7 +799,7 @@ resource "google_container_node_pool" "windows_pools" {
     }
 
     dynamic "secondary_boot_disks" {
-      for_each = lookup(each.value, "secondary_boot_disks", [])
+      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
       content {
         disk_image = secondary_boot_disks.value.disk_image
         mode       = secondary_boot_disks.value.mode

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -390,7 +390,7 @@ The node_pools variable takes the following parameters:
 | value | The value for the taint | | Required |
 | version | The Kubernetes version for the nodes in this pool. Should only be set if auto_upgrade is false | " " | Optional |
 | location_policy | [Location policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#location_policy) specifies the algorithm used when scaling-up the node pool. Location policy is supported only in 1.24.1+ clusters. | " " | Optional |
-| secondary_boot_disks | Parameters for secondary boot disks to preload container images and data on new nodes. Structure is [documented here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
+| secondary_boot_disk | Image of a secondary boot disk to preload container images and data on new nodes. For detail see [documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
 
 ## windows_node_pools variable
 The windows_node_pools variable takes the same parameters as [node_pools](#node\_pools-variable) but is reserved for provisioning Windows based node pools only. This variable is introduced to satisfy a [specific requirement](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#create_a_cluster_and_node_pools) for the presence of at least one linux based node pool in the cluster before a windows based node pool can be created.

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -390,6 +390,7 @@ The node_pools variable takes the following parameters:
 | value | The value for the taint | | Required |
 | version | The Kubernetes version for the nodes in this pool. Should only be set if auto_upgrade is false | " " | Optional |
 | location_policy | [Location policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#location_policy) specifies the algorithm used when scaling-up the node pool. Location policy is supported only in 1.24.1+ clusters. | " " | Optional |
+| secondary_boot_disks | Parameters for secondary boot disks to preload container images and data on new nodes. Structure is [documented here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
 
 ## windows_node_pools variable
 The windows_node_pools variable takes the same parameters as [node_pools](#node\_pools-variable) but is reserved for provisioning Windows based node pools only. This variable is introduced to satisfy a [specific requirement](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#create_a_cluster_and_node_pools) for the presence of at least one linux based node pool in the cluster before a windows based node pool can be created.

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -741,7 +741,7 @@ resource "google_container_node_pool" "pools" {
     }
 
     dynamic "secondary_boot_disks" {
-      for_each = lookup(each.value, "secondary_boot_disks", [])
+      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
       content {
         disk_image = secondary_boot_disks.value.disk_image
         mode       = secondary_boot_disks.value.mode
@@ -991,7 +991,7 @@ resource "google_container_node_pool" "windows_pools" {
     }
 
     dynamic "secondary_boot_disks" {
-      for_each = lookup(each.value, "secondary_boot_disks", [])
+      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
       content {
         disk_image = secondary_boot_disks.value.disk_image
         mode       = secondary_boot_disks.value.mode

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -740,6 +740,14 @@ resource "google_container_node_pool" "pools" {
       }
     }
 
+    dynamic "secondary_boot_disks" {
+      for_each = lookup(each.value, "secondary_boot_disks", [])
+      content {
+        disk_image = secondary_boot_disks.value.disk_image
+        mode       = secondary_boot_disks.value.mode
+      }
+    }
+
     service_account = lookup(
       each.value,
       "service_account",
@@ -979,6 +987,14 @@ resource "google_container_node_pool" "windows_pools" {
       for_each = lookup(each.value, "local_nvme_ssd_count", 0) > 0 ? [each.value.local_nvme_ssd_count] : []
       content {
         local_ssd_count = local_nvme_ssd_block_config.value
+      }
+    }
+
+    dynamic "secondary_boot_disks" {
+      for_each = lookup(each.value, "secondary_boot_disks", [])
+      content {
+        disk_image = secondary_boot_disks.value.disk_image
+        mode       = secondary_boot_disks.value.mode
       }
     }
 

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -740,11 +740,12 @@ resource "google_container_node_pool" "pools" {
       }
     }
 
+    # Supports a single secondary boot disk because `map(any)` must have the same values type.
     dynamic "secondary_boot_disks" {
-      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
+      for_each = lookup(each.value, "secondary_boot_disk", "") != "" ? [each.value.secondary_boot_disk] : []
       content {
-        disk_image = secondary_boot_disks.value.disk_image
-        mode       = secondary_boot_disks.value.mode
+        disk_image = secondary_boot_disks.value
+        mode       = "CONTAINER_IMAGE_CACHE"
       }
     }
 
@@ -990,11 +991,12 @@ resource "google_container_node_pool" "windows_pools" {
       }
     }
 
+    # Supports a single secondary boot disk because `map(any)` must have the same values type.
     dynamic "secondary_boot_disks" {
-      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
+      for_each = lookup(each.value, "secondary_boot_disk", "") != "" ? [each.value.secondary_boot_disk] : []
       content {
-        disk_image = secondary_boot_disks.value.disk_image
-        mode       = secondary_boot_disks.value.mode
+        disk_image = secondary_boot_disks.value
+        mode       = "CONTAINER_IMAGE_CACHE"
       }
     }
 

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -368,6 +368,7 @@ The node_pools variable takes the following parameters:
 | value | The value for the taint | | Required |
 | version | The Kubernetes version for the nodes in this pool. Should only be set if auto_upgrade is false | " " | Optional |
 | location_policy | [Location policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#location_policy) specifies the algorithm used when scaling-up the node pool. Location policy is supported only in 1.24.1+ clusters. | " " | Optional |
+| secondary_boot_disks | Parameters for secondary boot disks to preload container images and data on new nodes. Structure is [documented here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
 
 ## windows_node_pools variable
 The windows_node_pools variable takes the same parameters as [node_pools](#node\_pools-variable) but is reserved for provisioning Windows based node pools only. This variable is introduced to satisfy a [specific requirement](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#create_a_cluster_and_node_pools) for the presence of at least one linux based node pool in the cluster before a windows based node pool can be created.

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -368,7 +368,7 @@ The node_pools variable takes the following parameters:
 | value | The value for the taint | | Required |
 | version | The Kubernetes version for the nodes in this pool. Should only be set if auto_upgrade is false | " " | Optional |
 | location_policy | [Location policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#location_policy) specifies the algorithm used when scaling-up the node pool. Location policy is supported only in 1.24.1+ clusters. | " " | Optional |
-| secondary_boot_disks | Parameters for secondary boot disks to preload container images and data on new nodes. Structure is [documented here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
+| secondary_boot_disk | Image of a secondary boot disk to preload container images and data on new nodes. For detail see [documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
 
 ## windows_node_pools variable
 The windows_node_pools variable takes the same parameters as [node_pools](#node\_pools-variable) but is reserved for provisioning Windows based node pools only. This variable is introduced to satisfy a [specific requirement](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#create_a_cluster_and_node_pools) for the presence of at least one linux based node pool in the cluster before a windows based node pool can be created.

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -665,6 +665,14 @@ resource "google_container_node_pool" "pools" {
       }
     }
 
+    dynamic "secondary_boot_disks" {
+      for_each = lookup(each.value, "secondary_boot_disks", [])
+      content {
+        disk_image = secondary_boot_disks.value.disk_image
+        mode       = secondary_boot_disks.value.mode
+      }
+    }
+
     service_account = lookup(
       each.value,
       "service_account",
@@ -903,6 +911,14 @@ resource "google_container_node_pool" "windows_pools" {
       for_each = lookup(each.value, "local_nvme_ssd_count", 0) > 0 ? [each.value.local_nvme_ssd_count] : []
       content {
         local_ssd_count = local_nvme_ssd_block_config.value
+      }
+    }
+
+    dynamic "secondary_boot_disks" {
+      for_each = lookup(each.value, "secondary_boot_disks", [])
+      content {
+        disk_image = secondary_boot_disks.value.disk_image
+        mode       = secondary_boot_disks.value.mode
       }
     }
 

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -666,7 +666,7 @@ resource "google_container_node_pool" "pools" {
     }
 
     dynamic "secondary_boot_disks" {
-      for_each = lookup(each.value, "secondary_boot_disks", [])
+      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
       content {
         disk_image = secondary_boot_disks.value.disk_image
         mode       = secondary_boot_disks.value.mode
@@ -915,7 +915,7 @@ resource "google_container_node_pool" "windows_pools" {
     }
 
     dynamic "secondary_boot_disks" {
-      for_each = lookup(each.value, "secondary_boot_disks", [])
+      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
       content {
         disk_image = secondary_boot_disks.value.disk_image
         mode       = secondary_boot_disks.value.mode

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -665,11 +665,12 @@ resource "google_container_node_pool" "pools" {
       }
     }
 
+    # Supports a single secondary boot disk because `map(any)` must have the same values type.
     dynamic "secondary_boot_disks" {
-      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
+      for_each = lookup(each.value, "secondary_boot_disk", "") != "" ? [each.value.secondary_boot_disk] : []
       content {
-        disk_image = secondary_boot_disks.value.disk_image
-        mode       = secondary_boot_disks.value.mode
+        disk_image = secondary_boot_disks.value
+        mode       = "CONTAINER_IMAGE_CACHE"
       }
     }
 
@@ -914,11 +915,12 @@ resource "google_container_node_pool" "windows_pools" {
       }
     }
 
+    # Supports a single secondary boot disk because `map(any)` must have the same values type.
     dynamic "secondary_boot_disks" {
-      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
+      for_each = lookup(each.value, "secondary_boot_disk", "") != "" ? [each.value.secondary_boot_disk] : []
       content {
-        disk_image = secondary_boot_disks.value.disk_image
-        mode       = secondary_boot_disks.value.mode
+        disk_image = secondary_boot_disks.value
+        mode       = "CONTAINER_IMAGE_CACHE"
       }
     }
 

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -378,6 +378,7 @@ The node_pools variable takes the following parameters:
 | value | The value for the taint | | Required |
 | version | The Kubernetes version for the nodes in this pool. Should only be set if auto_upgrade is false | " " | Optional |
 | location_policy | [Location policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#location_policy) specifies the algorithm used when scaling-up the node pool. Location policy is supported only in 1.24.1+ clusters. | " " | Optional |
+| secondary_boot_disks | Parameters for secondary boot disks to preload container images and data on new nodes. Structure is [documented here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
 
 ## windows_node_pools variable
 The windows_node_pools variable takes the same parameters as [node_pools](#node\_pools-variable) but is reserved for provisioning Windows based node pools only. This variable is introduced to satisfy a [specific requirement](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#create_a_cluster_and_node_pools) for the presence of at least one linux based node pool in the cluster before a windows based node pool can be created.

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -378,7 +378,7 @@ The node_pools variable takes the following parameters:
 | value | The value for the taint | | Required |
 | version | The Kubernetes version for the nodes in this pool. Should only be set if auto_upgrade is false | " " | Optional |
 | location_policy | [Location policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#location_policy) specifies the algorithm used when scaling-up the node pool. Location policy is supported only in 1.24.1+ clusters. | " " | Optional |
-| secondary_boot_disks | Parameters for secondary boot disks to preload container images and data on new nodes. Structure is [documented here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
+| secondary_boot_disk | Image of a secondary boot disk to preload container images and data on new nodes. For detail see [documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
 
 ## windows_node_pools variable
 The windows_node_pools variable takes the same parameters as [node_pools](#node\_pools-variable) but is reserved for provisioning Windows based node pools only. This variable is introduced to satisfy a [specific requirement](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#create_a_cluster_and_node_pools) for the presence of at least one linux based node pool in the cluster before a windows based node pool can be created.

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -721,11 +721,12 @@ resource "google_container_node_pool" "pools" {
       }
     }
 
+    # Supports a single secondary boot disk because `map(any)` must have the same values type.
     dynamic "secondary_boot_disks" {
-      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
+      for_each = lookup(each.value, "secondary_boot_disk", "") != "" ? [each.value.secondary_boot_disk] : []
       content {
-        disk_image = secondary_boot_disks.value.disk_image
-        mode       = secondary_boot_disks.value.mode
+        disk_image = secondary_boot_disks.value
+        mode       = "CONTAINER_IMAGE_CACHE"
       }
     }
 
@@ -971,11 +972,12 @@ resource "google_container_node_pool" "windows_pools" {
       }
     }
 
+    # Supports a single secondary boot disk because `map(any)` must have the same values type.
     dynamic "secondary_boot_disks" {
-      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
+      for_each = lookup(each.value, "secondary_boot_disk", "") != "" ? [each.value.secondary_boot_disk] : []
       content {
-        disk_image = secondary_boot_disks.value.disk_image
-        mode       = secondary_boot_disks.value.mode
+        disk_image = secondary_boot_disks.value
+        mode       = "CONTAINER_IMAGE_CACHE"
       }
     }
 

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -721,6 +721,14 @@ resource "google_container_node_pool" "pools" {
       }
     }
 
+    dynamic "secondary_boot_disks" {
+      for_each = lookup(each.value, "secondary_boot_disks", [])
+      content {
+        disk_image = secondary_boot_disks.value.disk_image
+        mode       = secondary_boot_disks.value.mode
+      }
+    }
+
     service_account = lookup(
       each.value,
       "service_account",
@@ -960,6 +968,14 @@ resource "google_container_node_pool" "windows_pools" {
       for_each = lookup(each.value, "local_nvme_ssd_count", 0) > 0 ? [each.value.local_nvme_ssd_count] : []
       content {
         local_ssd_count = local_nvme_ssd_block_config.value
+      }
+    }
+
+    dynamic "secondary_boot_disks" {
+      for_each = lookup(each.value, "secondary_boot_disks", [])
+      content {
+        disk_image = secondary_boot_disks.value.disk_image
+        mode       = secondary_boot_disks.value.mode
       }
     }
 

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -722,7 +722,7 @@ resource "google_container_node_pool" "pools" {
     }
 
     dynamic "secondary_boot_disks" {
-      for_each = lookup(each.value, "secondary_boot_disks", [])
+      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
       content {
         disk_image = secondary_boot_disks.value.disk_image
         mode       = secondary_boot_disks.value.mode
@@ -972,7 +972,7 @@ resource "google_container_node_pool" "windows_pools" {
     }
 
     dynamic "secondary_boot_disks" {
-      for_each = lookup(each.value, "secondary_boot_disks", [])
+      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
       content {
         disk_image = secondary_boot_disks.value.disk_image
         mode       = secondary_boot_disks.value.mode

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -356,6 +356,7 @@ The node_pools variable takes the following parameters:
 | value | The value for the taint | | Required |
 | version | The Kubernetes version for the nodes in this pool. Should only be set if auto_upgrade is false | " " | Optional |
 | location_policy | [Location policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#location_policy) specifies the algorithm used when scaling-up the node pool. Location policy is supported only in 1.24.1+ clusters. | " " | Optional |
+| secondary_boot_disks | Parameters for secondary boot disks to preload container images and data on new nodes. Structure is [documented here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
 
 ## windows_node_pools variable
 The windows_node_pools variable takes the same parameters as [node_pools](#node\_pools-variable) but is reserved for provisioning Windows based node pools only. This variable is introduced to satisfy a [specific requirement](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#create_a_cluster_and_node_pools) for the presence of at least one linux based node pool in the cluster before a windows based node pool can be created.

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -356,7 +356,7 @@ The node_pools variable takes the following parameters:
 | value | The value for the taint | | Required |
 | version | The Kubernetes version for the nodes in this pool. Should only be set if auto_upgrade is false | " " | Optional |
 | location_policy | [Location policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#location_policy) specifies the algorithm used when scaling-up the node pool. Location policy is supported only in 1.24.1+ clusters. | " " | Optional |
-| secondary_boot_disks | Parameters for secondary boot disks to preload container images and data on new nodes. Structure is [documented here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
+| secondary_boot_disk | Image of a secondary boot disk to preload container images and data on new nodes. For detail see [documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
 
 ## windows_node_pools variable
 The windows_node_pools variable takes the same parameters as [node_pools](#node\_pools-variable) but is reserved for provisioning Windows based node pools only. This variable is introduced to satisfy a [specific requirement](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#create_a_cluster_and_node_pools) for the presence of at least one linux based node pool in the cluster before a windows based node pool can be created.

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -646,6 +646,14 @@ resource "google_container_node_pool" "pools" {
       }
     }
 
+    dynamic "secondary_boot_disks" {
+      for_each = lookup(each.value, "secondary_boot_disks", [])
+      content {
+        disk_image = secondary_boot_disks.value.disk_image
+        mode       = secondary_boot_disks.value.mode
+      }
+    }
+
     service_account = lookup(
       each.value,
       "service_account",
@@ -884,6 +892,14 @@ resource "google_container_node_pool" "windows_pools" {
       for_each = lookup(each.value, "local_nvme_ssd_count", 0) > 0 ? [each.value.local_nvme_ssd_count] : []
       content {
         local_ssd_count = local_nvme_ssd_block_config.value
+      }
+    }
+
+    dynamic "secondary_boot_disks" {
+      for_each = lookup(each.value, "secondary_boot_disks", [])
+      content {
+        disk_image = secondary_boot_disks.value.disk_image
+        mode       = secondary_boot_disks.value.mode
       }
     }
 

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -647,7 +647,7 @@ resource "google_container_node_pool" "pools" {
     }
 
     dynamic "secondary_boot_disks" {
-      for_each = lookup(each.value, "secondary_boot_disks", [])
+      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
       content {
         disk_image = secondary_boot_disks.value.disk_image
         mode       = secondary_boot_disks.value.mode
@@ -896,7 +896,7 @@ resource "google_container_node_pool" "windows_pools" {
     }
 
     dynamic "secondary_boot_disks" {
-      for_each = lookup(each.value, "secondary_boot_disks", [])
+      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
       content {
         disk_image = secondary_boot_disks.value.disk_image
         mode       = secondary_boot_disks.value.mode

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -646,11 +646,12 @@ resource "google_container_node_pool" "pools" {
       }
     }
 
+    # Supports a single secondary boot disk because `map(any)` must have the same values type.
     dynamic "secondary_boot_disks" {
-      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
+      for_each = lookup(each.value, "secondary_boot_disk", "") != "" ? [each.value.secondary_boot_disk] : []
       content {
-        disk_image = secondary_boot_disks.value.disk_image
-        mode       = secondary_boot_disks.value.mode
+        disk_image = secondary_boot_disks.value
+        mode       = "CONTAINER_IMAGE_CACHE"
       }
     }
 
@@ -895,11 +896,12 @@ resource "google_container_node_pool" "windows_pools" {
       }
     }
 
+    # Supports a single secondary boot disk because `map(any)` must have the same values type.
     dynamic "secondary_boot_disks" {
-      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
+      for_each = lookup(each.value, "secondary_boot_disk", "") != "" ? [each.value.secondary_boot_disk] : []
       content {
-        disk_image = secondary_boot_disks.value.disk_image
-        mode       = secondary_boot_disks.value.mode
+        disk_image = secondary_boot_disks.value
+        mode       = "CONTAINER_IMAGE_CACHE"
       }
     }
 

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -357,7 +357,7 @@ The node_pools variable takes the following parameters:
 | value | The value for the taint | | Required |
 | version | The Kubernetes version for the nodes in this pool. Should only be set if auto_upgrade is false | " " | Optional |
 | location_policy | [Location policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#location_policy) specifies the algorithm used when scaling-up the node pool. Location policy is supported only in 1.24.1+ clusters. | " " | Optional |
-| secondary_boot_disks | Parameters for secondary boot disks to preload container images and data on new nodes. Structure is [documented here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
+| secondary_boot_disk | Image of a secondary boot disk to preload container images and data on new nodes. For detail see [documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
 
 ## windows_node_pools variable
 The windows_node_pools variable takes the same parameters as [node_pools](#node\_pools-variable) but is reserved for provisioning Windows based node pools only. This variable is introduced to satisfy a [specific requirement](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#create_a_cluster_and_node_pools) for the presence of at least one linux based node pool in the cluster before a windows based node pool can be created.

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -357,6 +357,7 @@ The node_pools variable takes the following parameters:
 | value | The value for the taint | | Required |
 | version | The Kubernetes version for the nodes in this pool. Should only be set if auto_upgrade is false | " " | Optional |
 | location_policy | [Location policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#location_policy) specifies the algorithm used when scaling-up the node pool. Location policy is supported only in 1.24.1+ clusters. | " " | Optional |
+| secondary_boot_disks | Parameters for secondary boot disks to preload container images and data on new nodes. Structure is [documented here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
 
 ## windows_node_pools variable
 The windows_node_pools variable takes the same parameters as [node_pools](#node\_pools-variable) but is reserved for provisioning Windows based node pools only. This variable is introduced to satisfy a [specific requirement](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#create_a_cluster_and_node_pools) for the presence of at least one linux based node pool in the cluster before a windows based node pool can be created.

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -668,6 +668,14 @@ resource "google_container_node_pool" "pools" {
       }
     }
 
+    dynamic "secondary_boot_disks" {
+      for_each = lookup(each.value, "secondary_boot_disks", [])
+      content {
+        disk_image = secondary_boot_disks.value.disk_image
+        mode       = secondary_boot_disks.value.mode
+      }
+    }
+
     service_account = lookup(
       each.value,
       "service_account",
@@ -882,6 +890,14 @@ resource "google_container_node_pool" "windows_pools" {
       for_each = lookup(each.value, "local_nvme_ssd_count", 0) > 0 ? [each.value.local_nvme_ssd_count] : []
       content {
         local_ssd_count = local_nvme_ssd_block_config.value
+      }
+    }
+
+    dynamic "secondary_boot_disks" {
+      for_each = lookup(each.value, "secondary_boot_disks", [])
+      content {
+        disk_image = secondary_boot_disks.value.disk_image
+        mode       = secondary_boot_disks.value.mode
       }
     }
 

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -668,11 +668,12 @@ resource "google_container_node_pool" "pools" {
       }
     }
 
+    # Supports a single secondary boot disk because `map(any)` must have the same values type.
     dynamic "secondary_boot_disks" {
-      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
+      for_each = lookup(each.value, "secondary_boot_disk", "") != "" ? [each.value.secondary_boot_disk] : []
       content {
-        disk_image = secondary_boot_disks.value.disk_image
-        mode       = secondary_boot_disks.value.mode
+        disk_image = secondary_boot_disks.value
+        mode       = "CONTAINER_IMAGE_CACHE"
       }
     }
 
@@ -893,11 +894,12 @@ resource "google_container_node_pool" "windows_pools" {
       }
     }
 
+    # Supports a single secondary boot disk because `map(any)` must have the same values type.
     dynamic "secondary_boot_disks" {
-      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
+      for_each = lookup(each.value, "secondary_boot_disk", "") != "" ? [each.value.secondary_boot_disk] : []
       content {
-        disk_image = secondary_boot_disks.value.disk_image
-        mode       = secondary_boot_disks.value.mode
+        disk_image = secondary_boot_disks.value
+        mode       = "CONTAINER_IMAGE_CACHE"
       }
     }
 

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -669,7 +669,7 @@ resource "google_container_node_pool" "pools" {
     }
 
     dynamic "secondary_boot_disks" {
-      for_each = lookup(each.value, "secondary_boot_disks", [])
+      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
       content {
         disk_image = secondary_boot_disks.value.disk_image
         mode       = secondary_boot_disks.value.mode
@@ -894,7 +894,7 @@ resource "google_container_node_pool" "windows_pools" {
     }
 
     dynamic "secondary_boot_disks" {
-      for_each = lookup(each.value, "secondary_boot_disks", [])
+      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
       content {
         disk_image = secondary_boot_disks.value.disk_image
         mode       = secondary_boot_disks.value.mode

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -335,7 +335,7 @@ The node_pools variable takes the following parameters:
 | value | The value for the taint | | Required |
 | version | The Kubernetes version for the nodes in this pool. Should only be set if auto_upgrade is false | " " | Optional |
 | location_policy | [Location policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#location_policy) specifies the algorithm used when scaling-up the node pool. Location policy is supported only in 1.24.1+ clusters. | " " | Optional |
-| secondary_boot_disks | Parameters for secondary boot disks to preload container images and data on new nodes. Structure is [documented here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
+| secondary_boot_disk | Image of a secondary boot disk to preload container images and data on new nodes. For detail see [documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
 
 ## windows_node_pools variable
 The windows_node_pools variable takes the same parameters as [node_pools](#node\_pools-variable) but is reserved for provisioning Windows based node pools only. This variable is introduced to satisfy a [specific requirement](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#create_a_cluster_and_node_pools) for the presence of at least one linux based node pool in the cluster before a windows based node pool can be created.

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -335,6 +335,7 @@ The node_pools variable takes the following parameters:
 | value | The value for the taint | | Required |
 | version | The Kubernetes version for the nodes in this pool. Should only be set if auto_upgrade is false | " " | Optional |
 | location_policy | [Location policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#location_policy) specifies the algorithm used when scaling-up the node pool. Location policy is supported only in 1.24.1+ clusters. | " " | Optional |
+| secondary_boot_disks | Parameters for secondary boot disks to preload container images and data on new nodes. Structure is [documented here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_secondary_boot_disks). `gcfs_config` must be `enabled=true` for this feature to work. | | Optional |
 
 ## windows_node_pools variable
 The windows_node_pools variable takes the same parameters as [node_pools](#node\_pools-variable) but is reserved for provisioning Windows based node pools only. This variable is introduced to satisfy a [specific requirement](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster-windows#create_a_cluster_and_node_pools) for the presence of at least one linux based node pool in the cluster before a windows based node pool can be created.

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -593,11 +593,12 @@ resource "google_container_node_pool" "pools" {
       }
     }
 
+    # Supports a single secondary boot disk because `map(any)` must have the same values type.
     dynamic "secondary_boot_disks" {
-      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
+      for_each = lookup(each.value, "secondary_boot_disk", "") != "" ? [each.value.secondary_boot_disk] : []
       content {
-        disk_image = secondary_boot_disks.value.disk_image
-        mode       = secondary_boot_disks.value.mode
+        disk_image = secondary_boot_disks.value
+        mode       = "CONTAINER_IMAGE_CACHE"
       }
     }
 
@@ -817,11 +818,12 @@ resource "google_container_node_pool" "windows_pools" {
       }
     }
 
+    # Supports a single secondary boot disk because `map(any)` must have the same values type.
     dynamic "secondary_boot_disks" {
-      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
+      for_each = lookup(each.value, "secondary_boot_disk", "") != "" ? [each.value.secondary_boot_disk] : []
       content {
-        disk_image = secondary_boot_disks.value.disk_image
-        mode       = secondary_boot_disks.value.mode
+        disk_image = secondary_boot_disks.value
+        mode       = "CONTAINER_IMAGE_CACHE"
       }
     }
 

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -594,7 +594,7 @@ resource "google_container_node_pool" "pools" {
     }
 
     dynamic "secondary_boot_disks" {
-      for_each = lookup(each.value, "secondary_boot_disks", [])
+      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
       content {
         disk_image = secondary_boot_disks.value.disk_image
         mode       = secondary_boot_disks.value.mode
@@ -818,7 +818,7 @@ resource "google_container_node_pool" "windows_pools" {
     }
 
     dynamic "secondary_boot_disks" {
-      for_each = lookup(each.value, "secondary_boot_disks", [])
+      for_each = contains(keys(each.value), "secondary_boot_disks") ? each.value.secondary_boot_disks : []
       content {
         disk_image = secondary_boot_disks.value.disk_image
         mode       = secondary_boot_disks.value.mode

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -593,6 +593,14 @@ resource "google_container_node_pool" "pools" {
       }
     }
 
+    dynamic "secondary_boot_disks" {
+      for_each = lookup(each.value, "secondary_boot_disks", [])
+      content {
+        disk_image = secondary_boot_disks.value.disk_image
+        mode       = secondary_boot_disks.value.mode
+      }
+    }
+
     service_account = lookup(
       each.value,
       "service_account",
@@ -806,6 +814,14 @@ resource "google_container_node_pool" "windows_pools" {
       for_each = lookup(each.value, "local_nvme_ssd_count", 0) > 0 ? [each.value.local_nvme_ssd_count] : []
       content {
         local_ssd_count = local_nvme_ssd_block_config.value
+      }
+    }
+
+    dynamic "secondary_boot_disks" {
+      for_each = lookup(each.value, "secondary_boot_disks", [])
+      content {
+        disk_image = secondary_boot_disks.value.disk_image
+        mode       = secondary_boot_disks.value.mode
       }
     }
 


### PR DESCRIPTION
PR adds secondary_boot_disks setting to cluster.tf in the node_config part.