### PR TITLE
feat: support cilium clusterwide

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -171,6 +171,8 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
+
   enable_kubernetes_alpha = var.enable_kubernetes_alpha
   enable_tpu              = var.enable_tpu
 

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -308,7 +308,7 @@ resource "google_container_cluster" "primary" {
     }
   }
 
-  datapath_provider = var.datapath_provider
+  datapath_provider                        = var.datapath_provider
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
   networking_mode = "VPC_NATIVE"

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -309,6 +309,7 @@ resource "google_container_cluster" "primary" {
   }
 
   datapath_provider = var.datapath_provider
+  enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
   networking_mode = "VPC_NATIVE"
 

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -852,4 +852,5 @@ variable "fleet_project_grant_service_agent" {
 variable "enable_cilium_clusterwide_network_policy" {
   description = "(Optional) Whether CiliumClusterWideNetworkPolicy is enabled on this cluster. Defaults to false."
   type        = bool
+  default     = false
 }

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -848,3 +848,8 @@ variable "fleet_project_grant_service_agent" {
   type        = bool
   default     = false
 }
+
+variable "enable_cilium_clusterwide_network_policy" {
+  description = "(Optional) Whether CiliumClusterWideNetworkPolicy is enabled on this cluster. Defaults to false."
+  type        = bool
+}

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -309,6 +309,8 @@ resource "google_container_cluster" "primary" {
   }
 
   datapath_provider = var.datapath_provider
+  enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
+  
 
   networking_mode = "VPC_NATIVE"
 

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -308,9 +308,9 @@ resource "google_container_cluster" "primary" {
     }
   }
 
-  datapath_provider = var.datapath_provider
+  datapath_provider                        = var.datapath_provider
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
-  
+
 
   networking_mode = "VPC_NATIVE"
 

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -852,4 +852,5 @@ variable "fleet_project_grant_service_agent" {
 variable "enable_cilium_clusterwide_network_policy" {
   description = "(Optional) Whether CiliumClusterWideNetworkPolicy is enabled on this cluster. Defaults to false."
   type        = bool
+  default     = false
 }

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -848,3 +848,8 @@ variable "fleet_project_grant_service_agent" {
   type        = bool
   default     = false
 }
+
+variable "enable_cilium_clusterwide_network_policy" {
+  description = "(Optional) Whether CiliumClusterWideNetworkPolicy is enabled on this cluster. Defaults to false."
+  type        = bool
+}

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -269,6 +269,7 @@ resource "google_container_cluster" "primary" {
   }
 
   datapath_provider = var.datapath_provider
+  enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
 
   security_posture_config {

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -268,7 +268,7 @@ resource "google_container_cluster" "primary" {
     }
   }
 
-  datapath_provider = var.datapath_provider
+  datapath_provider                        = var.datapath_provider
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
 

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -758,3 +758,8 @@ variable "fleet_project" {
   type        = string
   default     = null
 }
+
+variable "enable_cilium_clusterwide_network_policy" {
+  description = "(Optional) Whether CiliumClusterWideNetworkPolicy is enabled on this cluster. Defaults to false."
+  type        = bool
+}

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -762,4 +762,5 @@ variable "fleet_project" {
 variable "enable_cilium_clusterwide_network_policy" {
   description = "(Optional) Whether CiliumClusterWideNetworkPolicy is enabled on this cluster. Defaults to false."
   type        = bool
+  default     = false
 }

--- a/modules/safer-cluster-update-variant/main.tf
+++ b/modules/safer-cluster-update-variant/main.tf
@@ -69,6 +69,7 @@ module "gke" {
   // it provides redundant NetworkPolicy capabilities. If V2 is enabled, the
   // Calico add-on should be disabled.
   network_policy = var.datapath_provider == "ADVANCED_DATAPATH" ? false : true
+  enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
   // Default to the recommended Dataplane V2 which enables NetworkPolicies and
   // allows for network policy logging of allowed and denied requests to Pods.

--- a/modules/safer-cluster-update-variant/main.tf
+++ b/modules/safer-cluster-update-variant/main.tf
@@ -68,7 +68,7 @@ module "gke" {
   // NOTE: Dataplane-V2 conflicts with the Calico network policy add-on because
   // it provides redundant NetworkPolicy capabilities. If V2 is enabled, the
   // Calico add-on should be disabled.
-  network_policy = var.datapath_provider == "ADVANCED_DATAPATH" ? false : true
+  network_policy                           = var.datapath_provider == "ADVANCED_DATAPATH" ? false : true
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
   // Default to the recommended Dataplane V2 which enables NetworkPolicies and

--- a/modules/safer-cluster-update-variant/variables.tf
+++ b/modules/safer-cluster-update-variant/variables.tf
@@ -536,4 +536,5 @@ variable "deletion_protection" {
 variable "enable_cilium_clusterwide_network_policy" {
   description = "(Optional) Whether CiliumClusterWideNetworkPolicy is enabled on this cluster. Defaults to false."
   type        = bool
+  default     = false
 }

--- a/modules/safer-cluster-update-variant/variables.tf
+++ b/modules/safer-cluster-update-variant/variables.tf
@@ -532,3 +532,8 @@ variable "deletion_protection" {
   description = "Whether or not to allow Terraform to destroy the cluster."
   default     = true
 }
+
+variable "enable_cilium_clusterwide_network_policy" {
+  description = "(Optional) Whether CiliumClusterWideNetworkPolicy is enabled on this cluster. Defaults to false."
+  type        = bool
+}

--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -73,6 +73,7 @@ module "gke" {
   // Default to the recommended Dataplane V2 which enables NetworkPolicies and
   // allows for network policy logging of allowed and denied requests to Pods.
   datapath_provider = var.datapath_provider
+  enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
   maintenance_start_time = var.maintenance_start_time
   maintenance_end_time   = var.maintenance_end_time

--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -72,7 +72,7 @@ module "gke" {
 
   // Default to the recommended Dataplane V2 which enables NetworkPolicies and
   // allows for network policy logging of allowed and denied requests to Pods.
-  datapath_provider = var.datapath_provider
+  datapath_provider                        = var.datapath_provider
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
   maintenance_start_time = var.maintenance_start_time

--- a/modules/safer-cluster/variables.tf
+++ b/modules/safer-cluster/variables.tf
@@ -536,4 +536,5 @@ variable "deletion_protection" {
 variable "enable_cilium_clusterwide_network_policy" {
   description = "(Optional) Whether CiliumClusterWideNetworkPolicy is enabled on this cluster. Defaults to false."
   type        = bool
+  default     = false
 }

--- a/modules/safer-cluster/variables.tf
+++ b/modules/safer-cluster/variables.tf
@@ -532,3 +532,8 @@ variable "deletion_protection" {
   description = "Whether or not to allow Terraform to destroy the cluster."
   default     = true
 }
+
+variable "enable_cilium_clusterwide_network_policy" {
+  description = "(Optional) Whether CiliumClusterWideNetworkPolicy is enabled on this cluster. Defaults to false."
+  type        = bool
+}

--- a/variables.tf
+++ b/variables.tf
@@ -732,5 +732,5 @@ variable "fleet_project" {
 variable "enable_cilium_clusterwide_network_policy" {
   description = "(Optional) Whether CiliumClusterWideNetworkPolicy is enabled on this cluster. Defaults to false."
   type        = bool
-  default     = false  
+  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -728,3 +728,9 @@ variable "fleet_project" {
   type        = string
   default     = null
 }
+
+variable "enable_cilium_clusterwide_network_policy" {
+  description = "(Optional) Whether CiliumClusterWideNetworkPolicy is enabled on this cluster. Defaults to false."
+  type        = bool
+  default     = false  
+}


### PR DESCRIPTION
Enabled support for CiliumClusterWideNetworkPolicy across various Terraform modules to enhance network security and policy enforcement capabilities in Kubernetes clusters. This change allows for the utilization of Cilium's extended network policy features, providing users with the option to enforce more granular network policies at the cluster level.

In link with https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#enable_cilium_clusterwide_network_policy