### PR TITLE
beta-autopilot-private-cluster: support CiliumClusterwideNetworkPolicy

### DIFF
--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -85,6 +85,8 @@ resource "google_container_cluster" "primary" {
     enabled = var.enable_vertical_pod_autoscaling
   }
   enable_fqdn_network_policy = var.enable_fqdn_network_policy
+  enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
+
   enable_autopilot           = true
   dynamic "master_authorized_networks_config" {
     for_each = local.master_authorized_networks_config

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -399,6 +399,12 @@ variable "enable_fqdn_network_policy" {
   default     = null
 }
 
+variable "enable_cilium_clusterwide_network_policy" {
+  type = bool
+  description = "Enable Cilium cluster-wide network policy."
+  default = false
+}
+
 variable "security_posture_mode" {
   description = "Security posture mode.  Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`."
   type        = string


### PR DESCRIPTION
This introduces support for passing `enable_cilium_clusterwide_network_policy` for `google_container_cluster` in `beta-autopilot-private-cluster`.