### PR TITLE
Added remote fleet support for anthos modules

### DIFF
--- a/modules/acm/feature.tf
+++ b/modules/acm/feature.tf
@@ -33,7 +33,7 @@ resource "google_gke_hub_feature_membership" "main" {
   feature  = "configmanagement"
 
   membership = module.registration.cluster_membership_id
-  project    = var.project_id
+  project    = try(var.hub_project_id, var.project_id)
 
   configmanagement {
     version = var.configmanagement_version

--- a/modules/acm/main.tf
+++ b/modules/acm/main.tf
@@ -24,6 +24,7 @@ module "registration" {
 
   cluster_name              = var.cluster_name
   project_id                = var.project_id
+  hub_project_id            = var.hub_project_id
   location                  = var.location
   enable_fleet_registration = var.enable_fleet_registration
   membership_name           = var.cluster_membership_id

--- a/modules/acm/variables.tf
+++ b/modules/acm/variables.tf
@@ -24,6 +24,12 @@ variable "project_id" {
   type        = string
 }
 
+variable "hub_project_id" {
+  description = "The project in which the GKE Hub belongs. Defaults to GKE cluster project_id."
+  type        = string
+  default     = ""
+}
+
 variable "location" {
   description = "GCP location used to reach cluster."
   type        = string


### PR DESCRIPTION
We faced the issue that we wanted to register a gke cluster in a fleet of another project, but ACM-Module doesn't support the configuration of another project id like fleet-registration module.

With this PR we want to add the support for this configuration.