### PR TITLE
chore(kms): add support of kms key in node config

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -511,6 +511,9 @@ resource "google_container_cluster" "primary" {
     }
 
     node_config {
+      {% if not beta_cluster %}
+      boot_disk_kms_key           = lookup(var.node_pools[0], "boot_disk_kms_key", var.boot_disk_kms_key)
+      {% endif %}
       image_type                  = lookup(var.node_pools[0], "image_type", "COS_CONTAINERD")
       machine_type                = lookup(var.node_pools[0], "machine_type", "e2-medium")
       min_cpu_platform            = lookup(var.node_pools[0], "min_cpu_platform", "")

--- a/cluster.tf
+++ b/cluster.tf
@@ -388,6 +388,7 @@ resource "google_container_cluster" "primary" {
     }
 
     node_config {
+      boot_disk_kms_key           = lookup(var.node_pools[0], "boot_disk_kms_key", var.boot_disk_kms_key)
       image_type                  = lookup(var.node_pools[0], "image_type", "COS_CONTAINERD")
       machine_type                = lookup(var.node_pools[0], "machine_type", "e2-medium")
       min_cpu_platform            = lookup(var.node_pools[0], "min_cpu_platform", "")

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -388,6 +388,7 @@ resource "google_container_cluster" "primary" {
     }
 
     node_config {
+      boot_disk_kms_key           = lookup(var.node_pools[0], "boot_disk_kms_key", var.boot_disk_kms_key)
       image_type                  = lookup(var.node_pools[0], "image_type", "COS_CONTAINERD")
       machine_type                = lookup(var.node_pools[0], "machine_type", "e2-medium")
       min_cpu_platform            = lookup(var.node_pools[0], "min_cpu_platform", "")

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -388,6 +388,7 @@ resource "google_container_cluster" "primary" {
     }
 
     node_config {
+      boot_disk_kms_key           = lookup(var.node_pools[0], "boot_disk_kms_key", var.boot_disk_kms_key)
       image_type                  = lookup(var.node_pools[0], "image_type", "COS_CONTAINERD")
       machine_type                = lookup(var.node_pools[0], "machine_type", "e2-medium")
       min_cpu_platform            = lookup(var.node_pools[0], "min_cpu_platform", "")


### PR DESCRIPTION
To avoid the following error

```
[...].module.gke.google_container_cluster.primary: Creating...
╷
│ Error: googleapi: Error 400: Failed precondition: Constraint `constraints/gcp.restrictNonCmekServices` violated for `projects/427955863992` attempting to create a resource without specifying a KMS CryptoKey.
│ Details:
│ [
│   {
│     "@type": "[type.googleapis.com/google.rpc.RequestInfo](http://type.googleapis.com/google.rpc.RequestInfo)",
│     "requestId": "0x49b9d3b73e2c5556"
│   }
│ ]
│ , failedPrecondition
│
│   with module.environment_cluster.module.cluster.module.gke.google_container_cluster.primary,
│   on .terraform/modules/environment_cluster.cluster.gke/cluster.tf line 22, in resource "google_container_cluster" "primary":
│   22: resource "google_container_cluster" "primary" {
│
```

Unfortunately cannot have enough rights to properly test end to end 