### PR TITLE
feat: add in sole tenant selectors

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -757,9 +757,9 @@ resource "google_container_node_pool" "pools" {
       for_each = lookup(var.node_pools_sole_tenant_selectors, each.value["name"], null) == null ? [] : [1]
       content {
         node_affinity {
-          key = var.node_pools_sole_tenant_selectors[each.value["name"]]["key"]
+          key      = var.node_pools_sole_tenant_selectors[each.value["name"]]["key"]
           operator = var.node_pools_sole_tenant_selectors[each.value["name"]]["operator"]
-          values = var.node_pools_sole_tenant_selectors[each.value["name"]]["values"]
+          values   = var.node_pools_sole_tenant_selectors[each.value["name"]]["values"]
         }
       }
     }

--- a/cluster.tf
+++ b/cluster.tf
@@ -752,6 +752,17 @@ resource "google_container_node_pool" "pools" {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)
     }
+
+    dynamic "sole_tenant_config" {
+      for_each = lookup(var.node_pools_sole_tenant_selectors, each.value["name"], null) == null ? [] : [1]
+      content {
+        node_affinity {
+          key = var.node_pools_sole_tenant_selectors[each.value["name"]]["key"]
+          operator = var.node_pools_sole_tenant_selectors[each.value["name"]]["operator"]
+          values = var.node_pools_sole_tenant_selectors[each.value["name"]]["values"]
+        }
+      }
+    }
   }
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -192,6 +192,16 @@ variable "node_pools_resource_labels" {
   }
 }
 
+variable "node_pools_sole_tenant_selectors" {
+  type        = map(object({ key = optional(string), values = optional(list(string)), operator = optional(string) }))
+  description = "Map of maps containing label selectors for sole tenant nodes"
+
+  default = {
+    all               = {}
+    default-node-pool = {}
+  }
+}
+
 variable "node_pools_resource_manager_tags" {
   type        = map(map(string))
   description = "Map of maps containing resource manager tags by node-pool name"


### PR DESCRIPTION
The goal of this PR is to add sole_tenant support in the node_config of private nodes, similar to how taints current work. It works additive only, and out add the config if someone inputted something like below:

```
...
node_pools_sole_tenant_selectors = {
    "my-node-pool" = {
      key = "compute.googleapis.com/node-group-name"
      operator = "IN"
      values = ["sole-pool-host"]
    }
  }
...
```