### PR TITLE
fix(fleet_app_operator_permissions): optional groups and users

### DIFF
--- a/examples/simple_fleet_app_operator_permissions/main.tf
+++ b/examples/simple_fleet_app_operator_permissions/main.tf
@@ -40,7 +40,6 @@ module "permissions" {
   fleet_project_id = var.fleet_project_id
   scope_id         = google_gke_hub_scope.scope.scope_id
   users            = ["${local.app_operator_id}@${var.fleet_project_id}.iam.gserviceaccount.com"]
-  groups           = []
   role             = local.app_operator_role
 
   depends_on = [

--- a/modules/fleet-app-operator-permissions/README.md
+++ b/modules/fleet-app-operator-permissions/README.md
@@ -29,10 +29,10 @@ To deploy this config, run:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | fleet\_project\_id | The project to which the Fleet belongs. | `string` | n/a | yes |
-| groups | The list of app operator group principals, e.g., `people@google.com`, `principalSet://iam.googleapis.com/locations/global/workforcePools/my-pool/group/people`. | `list(string)` | n/a | yes |
+| groups | The list of app operator group principals, e.g., `people@google.com`, `principalSet://iam.googleapis.com/locations/global/workforcePools/my-pool/group/people`. | `list(string)` | `[]` | no |
 | role | The principals role for the Fleet Scope (`VIEW`/`EDIT`/`ADMIN`). | `string` | n/a | yes |
 | scope\_id | The scope for which IAM and RBAC role bindings are created. | `string` | n/a | yes |
-| users | The list of app operator user principals, e.g., `person@google.com`, `principal://iam.googleapis.com/locations/global/workforcePools/my-pool/subject/person`, `serviceAccount:my-service-account@my-project.iam.gserviceaccount.com`. | `list(string)` | n/a | yes |
+| users | The list of app operator user principals, e.g., `person@google.com`, `principal://iam.googleapis.com/locations/global/workforcePools/my-pool/subject/person`, `serviceAccount:my-service-account@my-project.iam.gserviceaccount.com`. | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/modules/fleet-app-operator-permissions/variables.tf
+++ b/modules/fleet-app-operator-permissions/variables.tf
@@ -27,11 +27,13 @@ variable "scope_id" {
 variable "users" {
   description = "The list of app operator user principals, e.g., `person@google.com`, `principal://iam.googleapis.com/locations/global/workforcePools/my-pool/subject/person`, `serviceAccount:my-service-account@my-project.iam.gserviceaccount.com`."
   type        = list(string)
+  default     = []
 }
 
 variable "groups" {
   description = "The list of app operator group principals, e.g., `people@google.com`, `principalSet://iam.googleapis.com/locations/global/workforcePools/my-pool/group/people`."
   type        = list(string)
+  default     = []
 }
 
 variable "role" {


### PR DESCRIPTION
Enable `groups` and `users` parameters to be optional.