### PR TITLE
fix(autopilot): option to configure gcfs

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -671,6 +671,12 @@ resource "google_container_cluster" "primary" {
     node_config_defaults {
       {% if autopilot_cluster %}
       logging_variant = var.logging_variant
+      dynamic "gcfs_config" {
+        for_each = var.enable_gcfs != null ? [true] : []
+        content {
+          enabled = var.enable_gcfs
+        }
+      }
       {% endif %}
       {% if autopilot_cluster != true %}
       gcfs_config {

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -480,11 +480,6 @@ resource "google_container_cluster" "primary" {
     ignore_changes = [node_pool, initial_node_count, resource_labels["asmv"]]
   }
   {% endif %}
-  {% if autopilot_cluster == true %}
-  lifecycle {
-    ignore_changes = [node_pool_defaults[0].node_config_defaults[0].gcfs_config[0]]
-  }
-  {% endif %}
 
   {% if autopilot_cluster != true %}
   dynamic "dns_config" {

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -941,13 +941,18 @@ variable "sandbox_enabled" {
   description = "(Beta) Enable GKE Sandbox (Do not forget to set `image_type` = `COS_CONTAINERD` to use it)."
   default     = false
 }
+  {% endif %}
 
 variable "enable_gcfs" {
   type        = bool
   description = "(Beta) Enable image streaming on cluster level."
+  {% if autopilot_cluster != true %}
   default     = false
-}
   {% endif %}
+  {% if autopilot_cluster %}
+  default     = null
+  {% endif %}
+}
 {% endif %}
 
 {% if autopilot_cluster != true %}

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -93,6 +93,7 @@ Then perform the following commands on the root folder:
 | enable\_confidential\_nodes | An optional flag to enable confidential node config. | `bool` | `false` | no |
 | enable\_cost\_allocation | Enables Cost Allocation Feature and the cluster name and namespace of your GKE workloads appear in the labels field of the billing export to BigQuery | `bool` | `false` | no |
 | enable\_fqdn\_network\_policy | Enable FQDN Network Policies on the cluster | `bool` | `null` | no |
+| enable\_gcfs | (Beta) Enable image streaming on cluster level. | `bool` | `null` | no |
 | enable\_l4\_ilb\_subsetting | Enable L4 ILB Subsetting on the cluster | `bool` | `false` | no |
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_private\_endpoint | Whether the master's internal IP address is used as the cluster endpoint | `bool` | `false` | no |

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -352,6 +352,12 @@ resource "google_container_cluster" "primary" {
   node_pool_defaults {
     node_config_defaults {
       logging_variant = var.logging_variant
+      dynamic "gcfs_config" {
+        for_each = var.enable_gcfs != null ? [true] : []
+        content {
+          enabled = var.enable_gcfs
+        }
+      }
     }
   }
 

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -261,9 +261,6 @@ resource "google_container_cluster" "primary" {
     }
   }
 
-  lifecycle {
-    ignore_changes = [node_pool_defaults[0].node_config_defaults[0].gcfs_config[0]]
-  }
 
   timeouts {
     create = lookup(var.timeouts, "create", "45m")

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -524,6 +524,12 @@ variable "enable_l4_ilb_subsetting" {
   default     = false
 }
 
+variable "enable_gcfs" {
+  type        = bool
+  description = "(Beta) Enable image streaming on cluster level."
+  default     = null
+}
+
 variable "allow_net_admin" {
   description = "(Optional) Enable NET_ADMIN for the cluster."
   type        = bool

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -86,6 +86,7 @@ Then perform the following commands on the root folder:
 | enable\_confidential\_nodes | An optional flag to enable confidential node config. | `bool` | `false` | no |
 | enable\_cost\_allocation | Enables Cost Allocation Feature and the cluster name and namespace of your GKE workloads appear in the labels field of the billing export to BigQuery | `bool` | `false` | no |
 | enable\_fqdn\_network\_policy | Enable FQDN Network Policies on the cluster | `bool` | `null` | no |
+| enable\_gcfs | (Beta) Enable image streaming on cluster level. | `bool` | `null` | no |
 | enable\_l4\_ilb\_subsetting | Enable L4 ILB Subsetting on the cluster | `bool` | `false` | no |
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -261,9 +261,6 @@ resource "google_container_cluster" "primary" {
     }
   }
 
-  lifecycle {
-    ignore_changes = [node_pool_defaults[0].node_config_defaults[0].gcfs_config[0]]
-  }
 
   timeouts {
     create = lookup(var.timeouts, "create", "45m")

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -331,6 +331,12 @@ resource "google_container_cluster" "primary" {
   node_pool_defaults {
     node_config_defaults {
       logging_variant = var.logging_variant
+      dynamic "gcfs_config" {
+        for_each = var.enable_gcfs != null ? [true] : []
+        content {
+          enabled = var.enable_gcfs
+        }
+      }
     }
   }
 

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -488,6 +488,12 @@ variable "enable_l4_ilb_subsetting" {
   default     = false
 }
 
+variable "enable_gcfs" {
+  type        = bool
+  description = "(Beta) Enable image streaming on cluster level."
+  default     = null
+}
+
 variable "allow_net_admin" {
   description = "(Optional) Enable NET_ADMIN for the cluster."
   type        = bool


### PR DESCRIPTION
This currently plumbs `enable_gcfs` with a default of `null`, however in a future breaking change it will be `true`.