### PR TITLE
fix: skip retrieving engine_versions if kubernetes_version is not latest

### DIFF
--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -49,8 +49,8 @@ locals {
   // for regional cluster - use var.zones if provided, use available otherwise, for zonal cluster use var.zones with first element extracted
   node_locations = var.regional ? coalescelist(compact(var.zones), try(sort(random_shuffle.available_zones[0].result),[])) : slice(var.zones, 1, length(var.zones))
   // Kubernetes version
-  master_version_regional = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.region.latest_master_version
-  master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone.latest_master_version
+  master_version_regional = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.region[0].latest_master_version
+  master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone[0].latest_master_version
   master_version          = var.regional ? local.master_version_regional : local.master_version_zonal
   {% if autopilot_cluster != true %}
   // Build a map of maps of node pools from a list of objects
@@ -255,11 +255,15 @@ locals {
   Get available container engine versions
  *****************************************/
 data "google_container_engine_versions" "region" {
+  count = var.kubernetes_version != "latest" ? 0 : 1
+
   location = local.location
   project  = var.project_id
 }
 
 data "google_container_engine_versions" "zone" {
+  count = var.kubernetes_version != "latest" ? 0 : 1
+
   // Work around to prevent a lack of zone declaration from causing regional cluster creation from erroring out due to error
   //
   //     data.google_container_engine_versions.zone: Cannot determine zone: set in this resource, or set provider-level zone.

--- a/main.tf
+++ b/main.tf
@@ -45,8 +45,8 @@ locals {
   // for regional cluster - use var.zones if provided, use available otherwise, for zonal cluster use var.zones with first element extracted
   node_locations = var.regional ? coalescelist(compact(var.zones), try(sort(random_shuffle.available_zones[0].result), [])) : slice(var.zones, 1, length(var.zones))
   // Kubernetes version
-  master_version_regional = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.region.latest_master_version
-  master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone.latest_master_version
+  master_version_regional = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.region[0].latest_master_version
+  master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone[0].latest_master_version
   master_version          = var.regional ? local.master_version_regional : local.master_version_zonal
   // Build a map of maps of node pools from a list of objects
   node_pool_names         = [for np in toset(var.node_pools) : np.name]
@@ -185,11 +185,15 @@ locals {
   Get available container engine versions
  *****************************************/
 data "google_container_engine_versions" "region" {
+  count = var.kubernetes_version != "latest" ? 0 : 1
+
   location = local.location
   project  = var.project_id
 }
 
 data "google_container_engine_versions" "zone" {
+  count = var.kubernetes_version != "latest" ? 0 : 1
+
   // Work around to prevent a lack of zone declaration from causing regional cluster creation from erroring out due to error
   //
   //     data.google_container_engine_versions.zone: Cannot determine zone: set in this resource, or set provider-level zone.

--- a/modules/beta-autopilot-public-cluster/main.tf
+++ b/modules/beta-autopilot-public-cluster/main.tf
@@ -45,8 +45,8 @@ locals {
   // for regional cluster - use var.zones if provided, use available otherwise, for zonal cluster use var.zones with first element extracted
   node_locations = var.regional ? coalescelist(compact(var.zones), try(sort(random_shuffle.available_zones[0].result), [])) : slice(var.zones, 1, length(var.zones))
   // Kubernetes version
-  master_version_regional = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.region.latest_master_version
-  master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone.latest_master_version
+  master_version_regional = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.region[0].latest_master_version
+  master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone[0].latest_master_version
   master_version          = var.regional ? local.master_version_regional : local.master_version_zonal
 
   fleet_membership = var.fleet_project != null ? google_container_cluster.primary.fleet[0].membership : null
@@ -148,11 +148,15 @@ locals {
   Get available container engine versions
  *****************************************/
 data "google_container_engine_versions" "region" {
+  count = var.kubernetes_version != "latest" ? 0 : 1
+
   location = local.location
   project  = var.project_id
 }
 
 data "google_container_engine_versions" "zone" {
+  count = var.kubernetes_version != "latest" ? 0 : 1
+
   // Work around to prevent a lack of zone declaration from causing regional cluster creation from erroring out due to error
   //
   //     data.google_container_engine_versions.zone: Cannot determine zone: set in this resource, or set provider-level zone.

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -45,8 +45,8 @@ locals {
   // for regional cluster - use var.zones if provided, use available otherwise, for zonal cluster use var.zones with first element extracted
   node_locations = var.regional ? coalescelist(compact(var.zones), try(sort(random_shuffle.available_zones[0].result), [])) : slice(var.zones, 1, length(var.zones))
   // Kubernetes version
-  master_version_regional = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.region.latest_master_version
-  master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone.latest_master_version
+  master_version_regional = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.region[0].latest_master_version
+  master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone[0].latest_master_version
   master_version          = var.regional ? local.master_version_regional : local.master_version_zonal
   // Build a map of maps of node pools from a list of objects
   node_pool_names         = [for np in toset(var.node_pools) : np.name]
@@ -211,11 +211,15 @@ locals {
   Get available container engine versions
  *****************************************/
 data "google_container_engine_versions" "region" {
+  count = var.kubernetes_version != "latest" ? 0 : 1
+
   location = local.location
   project  = var.project_id
 }
 
 data "google_container_engine_versions" "zone" {
+  count = var.kubernetes_version != "latest" ? 0 : 1
+
   // Work around to prevent a lack of zone declaration from causing regional cluster creation from erroring out due to error
   //
   //     data.google_container_engine_versions.zone: Cannot determine zone: set in this resource, or set provider-level zone.

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -45,8 +45,8 @@ locals {
   // for regional cluster - use var.zones if provided, use available otherwise, for zonal cluster use var.zones with first element extracted
   node_locations = var.regional ? coalescelist(compact(var.zones), try(sort(random_shuffle.available_zones[0].result), [])) : slice(var.zones, 1, length(var.zones))
   // Kubernetes version
-  master_version_regional = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.region.latest_master_version
-  master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone.latest_master_version
+  master_version_regional = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.region[0].latest_master_version
+  master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone[0].latest_master_version
   master_version          = var.regional ? local.master_version_regional : local.master_version_zonal
   // Build a map of maps of node pools from a list of objects
   node_pool_names         = [for np in toset(var.node_pools) : np.name]
@@ -211,11 +211,15 @@ locals {
   Get available container engine versions
  *****************************************/
 data "google_container_engine_versions" "region" {
+  count = var.kubernetes_version != "latest" ? 0 : 1
+
   location = local.location
   project  = var.project_id
 }
 
 data "google_container_engine_versions" "zone" {
+  count = var.kubernetes_version != "latest" ? 0 : 1
+
   // Work around to prevent a lack of zone declaration from causing regional cluster creation from erroring out due to error
   //
   //     data.google_container_engine_versions.zone: Cannot determine zone: set in this resource, or set provider-level zone.

--- a/modules/beta-public-cluster-update-variant/main.tf
+++ b/modules/beta-public-cluster-update-variant/main.tf
@@ -45,8 +45,8 @@ locals {
   // for regional cluster - use var.zones if provided, use available otherwise, for zonal cluster use var.zones with first element extracted
   node_locations = var.regional ? coalescelist(compact(var.zones), try(sort(random_shuffle.available_zones[0].result), [])) : slice(var.zones, 1, length(var.zones))
   // Kubernetes version
-  master_version_regional = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.region.latest_master_version
-  master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone.latest_master_version
+  master_version_regional = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.region[0].latest_master_version
+  master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone[0].latest_master_version
   master_version          = var.regional ? local.master_version_regional : local.master_version_zonal
   // Build a map of maps of node pools from a list of objects
   node_pool_names         = [for np in toset(var.node_pools) : np.name]
@@ -210,11 +210,15 @@ locals {
   Get available container engine versions
  *****************************************/
 data "google_container_engine_versions" "region" {
+  count = var.kubernetes_version != "latest" ? 0 : 1
+
   location = local.location
   project  = var.project_id
 }
 
 data "google_container_engine_versions" "zone" {
+  count = var.kubernetes_version != "latest" ? 0 : 1
+
   // Work around to prevent a lack of zone declaration from causing regional cluster creation from erroring out due to error
   //
   //     data.google_container_engine_versions.zone: Cannot determine zone: set in this resource, or set provider-level zone.

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -45,8 +45,8 @@ locals {
   // for regional cluster - use var.zones if provided, use available otherwise, for zonal cluster use var.zones with first element extracted
   node_locations = var.regional ? coalescelist(compact(var.zones), try(sort(random_shuffle.available_zones[0].result), [])) : slice(var.zones, 1, length(var.zones))
   // Kubernetes version
-  master_version_regional = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.region.latest_master_version
-  master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone.latest_master_version
+  master_version_regional = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.region[0].latest_master_version
+  master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone[0].latest_master_version
   master_version          = var.regional ? local.master_version_regional : local.master_version_zonal
   // Build a map of maps of node pools from a list of objects
   node_pool_names         = [for np in toset(var.node_pools) : np.name]
@@ -210,11 +210,15 @@ locals {
   Get available container engine versions
  *****************************************/
 data "google_container_engine_versions" "region" {
+  count = var.kubernetes_version != "latest" ? 0 : 1
+
   location = local.location
   project  = var.project_id
 }
 
 data "google_container_engine_versions" "zone" {
+  count = var.kubernetes_version != "latest" ? 0 : 1
+
   // Work around to prevent a lack of zone declaration from causing regional cluster creation from erroring out due to error
   //
   //     data.google_container_engine_versions.zone: Cannot determine zone: set in this resource, or set provider-level zone.

--- a/modules/private-cluster-update-variant/main.tf
+++ b/modules/private-cluster-update-variant/main.tf
@@ -45,8 +45,8 @@ locals {
   // for regional cluster - use var.zones if provided, use available otherwise, for zonal cluster use var.zones with first element extracted
   node_locations = var.regional ? coalescelist(compact(var.zones), try(sort(random_shuffle.available_zones[0].result), [])) : slice(var.zones, 1, length(var.zones))
   // Kubernetes version
-  master_version_regional = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.region.latest_master_version
-  master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone.latest_master_version
+  master_version_regional = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.region[0].latest_master_version
+  master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone[0].latest_master_version
   master_version          = var.regional ? local.master_version_regional : local.master_version_zonal
   // Build a map of maps of node pools from a list of objects
   node_pool_names         = [for np in toset(var.node_pools) : np.name]
@@ -186,11 +186,15 @@ locals {
   Get available container engine versions
  *****************************************/
 data "google_container_engine_versions" "region" {
+  count = var.kubernetes_version != "latest" ? 0 : 1
+
   location = local.location
   project  = var.project_id
 }
 
 data "google_container_engine_versions" "zone" {
+  count = var.kubernetes_version != "latest" ? 0 : 1
+
   // Work around to prevent a lack of zone declaration from causing regional cluster creation from erroring out due to error
   //
   //     data.google_container_engine_versions.zone: Cannot determine zone: set in this resource, or set provider-level zone.

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -45,8 +45,8 @@ locals {
   // for regional cluster - use var.zones if provided, use available otherwise, for zonal cluster use var.zones with first element extracted
   node_locations = var.regional ? coalescelist(compact(var.zones), try(sort(random_shuffle.available_zones[0].result), [])) : slice(var.zones, 1, length(var.zones))
   // Kubernetes version
-  master_version_regional = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.region.latest_master_version
-  master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone.latest_master_version
+  master_version_regional = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.region[0].latest_master_version
+  master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone[0].latest_master_version
   master_version          = var.regional ? local.master_version_regional : local.master_version_zonal
   // Build a map of maps of node pools from a list of objects
   node_pool_names         = [for np in toset(var.node_pools) : np.name]
@@ -186,11 +186,15 @@ locals {
   Get available container engine versions
  *****************************************/
 data "google_container_engine_versions" "region" {
+  count = var.kubernetes_version != "latest" ? 0 : 1
+
   location = local.location
   project  = var.project_id
 }
 
 data "google_container_engine_versions" "zone" {
+  count = var.kubernetes_version != "latest" ? 0 : 1
+
   // Work around to prevent a lack of zone declaration from causing regional cluster creation from erroring out due to error
   //
   //     data.google_container_engine_versions.zone: Cannot determine zone: set in this resource, or set provider-level zone.


### PR DESCRIPTION
### Summary / TL;DR 🎯
There's no need to fetch available container engine versions when `var.kubernetes_version` is explicitly defined. 
Updates data blocks so we only retrieve engine versions when `var.kubernetes_version` is set to `"latest"`. 

---

### Added Context 📃 
We've noticed a planning issue when we try to create a GKE cluster, but the GCP project it's going to be created in doesn't exist yet i.e. we're creating a GKE cluster and it's host GCP project as part of the same plan.

Retrieving `data.google_container_engine_versions.region.latest_master_version` or `data.google_container_engine_versions.zone.latest_master_version` fails because they both rely on the host `var.project_id` existing to work. Buuuut if you're creating the cluster and project as part of the same plan, this won't be the case at plan time.

Counter-intuitively though, we still get this planning error even if we explicitly set a `var.kubernetes_version`, even though we shouldn't _really_ need to retrieve all available container engine versions at that point. This PR address that by only creating the data blocks when we need to fetch the 'latest' `var.kubernetes_version`

### Personal notes / thoughts 💭 

In an ideal world though, we probably shouldn't need to rely on this (which admittedly feels somewhat like a workaround), and instead have some way to fetch all container versions that doesn't really on the host project existing first? 

The `var.project_id` is a little problematic here since it's also what we feed into the `data.google_container_engine_versions.region.latest_master_version`/`data.google_container_engine_versions.zone.latest_master_version` blocks, and we don't have a way to pass in a different project id to use for fetching `google_container_engine_versions` :/ 

But fixing that might be out of scope of what this PR is trying to address re. when we already know what k8 version we want