### PR TITLE
fix: avoid TPG v6.2.0 with Autopilot

### DIFF
--- a/autogen/main/versions.tf.tmpl
+++ b/autogen/main/versions.tf.tmpl
@@ -47,12 +47,12 @@ terraform {
     google = {
       source = "hashicorp/google"
       # Workaround for https://github.com/hashicorp/terraform-provider-google/issues/19428
-      version = ">= 5.40.0, != 5.44.0, < 7"
+      version = ">= 5.40.0, != 5.44.0, != 6.2.0, < 7"
     }
     google-beta = {
       source = "hashicorp/google-beta"
       # Workaround for https://github.com/hashicorp/terraform-provider-google/issues/19428
-      version = ">= 5.40.0, != 5.44.0, < 7"
+      version = ">= 5.40.0, != 5.44.0, != 6.2.0, < 7"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -71,7 +71,7 @@ terraform {
     google = {
       source = "hashicorp/google"
       # Workaround for https://github.com/hashicorp/terraform-provider-google/issues/19428
-      version = ">= 5.40.0, != 5.44.0, < 7"
+      version = ">= 5.40.0, != 5.44.0, != 6.2.0, < 7"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-autopilot-private-cluster/versions.tf
+++ b/modules/beta-autopilot-private-cluster/versions.tf
@@ -22,12 +22,12 @@ terraform {
     google = {
       source = "hashicorp/google"
       # Workaround for https://github.com/hashicorp/terraform-provider-google/issues/19428
-      version = ">= 5.40.0, != 5.44.0, < 7"
+      version = ">= 5.40.0, != 5.44.0, != 6.2.0, < 7"
     }
     google-beta = {
       source = "hashicorp/google-beta"
       # Workaround for https://github.com/hashicorp/terraform-provider-google/issues/19428
-      version = ">= 5.40.0, != 5.44.0, < 7"
+      version = ">= 5.40.0, != 5.44.0, != 6.2.0, < 7"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-autopilot-public-cluster/versions.tf
+++ b/modules/beta-autopilot-public-cluster/versions.tf
@@ -22,12 +22,12 @@ terraform {
     google = {
       source = "hashicorp/google"
       # Workaround for https://github.com/hashicorp/terraform-provider-google/issues/19428
-      version = ">= 5.40.0, != 5.44.0, < 7"
+      version = ">= 5.40.0, != 5.44.0, != 6.2.0, < 7"
     }
     google-beta = {
       source = "hashicorp/google-beta"
       # Workaround for https://github.com/hashicorp/terraform-provider-google/issues/19428
-      version = ">= 5.40.0, != 5.44.0, < 7"
+      version = ">= 5.40.0, != 5.44.0, != 6.2.0, < 7"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
Workaround: https://github.com/hashicorp/terraform-provider-google/issues/19428