### PR TITLE
feat: added confidential-nodes flag for node-pools

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -597,7 +597,7 @@ resource "google_container_cluster" "primary" {
     content {
       enable_private_endpoint     = private_cluster_config.value.enable_private_endpoint
       enable_private_nodes        = private_cluster_config.value.enable_private_nodes
-      master_ipv4_cidr_block      = private_cluster_config.value.master_ipv4_cidr_block
+      master_ipv4_cidr_block      = var.private_endpoint_subnetwork == null ? private_cluster_config.value.master_ipv4_cidr_block : null
       private_endpoint_subnetwork = private_cluster_config.value.private_endpoint_subnetwork
       dynamic "master_global_access_config" {
         for_each = var.master_global_access_enabled ? [var.master_global_access_enabled] : []

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -720,7 +720,8 @@ locals {
     "enable_confidential_storage",
     "consume_reservation_type",
     "reservation_affinity_key",
-    "reservation_affinity_values"
+    "reservation_affinity_values",
+    "enable_confidential_nodes",
   ]
 }
 
@@ -1084,6 +1085,14 @@ resource "google_container_node_pool" "windows_pools" {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)
     }
+
+    dynamic "confidential_nodes" {
+      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      content {
+        enabled = confidential_nodes.value
+      }
+    }
+
   }
 
   lifecycle {

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -1087,7 +1087,7 @@ resource "google_container_node_pool" "windows_pools" {
     }
 
     dynamic "confidential_nodes" {
-      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      for_each = lookup(each.value, "enable_confidential_nodes", null) != null ? [each.value.confidential_nodes] : []
       content {
         enabled = confidential_nodes.value
       }

--- a/cluster.tf
+++ b/cluster.tf
@@ -773,7 +773,7 @@ resource "google_container_node_pool" "pools" {
     }
 
     dynamic "confidential_nodes" {
-      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      for_each = lookup(each.value, "enable_confidential_nodes", null) != null ? [each.value.confidential_nodes] : []
       content {
         enabled = confidential_nodes.value
       }
@@ -1048,7 +1048,7 @@ resource "google_container_node_pool" "windows_pools" {
     }
 
     dynamic "confidential_nodes" {
-      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      for_each = lookup(each.value, "enable_confidential_nodes", null) != null ? [each.value.confidential_nodes] : []
       content {
         enabled = confidential_nodes.value
       }

--- a/cluster.tf
+++ b/cluster.tf
@@ -771,6 +771,14 @@ resource "google_container_node_pool" "pools" {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)
     }
+
+    dynamic "confidential_nodes" {
+      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      content {
+        enabled = confidential_nodes.value
+      }
+    }
+
   }
 
   lifecycle {
@@ -1038,6 +1046,14 @@ resource "google_container_node_pool" "windows_pools" {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)
     }
+
+    dynamic "confidential_nodes" {
+      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      content {
+        enabled = confidential_nodes.value
+      }
+    }
+
   }
 
   lifecycle {

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -295,7 +295,7 @@ resource "google_container_cluster" "primary" {
     content {
       enable_private_endpoint     = private_cluster_config.value.enable_private_endpoint
       enable_private_nodes        = private_cluster_config.value.enable_private_nodes
-      master_ipv4_cidr_block      = private_cluster_config.value.master_ipv4_cidr_block
+      master_ipv4_cidr_block      = var.private_endpoint_subnetwork == null ? private_cluster_config.value.master_ipv4_cidr_block : null
       private_endpoint_subnetwork = private_cluster_config.value.private_endpoint_subnetwork
       dynamic "master_global_access_config" {
         for_each = var.master_global_access_enabled ? [var.master_global_access_enabled] : []

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -616,7 +616,8 @@ locals {
     "enable_confidential_storage",
     "consume_reservation_type",
     "reservation_affinity_key",
-    "reservation_affinity_values"
+    "reservation_affinity_values",
+    "enable_confidential_nodes",
   ]
 }
 
@@ -951,6 +952,14 @@ resource "google_container_node_pool" "pools" {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)
     }
+
+    dynamic "confidential_nodes" {
+      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      content {
+        enabled = confidential_nodes.value
+      }
+    }
+
   }
 
   lifecycle {
@@ -1232,6 +1241,14 @@ resource "google_container_node_pool" "windows_pools" {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)
     }
+
+    dynamic "confidential_nodes" {
+      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      content {
+        enabled = confidential_nodes.value
+      }
+    }
+
   }
 
   lifecycle {

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -954,7 +954,7 @@ resource "google_container_node_pool" "pools" {
     }
 
     dynamic "confidential_nodes" {
-      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      for_each = lookup(each.value, "enable_confidential_nodes", null) != null ? [each.value.confidential_nodes] : []
       content {
         enabled = confidential_nodes.value
       }
@@ -1243,7 +1243,7 @@ resource "google_container_node_pool" "windows_pools" {
     }
 
     dynamic "confidential_nodes" {
-      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      for_each = lookup(each.value, "enable_confidential_nodes", null) != null ? [each.value.confidential_nodes] : []
       content {
         enabled = confidential_nodes.value
       }

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -516,7 +516,7 @@ resource "google_container_cluster" "primary" {
     content {
       enable_private_endpoint     = private_cluster_config.value.enable_private_endpoint
       enable_private_nodes        = private_cluster_config.value.enable_private_nodes
-      master_ipv4_cidr_block      = private_cluster_config.value.master_ipv4_cidr_block
+      master_ipv4_cidr_block      = var.private_endpoint_subnetwork == null ? private_cluster_config.value.master_ipv4_cidr_block : null
       private_endpoint_subnetwork = private_cluster_config.value.private_endpoint_subnetwork
       dynamic "master_global_access_config" {
         for_each = var.master_global_access_enabled ? [var.master_global_access_enabled] : []

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -869,6 +869,14 @@ resource "google_container_node_pool" "pools" {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)
     }
+
+    dynamic "confidential_nodes" {
+      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      content {
+        enabled = confidential_nodes.value
+      }
+    }
+
   }
 
   lifecycle {
@@ -1149,6 +1157,14 @@ resource "google_container_node_pool" "windows_pools" {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)
     }
+
+    dynamic "confidential_nodes" {
+      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      content {
+        enabled = confidential_nodes.value
+      }
+    }
+
   }
 
   lifecycle {

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -871,7 +871,7 @@ resource "google_container_node_pool" "pools" {
     }
 
     dynamic "confidential_nodes" {
-      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      for_each = lookup(each.value, "enable_confidential_nodes", null) != null ? [each.value.confidential_nodes] : []
       content {
         enabled = confidential_nodes.value
       }
@@ -1159,7 +1159,7 @@ resource "google_container_node_pool" "windows_pools" {
     }
 
     dynamic "confidential_nodes" {
-      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      for_each = lookup(each.value, "enable_confidential_nodes", null) != null ? [each.value.confidential_nodes] : []
       content {
         enabled = confidential_nodes.value
       }

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -516,7 +516,7 @@ resource "google_container_cluster" "primary" {
     content {
       enable_private_endpoint     = private_cluster_config.value.enable_private_endpoint
       enable_private_nodes        = private_cluster_config.value.enable_private_nodes
-      master_ipv4_cidr_block      = private_cluster_config.value.master_ipv4_cidr_block
+      master_ipv4_cidr_block      = var.private_endpoint_subnetwork == null ? private_cluster_config.value.master_ipv4_cidr_block : null
       private_endpoint_subnetwork = private_cluster_config.value.private_endpoint_subnetwork
       dynamic "master_global_access_config" {
         for_each = var.master_global_access_enabled ? [var.master_global_access_enabled] : []

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -595,7 +595,8 @@ locals {
     "enable_confidential_storage",
     "consume_reservation_type",
     "reservation_affinity_key",
-    "reservation_affinity_values"
+    "reservation_affinity_values",
+    "enable_confidential_nodes",
   ]
 }
 
@@ -930,6 +931,14 @@ resource "google_container_node_pool" "pools" {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)
     }
+
+    dynamic "confidential_nodes" {
+      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      content {
+        enabled = confidential_nodes.value
+      }
+    }
+
   }
 
   lifecycle {
@@ -1211,6 +1220,14 @@ resource "google_container_node_pool" "windows_pools" {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)
     }
+
+    dynamic "confidential_nodes" {
+      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      content {
+        enabled = confidential_nodes.value
+      }
+    }
+
   }
 
   lifecycle {

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -933,7 +933,7 @@ resource "google_container_node_pool" "pools" {
     }
 
     dynamic "confidential_nodes" {
-      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      for_each = lookup(each.value, "enable_confidential_nodes", null) != null ? [each.value.confidential_nodes] : []
       content {
         enabled = confidential_nodes.value
       }
@@ -1222,7 +1222,7 @@ resource "google_container_node_pool" "windows_pools" {
     }
 
     dynamic "confidential_nodes" {
-      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      for_each = lookup(each.value, "enable_confidential_nodes", null) != null ? [each.value.confidential_nodes] : []
       content {
         enabled = confidential_nodes.value
       }

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -850,7 +850,7 @@ resource "google_container_node_pool" "pools" {
     }
 
     dynamic "confidential_nodes" {
-      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      for_each = lookup(each.value, "enable_confidential_nodes", null) != null ? [each.value.confidential_nodes] : []
       content {
         enabled = confidential_nodes.value
       }
@@ -1138,7 +1138,7 @@ resource "google_container_node_pool" "windows_pools" {
     }
 
     dynamic "confidential_nodes" {
-      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      for_each = lookup(each.value, "enable_confidential_nodes", null) != null ? [each.value.confidential_nodes] : []
       content {
         enabled = confidential_nodes.value
       }

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -848,6 +848,14 @@ resource "google_container_node_pool" "pools" {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)
     }
+
+    dynamic "confidential_nodes" {
+      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      content {
+        enabled = confidential_nodes.value
+      }
+    }
+
   }
 
   lifecycle {
@@ -1128,6 +1136,14 @@ resource "google_container_node_pool" "windows_pools" {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)
     }
+
+    dynamic "confidential_nodes" {
+      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      content {
+        enabled = confidential_nodes.value
+      }
+    }
+
   }
 
   lifecycle {

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -462,7 +462,7 @@ resource "google_container_cluster" "primary" {
     content {
       enable_private_endpoint     = private_cluster_config.value.enable_private_endpoint
       enable_private_nodes        = private_cluster_config.value.enable_private_nodes
-      master_ipv4_cidr_block      = private_cluster_config.value.master_ipv4_cidr_block
+      master_ipv4_cidr_block      = var.private_endpoint_subnetwork == null ? private_cluster_config.value.master_ipv4_cidr_block : null
       private_endpoint_subnetwork = private_cluster_config.value.private_endpoint_subnetwork
       dynamic "master_global_access_config" {
         for_each = var.master_global_access_enabled ? [var.master_global_access_enabled] : []

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -552,7 +552,8 @@ locals {
     "enable_confidential_storage",
     "consume_reservation_type",
     "reservation_affinity_key",
-    "reservation_affinity_values"
+    "reservation_affinity_values",
+    "enable_confidential_nodes",
   ]
 }
 
@@ -874,6 +875,14 @@ resource "google_container_node_pool" "pools" {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)
     }
+
+    dynamic "confidential_nodes" {
+      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      content {
+        enabled = confidential_nodes.value
+      }
+    }
+
   }
 
   lifecycle {
@@ -1142,6 +1151,14 @@ resource "google_container_node_pool" "windows_pools" {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)
     }
+
+    dynamic "confidential_nodes" {
+      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      content {
+        enabled = confidential_nodes.value
+      }
+    }
+
   }
 
   lifecycle {

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -877,7 +877,7 @@ resource "google_container_node_pool" "pools" {
     }
 
     dynamic "confidential_nodes" {
-      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      for_each = lookup(each.value, "enable_confidential_nodes", null) != null ? [each.value.confidential_nodes] : []
       content {
         enabled = confidential_nodes.value
       }
@@ -1153,7 +1153,7 @@ resource "google_container_node_pool" "windows_pools" {
     }
 
     dynamic "confidential_nodes" {
-      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      for_each = lookup(each.value, "enable_confidential_nodes", null) != null ? [each.value.confidential_nodes] : []
       content {
         enabled = confidential_nodes.value
       }

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -792,6 +792,14 @@ resource "google_container_node_pool" "pools" {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)
     }
+
+    dynamic "confidential_nodes" {
+      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      content {
+        enabled = confidential_nodes.value
+      }
+    }
+
   }
 
   lifecycle {
@@ -1059,6 +1067,14 @@ resource "google_container_node_pool" "windows_pools" {
       enable_secure_boot          = lookup(each.value, "enable_secure_boot", false)
       enable_integrity_monitoring = lookup(each.value, "enable_integrity_monitoring", true)
     }
+
+    dynamic "confidential_nodes" {
+      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      content {
+        enabled = confidential_nodes.value
+      }
+    }
+
   }
 
   lifecycle {

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -794,7 +794,7 @@ resource "google_container_node_pool" "pools" {
     }
 
     dynamic "confidential_nodes" {
-      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      for_each = lookup(each.value, "enable_confidential_nodes", null) != null ? [each.value.confidential_nodes] : []
       content {
         enabled = confidential_nodes.value
       }
@@ -1069,7 +1069,7 @@ resource "google_container_node_pool" "windows_pools" {
     }
 
     dynamic "confidential_nodes" {
-      for_each = lookup(each.value, "enable_confidential_nodes", false) ? [true] : []
+      for_each = lookup(each.value, "enable_confidential_nodes", null) != null ? [each.value.confidential_nodes] : []
       content {
         enabled = confidential_nodes.value
       }

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -462,7 +462,7 @@ resource "google_container_cluster" "primary" {
     content {
       enable_private_endpoint     = private_cluster_config.value.enable_private_endpoint
       enable_private_nodes        = private_cluster_config.value.enable_private_nodes
-      master_ipv4_cidr_block      = private_cluster_config.value.master_ipv4_cidr_block
+      master_ipv4_cidr_block      = var.private_endpoint_subnetwork == null ? private_cluster_config.value.master_ipv4_cidr_block : null
       private_endpoint_subnetwork = private_cluster_config.value.private_endpoint_subnetwork
       dynamic "master_global_access_config" {
         for_each = var.master_global_access_enabled ? [var.master_global_access_enabled] : []


### PR DESCRIPTION
_**Motivation**_
The current set of confidential node support is available only at the cluster level, but the confidential node support at the node level is required to have new node pools created with confidential nodes.

_**Summary of changes**_
Added `enable_confidential_nodes` variable at the node pool level.

**_P.S_**: This is addressing the issue https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1386 and has same changes as that of the PR https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/1756. As the PR author has not responded for the review comments, I'm thus creating a fresh PR as this feature is needed at the earliest.

Fixes: #1386
Closes: #1756