### PR TITLE
fix: allow null `enable_gcfs` setting in defined nodepools

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -887,7 +887,7 @@ resource "google_container_node_pool" "windows_pools" {
     min_cpu_platform            = lookup(each.value, "min_cpu_platform", "")
     enable_confidential_storage = lookup(each.value, "enable_confidential_storage", false)
     dynamic "gcfs_config" {
-        for_each = lookup(each.value, "enable_gcfs", false) ? [true] : [false]
+        for_each = lookup(each.value, "enable_gcfs", null ) !=null ? [each.value.enable_gcfs] : []
         content {
           enabled = gcfs_config.value
         }

--- a/cluster.tf
+++ b/cluster.tf
@@ -593,7 +593,7 @@ resource "google_container_node_pool" "pools" {
     min_cpu_platform            = lookup(each.value, "min_cpu_platform", "")
     enable_confidential_storage = lookup(each.value, "enable_confidential_storage", false)
     dynamic "gcfs_config" {
-      for_each = lookup(each.value, "enable_gcfs", false) ? [true] : [false]
+      for_each = lookup(each.value, "enable_gcfs", null) != null ? [each.value.enable_gcfs] : []
       content {
         enabled = gcfs_config.value
       }
@@ -875,7 +875,7 @@ resource "google_container_node_pool" "windows_pools" {
     min_cpu_platform            = lookup(each.value, "min_cpu_platform", "")
     enable_confidential_storage = lookup(each.value, "enable_confidential_storage", false)
     dynamic "gcfs_config" {
-      for_each = lookup(each.value, "enable_gcfs", false) ? [true] : [false]
+      for_each = lookup(each.value, "enable_gcfs", null) != null ? [each.value.enable_gcfs] : []
       content {
         enabled = gcfs_config.value
       }

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -760,7 +760,7 @@ resource "google_container_node_pool" "pools" {
     min_cpu_platform            = lookup(each.value, "min_cpu_platform", "")
     enable_confidential_storage = lookup(each.value, "enable_confidential_storage", false)
     dynamic "gcfs_config" {
-      for_each = lookup(each.value, "enable_gcfs", false) ? [true] : [false]
+      for_each = lookup(each.value, "enable_gcfs", null) != null ? [each.value.enable_gcfs] : []
       content {
         enabled = gcfs_config.value
       }
@@ -1056,7 +1056,7 @@ resource "google_container_node_pool" "windows_pools" {
     min_cpu_platform            = lookup(each.value, "min_cpu_platform", "")
     enable_confidential_storage = lookup(each.value, "enable_confidential_storage", false)
     dynamic "gcfs_config" {
-      for_each = lookup(each.value, "enable_gcfs", false) ? [true] : [false]
+      for_each = lookup(each.value, "enable_gcfs", null) != null ? [each.value.enable_gcfs] : []
       content {
         enabled = gcfs_config.value
       }

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -678,7 +678,7 @@ resource "google_container_node_pool" "pools" {
     min_cpu_platform            = lookup(each.value, "min_cpu_platform", "")
     enable_confidential_storage = lookup(each.value, "enable_confidential_storage", false)
     dynamic "gcfs_config" {
-      for_each = lookup(each.value, "enable_gcfs", false) ? [true] : [false]
+      for_each = lookup(each.value, "enable_gcfs", null) != null ? [each.value.enable_gcfs] : []
       content {
         enabled = gcfs_config.value
       }
@@ -973,7 +973,7 @@ resource "google_container_node_pool" "windows_pools" {
     min_cpu_platform            = lookup(each.value, "min_cpu_platform", "")
     enable_confidential_storage = lookup(each.value, "enable_confidential_storage", false)
     dynamic "gcfs_config" {
-      for_each = lookup(each.value, "enable_gcfs", false) ? [true] : [false]
+      for_each = lookup(each.value, "enable_gcfs", null) != null ? [each.value.enable_gcfs] : []
       content {
         enabled = gcfs_config.value
       }

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -739,7 +739,7 @@ resource "google_container_node_pool" "pools" {
     min_cpu_platform            = lookup(each.value, "min_cpu_platform", "")
     enable_confidential_storage = lookup(each.value, "enable_confidential_storage", false)
     dynamic "gcfs_config" {
-      for_each = lookup(each.value, "enable_gcfs", false) ? [true] : [false]
+      for_each = lookup(each.value, "enable_gcfs", null) != null ? [each.value.enable_gcfs] : []
       content {
         enabled = gcfs_config.value
       }
@@ -1035,7 +1035,7 @@ resource "google_container_node_pool" "windows_pools" {
     min_cpu_platform            = lookup(each.value, "min_cpu_platform", "")
     enable_confidential_storage = lookup(each.value, "enable_confidential_storage", false)
     dynamic "gcfs_config" {
-      for_each = lookup(each.value, "enable_gcfs", false) ? [true] : [false]
+      for_each = lookup(each.value, "enable_gcfs", null) != null ? [each.value.enable_gcfs] : []
       content {
         enabled = gcfs_config.value
       }

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -657,7 +657,7 @@ resource "google_container_node_pool" "pools" {
     min_cpu_platform            = lookup(each.value, "min_cpu_platform", "")
     enable_confidential_storage = lookup(each.value, "enable_confidential_storage", false)
     dynamic "gcfs_config" {
-      for_each = lookup(each.value, "enable_gcfs", false) ? [true] : [false]
+      for_each = lookup(each.value, "enable_gcfs", null) != null ? [each.value.enable_gcfs] : []
       content {
         enabled = gcfs_config.value
       }
@@ -952,7 +952,7 @@ resource "google_container_node_pool" "windows_pools" {
     min_cpu_platform            = lookup(each.value, "min_cpu_platform", "")
     enable_confidential_storage = lookup(each.value, "enable_confidential_storage", false)
     dynamic "gcfs_config" {
-      for_each = lookup(each.value, "enable_gcfs", false) ? [true] : [false]
+      for_each = lookup(each.value, "enable_gcfs", null) != null ? [each.value.enable_gcfs] : []
       content {
         enabled = gcfs_config.value
       }

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -696,7 +696,7 @@ resource "google_container_node_pool" "pools" {
     min_cpu_platform            = lookup(each.value, "min_cpu_platform", "")
     enable_confidential_storage = lookup(each.value, "enable_confidential_storage", false)
     dynamic "gcfs_config" {
-      for_each = lookup(each.value, "enable_gcfs", false) ? [true] : [false]
+      for_each = lookup(each.value, "enable_gcfs", null) != null ? [each.value.enable_gcfs] : []
       content {
         enabled = gcfs_config.value
       }
@@ -979,7 +979,7 @@ resource "google_container_node_pool" "windows_pools" {
     min_cpu_platform            = lookup(each.value, "min_cpu_platform", "")
     enable_confidential_storage = lookup(each.value, "enable_confidential_storage", false)
     dynamic "gcfs_config" {
-      for_each = lookup(each.value, "enable_gcfs", false) ? [true] : [false]
+      for_each = lookup(each.value, "enable_gcfs", null) != null ? [each.value.enable_gcfs] : []
       content {
         enabled = gcfs_config.value
       }

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -614,7 +614,7 @@ resource "google_container_node_pool" "pools" {
     min_cpu_platform            = lookup(each.value, "min_cpu_platform", "")
     enable_confidential_storage = lookup(each.value, "enable_confidential_storage", false)
     dynamic "gcfs_config" {
-      for_each = lookup(each.value, "enable_gcfs", false) ? [true] : [false]
+      for_each = lookup(each.value, "enable_gcfs", null) != null ? [each.value.enable_gcfs] : []
       content {
         enabled = gcfs_config.value
       }
@@ -896,7 +896,7 @@ resource "google_container_node_pool" "windows_pools" {
     min_cpu_platform            = lookup(each.value, "min_cpu_platform", "")
     enable_confidential_storage = lookup(each.value, "enable_confidential_storage", false)
     dynamic "gcfs_config" {
-      for_each = lookup(each.value, "enable_gcfs", false) ? [true] : [false]
+      for_each = lookup(each.value, "enable_gcfs", null) != null ? [each.value.enable_gcfs] : []
       content {
         enabled = gcfs_config.value
       }

--- a/test/integration/private_zonal_with_networking/testdata/TestPrivateZonalWithNetworking.json
+++ b/test/integration/private_zonal_with_networking/testdata/TestPrivateZonalWithNetworking.json
@@ -210,7 +210,6 @@
       "config": {
         "diskSizeGb": 100,
         "diskType": "pd-standard",
-        "gcfsConfig": {},
         "imageType": "COS_CONTAINERD",
         "labels": {
           "cluster_name": "CLUSTER_NAME",


### PR DESCRIPTION
Even with 6.4.0 or 5.44.1 (with my upstream fix), I am still seeing the issue described in #2100, since the earlier fixes were related to the default node-pool vs explicitly defined ones.

Fixes #2100
This basically replicates the fixes from #2093, #2095, but at the scope of implicitly defined nodepools.