### PR TITLE
chore: update kitchen config

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,6 +20,7 @@ provisioner:
   name: "terraform"
 
 transport:
+  name: "terraform"
   command_timeout: 2700
 
 verifier:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,11 +14,13 @@
 ---
 driver:
   name: "terraform"
-  command_timeout: 2700
   verify_version: false
 
 provisioner:
   name: "terraform"
+
+transport:
+  command_timeout: 2700
 
 verifier:
   name: terraform
@@ -30,14 +32,14 @@ platforms:
 
 suites:
   - name: "shared_vpc"
-    driver:
+    transport:
       root_module_directory: test/fixtures/shared_vpc
     verifier:
       systems:
         - name: shared_vpc
           backend: local
   - name: "safer_cluster"
-    driver:
+    transport:
       root_module_directory: test/fixtures/safer_cluster
     verifier:
       systems:
@@ -50,14 +52,14 @@ suites:
           controls:
             - network
   - name: "simple_regional"
-    driver:
+    transport:
       root_module_directory: test/fixtures/simple_regional
     verifier:
       systems:
         - name: simple_regional
           backend: local
   - name: "simple_regional_with_networking"
-    driver:
+    transport:
       root_module_directory: test/fixtures/simple_regional_with_networking
     verifier:
       systems:
@@ -74,35 +76,35 @@ suites:
           controls:
             - network
   - name: "simple_regional_private"
-    driver:
+    transport:
       root_module_directory: test/fixtures/simple_regional_private
     verifier:
       systems:
         - name: simple_regional_private
           backend: local
   - name: "simple_regional_with_gateway_api"
-    driver:
+    transport:
       root_module_directory: test/fixtures/simple_regional_with_gateway_api
     verifier:
       systems:
         - name: simple_regional_with_gateway_api
           backend: local
   - name: "simple_regional_with_ipv6"
-    driver:
+    transport:
       root_module_directory: test/fixtures/simple_regional_with_ipv6
     verifier:
       systems:
         - name: simple_regional_with_ipv6
           backend: local
   - name: "simple_regional_with_kubeconfig"
-    driver:
+    transport:
       root_module_directory: test/fixtures/simple_regional_with_kubeconfig
     verifier:
       systems:
         - name: simple_regional_with_kubeconfig
           backend: local
   - name: "simple_zonal"
-    driver:
+    transport:
       root_module_directory: test/fixtures/simple_zonal
     verifier:
       systems:
@@ -116,7 +118,7 @@ suites:
           controls:
             - gcp
   - name: "simple_zonal_private"
-    driver:
+    transport:
       root_module_directory: test/fixtures/simple_zonal_private
     verifier:
       systems:
@@ -125,7 +127,7 @@ suites:
           controls:
             - gcloud
   - name: "stub_domains"
-    driver:
+    transport:
       root_module_directory: test/fixtures/stub_domains
     verifier:
       systems:
@@ -137,27 +139,27 @@ suites:
   # Disabled due to issue #264
   # (https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/264)
   #  - name: stub_domains_private
-  #    driver:
+  #    transport:
   #      root_module_directory: test/fixtures/stub_domains_private
   #      systems:
   #        - name: stub_domains_private
   #          backend: local
   - name: "upstream_nameservers"
-    driver:
+    transport:
       root_module_directory: test/fixtures/upstream_nameservers
     verifier:
       systems:
         - name: upstream_nameservers
           backend: local
   - name: "stub_domains_upstream_nameservers"
-    driver:
+    transport:
       root_module_directory: test/fixtures/stub_domains_upstream_nameservers
     verifier:
       systems:
         - name: stub_domains_upstream_nameservers
           backend: local
   - name: "workload_identity"
-    driver:
+    transport:
       root_module_directory: test/fixtures/workload_identity
     verifier:
       systems:
@@ -170,14 +172,14 @@ suites:
           controls:
             - gcp
   - name: "workload_metadata_config"
-    driver:
+    transport:
       root_module_directory: test/fixtures/workload_metadata_config
     verifier:
       systems:
         - name: workload_metadata_config
           backend: local
   - name: "simple_windows_node_pool"
-    driver:
+    transport:
       root_module_directory: test/fixtures/simple_windows_node_pool
     verifier:
       systems:
@@ -190,7 +192,7 @@ suites:
           controls:
             - gcp
   - name: "deploy_service"
-    driver:
+    transport:
       root_module_directory: test/fixtures/deploy_service
     verifier:
       systems:
@@ -200,7 +202,7 @@ suites:
             - gcloud
             - kubectl
   - name: "node_pool"
-    driver:
+    transport:
       root_module_directory: test/fixtures/node_pool
     verifier:
       systems:
@@ -210,21 +212,21 @@ suites:
             - gcloud
             - kubectl
   - name: "sandbox_enabled"
-    driver:
+    transport:
       root_module_directory: test/fixtures/sandbox_enabled
     verifier:
       systems:
         - name: sandbox_enabled
           backend: local
   - name: "safer_cluster_iap_bastion"
-    driver:
+    transport:
       root_module_directory: test/fixtures/safer_cluster_iap_bastion
     verifier:
       systems:
         - name: safer_cluster_iap_bastion
           backend: local
   - name: "simple_zonal_with_asm"
-    driver:
+    transport:
       root_module_directory: test/fixtures/simple_zonal_with_asm
     verifier:
       systems:
@@ -234,14 +236,14 @@ suites:
             - gcloud
             - kubectl
   - name: "simple_autopilot_private"
-    driver:
+    transport:
       root_module_directory: test/fixtures/simple_autopilot_private
     verifier:
       systems:
         - name: simple_autopilot_private
           backend: local
   - name: "simple_autopilot_public"
-    driver:
+    transport:
       root_module_directory: test/fixtures/simple_autopilot_public
     verifier:
       systems:


### PR DESCRIPTION
With the test kitchen version (3.5) used by the tests, there are some parameters which have moved to new locations.

Follow the suggestions of `kitchen doctor`.