### PR TITLE
chore: pin version in `simple_regional_with_ipv6` example

### DIFF
--- a/examples/simple_regional_with_ipv6/main.tf
+++ b/examples/simple_regional_with_ipv6/main.tf
@@ -27,7 +27,9 @@ provider "kubernetes" {
 }
 
 module "gke" {
-  source                 = "terraform-google-modules/kubernetes-engine/google"
+  source  = "terraform-google-modules/kubernetes-engine/google"
+  version = "~> 33.0"
+
   project_id             = var.project_id
   name                   = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
   regional               = true


### PR DESCRIPTION
This resolves a warning that comes up when running the lint checks locally, and seems to bring it in line with other examples

The other thing I noticed when running the lint script locally from a fork is that it actually locally updates the module source when it's defined like this (e.g., `examples/simple_fleet_app_operator_permissions/main.tf`, and one other):

```hcl
module "permissions" {
  source = "../../modules/fleet-app-operator-permissions"
  # also no version specification here
```

it will get updated to this somewhere in the process -- not sure where, but maybe that's also something that should be fixed?
```diff
--- a/examples/autopilot_private_firewalls/main.tf
+++ b/examples/autopilot_private_firewalls/main.tf
@@ -33,7 +33,7 @@ provider "kubernetes" {
 }
 
 module "gke" {
-  source                            = "../../modules/beta-autopilot-private-cluster/"
+  source                            = "wyardley/kubernetes-engine/google//modules/beta-autopilot-private-cluster"
   project_id                        = var.project_id
   name                              = "${local.cluster_type}-cluster"
   regional                          = true
```

Does it make sense to reference this module the same way as the other examples have it (e.g., `terraform-google-modules/kubernetes-engine/google//modules/fleet-app-operator-permissions`), or will this cause unintended consequences in this case? I could add the two that are specified that way here as well if it makes sense.