### PR TITLE
chore: update example module sources and versions

### DIFF
--- a/examples/autopilot_private_firewalls/main.tf
+++ b/examples/autopilot_private_firewalls/main.tf
@@ -33,7 +33,9 @@ provider "kubernetes" {
 }
 
 module "gke" {
-  source                            = "../../modules/beta-autopilot-private-cluster/"
+  source  = "terraform-google-modules/kubernetes-engine/google//modules/beta-autopilot-private-cluster/"
+  version = "~> 33.0"
+
   project_id                        = var.project_id
   name                              = "${local.cluster_type}-cluster"
   regional                          = true

--- a/examples/autopilot_private_firewalls/main.tf
+++ b/examples/autopilot_private_firewalls/main.tf
@@ -33,7 +33,7 @@ provider "kubernetes" {
 }
 
 module "gke" {
-  source  = "terraform-google-modules/kubernetes-engine/google//modules/beta-autopilot-private-cluster/"
+  source  = "terraform-google-modules/kubernetes-engine/google//modules/beta-autopilot-private-cluster"
   version = "~> 33.0"
 
   project_id                        = var.project_id

--- a/examples/simple_fleet_app_operator_permissions/main.tf
+++ b/examples/simple_fleet_app_operator_permissions/main.tf
@@ -35,7 +35,8 @@ resource "google_gke_hub_scope" "scope" {
 
 # Grant permissions to the app operator to work with the Fleet Scope.
 module "permissions" {
-  source = "../../modules/fleet-app-operator-permissions"
+  source  = "terraform-google-modules/kubernetes-engine/google//modules/fleet-app-operator-permissions"
+  version = "~> 33.0"
 
   fleet_project_id = var.fleet_project_id
   scope_id         = google_gke_hub_scope.scope.scope_id


### PR DESCRIPTION
- Update module source. This should prevent the source from getting rewritten when tests are run locally
- Add missing version spec to match other modules

Follow-up to https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/2115#issuecomment-2375056239

For example this:
```hcl
module "permissions" {
  source = "../../modules/fleet-app-operator-permissions"
  # also no version specification here
}
```

gets rewritten like this when the docker test / lint make target is run.
```diff
--- a/examples/autopilot_private_firewalls/main.tf
+++ b/examples/autopilot_private_firewalls/main.tf
@@ -33,7 +33,7 @@ provider "kubernetes" {
 }
 
 module "gke" {
-  source                            = "../../modules/beta-autopilot-private-cluster/"
+  source                            = "wyardley/kubernetes-engine/google//modules/beta-autopilot-private-cluster"
   project_id                        = var.project_id
   name                              = "${local.cluster_type}-cluster"
   regional                          = true
```