### PR TITLE
chore: ignore top level `.terraform.lock`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ Session.vim
 # tf lock file
 .terraform.lock.hcl
 
+# Top level lock used by the test tooling
+/.terraform.lock
+
 # Crash log files
 crash.log
 


### PR DESCRIPTION
If there's a template repo, maybe this should get added there as well?