### PR TITLE
fix: ignore control plane network when private endpoint subnet is set

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -597,7 +597,7 @@ resource "google_container_cluster" "primary" {
     content {
       enable_private_endpoint     = private_cluster_config.value.enable_private_endpoint
       enable_private_nodes        = private_cluster_config.value.enable_private_nodes
-      master_ipv4_cidr_block      = private_cluster_config.value.master_ipv4_cidr_block
+      master_ipv4_cidr_block      = var.private_endpoint_subnetwork == null ? private_cluster_config.value.master_ipv4_cidr_block : null
       private_endpoint_subnetwork = private_cluster_config.value.private_endpoint_subnetwork
       dynamic "master_global_access_config" {
         for_each = var.master_global_access_enabled ? [var.master_global_access_enabled] : []

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -295,7 +295,7 @@ resource "google_container_cluster" "primary" {
     content {
       enable_private_endpoint     = private_cluster_config.value.enable_private_endpoint
       enable_private_nodes        = private_cluster_config.value.enable_private_nodes
-      master_ipv4_cidr_block      = private_cluster_config.value.master_ipv4_cidr_block
+      master_ipv4_cidr_block      = var.private_endpoint_subnetwork == null ? private_cluster_config.value.master_ipv4_cidr_block : null
       private_endpoint_subnetwork = private_cluster_config.value.private_endpoint_subnetwork
       dynamic "master_global_access_config" {
         for_each = var.master_global_access_enabled ? [var.master_global_access_enabled] : []

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -516,7 +516,7 @@ resource "google_container_cluster" "primary" {
     content {
       enable_private_endpoint     = private_cluster_config.value.enable_private_endpoint
       enable_private_nodes        = private_cluster_config.value.enable_private_nodes
-      master_ipv4_cidr_block      = private_cluster_config.value.master_ipv4_cidr_block
+      master_ipv4_cidr_block      = var.private_endpoint_subnetwork == null ? private_cluster_config.value.master_ipv4_cidr_block : null
       private_endpoint_subnetwork = private_cluster_config.value.private_endpoint_subnetwork
       dynamic "master_global_access_config" {
         for_each = var.master_global_access_enabled ? [var.master_global_access_enabled] : []

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -516,7 +516,7 @@ resource "google_container_cluster" "primary" {
     content {
       enable_private_endpoint     = private_cluster_config.value.enable_private_endpoint
       enable_private_nodes        = private_cluster_config.value.enable_private_nodes
-      master_ipv4_cidr_block      = private_cluster_config.value.master_ipv4_cidr_block
+      master_ipv4_cidr_block      = var.private_endpoint_subnetwork == null ? private_cluster_config.value.master_ipv4_cidr_block : null
       private_endpoint_subnetwork = private_cluster_config.value.private_endpoint_subnetwork
       dynamic "master_global_access_config" {
         for_each = var.master_global_access_enabled ? [var.master_global_access_enabled] : []

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -462,7 +462,7 @@ resource "google_container_cluster" "primary" {
     content {
       enable_private_endpoint     = private_cluster_config.value.enable_private_endpoint
       enable_private_nodes        = private_cluster_config.value.enable_private_nodes
-      master_ipv4_cidr_block      = private_cluster_config.value.master_ipv4_cidr_block
+      master_ipv4_cidr_block      = var.private_endpoint_subnetwork == null ? private_cluster_config.value.master_ipv4_cidr_block : null
       private_endpoint_subnetwork = private_cluster_config.value.private_endpoint_subnetwork
       dynamic "master_global_access_config" {
         for_each = var.master_global_access_enabled ? [var.master_global_access_enabled] : []

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -462,7 +462,7 @@ resource "google_container_cluster" "primary" {
     content {
       enable_private_endpoint     = private_cluster_config.value.enable_private_endpoint
       enable_private_nodes        = private_cluster_config.value.enable_private_nodes
-      master_ipv4_cidr_block      = private_cluster_config.value.master_ipv4_cidr_block
+      master_ipv4_cidr_block      = var.private_endpoint_subnetwork == null ? private_cluster_config.value.master_ipv4_cidr_block : null
       private_endpoint_subnetwork = private_cluster_config.value.private_endpoint_subnetwork
       dynamic "master_global_access_config" {
         for_each = var.master_global_access_enabled ? [var.master_global_access_enabled] : []


### PR DESCRIPTION
Set `master_ipv4_cidr_block` to `null` when `private_endpoint_subnetwork` is set, as the two conflict with an API level error being thrown:
`Error: googleapi: Error 400: When masterIpv4Cidr is set, privateEndpointSubnetwork must be unset.`

Fixes #2119

This would have the effect of silently ignoring the setting even when `master_ipv4_cidr_block` is explicitly set. A better fix might be to throw an error, but given that there's a baked in default and that terraform module validation can't look at the values of other variables, I don't think that would be trivial.