### PR TITLE
fix(acm): use membership registration location

### DIFF
--- a/modules/acm/feature.tf
+++ b/modules/acm/feature.tf
@@ -29,7 +29,7 @@ resource "google_gke_hub_feature_membership" "main" {
     google_gke_hub_feature.acm
   ]
 
-  location = "global"
+  location = module.registration.location
   feature  = "configmanagement"
 
   membership = module.registration.cluster_membership_id


### PR DESCRIPTION
 - use the actual membership location rather than always global