### PR TITLE
chore(CI): update testdata with insecureKubeletReadonlyPortEnabled

### DIFF
--- a/test/integration/private_zonal_with_networking/testdata/TestPrivateZonalWithNetworking.json
+++ b/test/integration/private_zonal_with_networking/testdata/TestPrivateZonalWithNetworking.json
@@ -212,6 +212,9 @@
         "diskType": "pd-standard",
         "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
         "imageType": "COS_CONTAINERD",
+        "kubeletConfig": {
+          "insecureKubeletReadonlyPortEnabled": true
+        },
         "labels": {
           "cluster_name": "CLUSTER_NAME",
           "node_pool": "default-node-pool"


### PR DESCRIPTION
seems inconsistent