### PR TITLE
fix(node_pools): Update Variants: Add recreate for `secondary_boot_disk` and `local_ssd_ephemeral_count` (beta)

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -706,6 +706,9 @@ locals {
     "enable_secure_boot",
     "enable_integrity_monitoring",
     "local_ssd_count",
+    {% if beta_cluster %}
+    "local_ssd_ephemeral_count",
+    {% endif %}
     "machine_type",
     "placement_policy",
     "max_pods_per_node",
@@ -723,6 +726,7 @@ locals {
     "reservation_affinity_key",
     "reservation_affinity_values",
     "enable_confidential_nodes",
+    "secondary_boot_disk",
   ]
 }
 

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -602,6 +602,7 @@ locals {
     "enable_secure_boot",
     "enable_integrity_monitoring",
     "local_ssd_count",
+    "local_ssd_ephemeral_count",
     "machine_type",
     "placement_policy",
     "max_pods_per_node",
@@ -619,6 +620,7 @@ locals {
     "reservation_affinity_key",
     "reservation_affinity_values",
     "enable_confidential_nodes",
+    "secondary_boot_disk",
   ]
 }
 

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -581,6 +581,7 @@ locals {
     "enable_secure_boot",
     "enable_integrity_monitoring",
     "local_ssd_count",
+    "local_ssd_ephemeral_count",
     "machine_type",
     "placement_policy",
     "max_pods_per_node",
@@ -598,6 +599,7 @@ locals {
     "reservation_affinity_key",
     "reservation_affinity_values",
     "enable_confidential_nodes",
+    "secondary_boot_disk",
   ]
 }
 

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -555,6 +555,7 @@ locals {
     "reservation_affinity_key",
     "reservation_affinity_values",
     "enable_confidential_nodes",
+    "secondary_boot_disk",
   ]
 }
 


### PR DESCRIPTION
Code in this PR forces re-creation of node pools with changes in `secondary_boot_disk` and `local_ssd_ephemeral_count` (for beta variants). Because of these are currently not in `random_id.name` keepers, the random suffix (and the entire node pool name) remains the same on updating these variables and replacing node pool resource results in `resource - <node_pool_path> - already exists` error.

Both of these parameters require node pool re-creation as per TF spec:

* `secondary_boot_disk`: [secondary_boot_disks](https://github.com/hashicorp/terraform-provider-google/blob/main/google/services/container/node_config.go#L287)
* `local_ssd_ephemeral_count`: [ephemeral_storage_local_ssd_config](https://github.com/hashicorp/terraform-provider-google/blob/main/google/services/container/node_config.go#L249)