### PR TITLE
feat: Add create_ignore_already_exists to workload_identity

### DIFF
--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -148,6 +148,7 @@ Error: Get "http://localhost/api/v1/namespaces/default/serviceaccounts/your-serv
 | annotate\_k8s\_sa | Annotate the kubernetes service account with 'iam.gke.io/gcp-service-account' annotation. Valid in cases when an existing SA is used. | `bool` | `true` | no |
 | automount\_service\_account\_token | Enable automatic mounting of the service account token | `bool` | `false` | no |
 | cluster\_name | Cluster name. Required if using existing KSA. | `string` | `""` | no |
+| create\_ignore\_already\_exists | If set to true, skip service account creation if a service account with the same email already exists. | `bool` | `false` | no |
 | gcp\_sa\_description | The Service Google service account desciption; if null, will be left out | `string` | `null` | no |
 | gcp\_sa\_display\_name | The Google service account display name; if null, a default string will be used | `string` | `null` | no |
 | gcp\_sa\_name | Name for the Google service account; overrides `var.name`. | `string` | `null` | no |

--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -148,7 +148,7 @@ Error: Get "http://localhost/api/v1/namespaces/default/serviceaccounts/your-serv
 | annotate\_k8s\_sa | Annotate the kubernetes service account with 'iam.gke.io/gcp-service-account' annotation. Valid in cases when an existing SA is used. | `bool` | `true` | no |
 | automount\_service\_account\_token | Enable automatic mounting of the service account token | `bool` | `false` | no |
 | cluster\_name | Cluster name. Required if using existing KSA. | `string` | `""` | no |
-| create\_ignore\_already\_exists | If set to true, skip service account creation if a service account with the same email already exists. | `bool` | `false` | no |
+| gcp\_sa\_create\_ignore\_already\_exists | If set to true, skip service account creation if a service account with the same email already exists. | `bool` | `null` | no |
 | gcp\_sa\_description | The Service Google service account desciption; if null, will be left out | `string` | `null` | no |
 | gcp\_sa\_display\_name | The Google service account display name; if null, a default string will be used | `string` | `null` | no |
 | gcp\_sa\_name | Name for the Google service account; overrides `var.name`. | `string` | `null` | no |

--- a/modules/workload-identity/main.tf
+++ b/modules/workload-identity/main.tf
@@ -46,7 +46,7 @@ resource "google_service_account" "cluster_service_account" {
   display_name                 = coalesce(var.gcp_sa_display_name, substr("GCP SA bound to K8S SA ${local.k8s_sa_project_id}[${local.k8s_given_name}]", 0, 100))
   description                  = var.gcp_sa_description
   project                      = var.project_id
-  create_ignore_already_exists = var.create_ignore_already_exists
+  create_ignore_already_exists = var.gcp_sa_create_ignore_already_exists
 }
 
 resource "kubernetes_service_account" "main" {

--- a/modules/workload-identity/main.tf
+++ b/modules/workload-identity/main.tf
@@ -42,10 +42,11 @@ data "google_service_account" "cluster_service_account" {
 resource "google_service_account" "cluster_service_account" {
   count = var.use_existing_gcp_sa ? 0 : 1
 
-  account_id   = local.gcp_given_name
-  display_name = coalesce(var.gcp_sa_display_name, substr("GCP SA bound to K8S SA ${local.k8s_sa_project_id}[${local.k8s_given_name}]", 0, 100))
-  description  = var.gcp_sa_description
-  project      = var.project_id
+  account_id                   = local.gcp_given_name
+  display_name                 = coalesce(var.gcp_sa_display_name, substr("GCP SA bound to K8S SA ${local.k8s_sa_project_id}[${local.k8s_given_name}]", 0, 100))
+  description                  = var.gcp_sa_description
+  project                      = var.project_id
+  create_ignore_already_exists = var.create_ignore_already_exists
 }
 
 resource "kubernetes_service_account" "main" {

--- a/modules/workload-identity/variables.tf
+++ b/modules/workload-identity/variables.tf
@@ -141,5 +141,5 @@ variable "gcp_sa_description" {
 variable "create_ignore_already_exists" {
   description = "If set to true, skip service account creation if a service account with the same email already exists."
   type        = bool
-  default     = false
+  default     = null
 }

--- a/modules/workload-identity/variables.tf
+++ b/modules/workload-identity/variables.tf
@@ -137,3 +137,9 @@ variable "gcp_sa_description" {
     error_message = "The Google service account description must be at most 256 characters"
   }
 }
+
+variable "create_ignore_already_exists" {
+  description = "If set to true, skip service account creation if a service account with the same email already exists."
+  type        = bool
+  default     = false
+}

--- a/modules/workload-identity/variables.tf
+++ b/modules/workload-identity/variables.tf
@@ -138,7 +138,7 @@ variable "gcp_sa_description" {
   }
 }
 
-variable "create_ignore_already_exists" {
+variable "gcp_sa_create_ignore_already_exists" {
   description = "If set to true, skip service account creation if a service account with the same email already exists."
   type        = bool
   default     = null


### PR DESCRIPTION
Adds [create_ignore_already_exists](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_service_account#create_ignore_already_exists) to workload-identity module to ignore an already existing google-service-account when hitting the [Provider produced inconsistent result after apply](https://github.com/hashicorp/terraform-provider-google/issues/18087) issue.

Fixes #2141 