### PR TITLE
fix: send provider enum values for `insecureKubeletReadonlyPortEnabled`

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -694,7 +694,7 @@ resource "google_container_cluster" "primary" {
         enabled = var.enable_gcfs
       }
       {% endif %}
-      insecure_kubelet_readonly_port_enabled = var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null
+      insecure_kubelet_readonly_port_enabled = var.insecure_kubelet_readonly_port_enabled != null ? upper(tostring(var.insecure_kubelet_readonly_port_enabled)) : null
       {% endif %}
     }
   }
@@ -1069,7 +1069,7 @@ resource "google_container_node_pool" "windows_pools" {
         cpu_manager_policy                     = lookup(each.value, "cpu_manager_policy", "static")
         cpu_cfs_quota                          = lookup(each.value, "cpu_cfs_quota", null)
         cpu_cfs_quota_period                   = lookup(each.value, "cpu_cfs_quota_period", null)
-        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null)
+        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", null) != null ? upper(tostring(each.value.insecure_kubelet_readonly_port_enabled)) : null
         pod_pids_limit                         = lookup(each.value, "pod_pids_limit", null)
       }
     }

--- a/cluster.tf
+++ b/cluster.tf
@@ -518,7 +518,7 @@ resource "google_container_cluster" "primary" {
 
   node_pool_defaults {
     node_config_defaults {
-      insecure_kubelet_readonly_port_enabled = var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null
+      insecure_kubelet_readonly_port_enabled = var.insecure_kubelet_readonly_port_enabled != null ? upper(tostring(var.insecure_kubelet_readonly_port_enabled)) : null
     }
   }
 
@@ -768,7 +768,7 @@ resource "google_container_node_pool" "pools" {
         cpu_manager_policy                     = lookup(each.value, "cpu_manager_policy", "static")
         cpu_cfs_quota                          = lookup(each.value, "cpu_cfs_quota", null)
         cpu_cfs_quota_period                   = lookup(each.value, "cpu_cfs_quota_period", null)
-        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null)
+        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", null) != null ? upper(tostring(each.value.insecure_kubelet_readonly_port_enabled)) : null
         pod_pids_limit                         = lookup(each.value, "pod_pids_limit", null)
       }
     }
@@ -1059,7 +1059,7 @@ resource "google_container_node_pool" "windows_pools" {
         cpu_manager_policy                     = lookup(each.value, "cpu_manager_policy", "static")
         cpu_cfs_quota                          = lookup(each.value, "cpu_cfs_quota", null)
         cpu_cfs_quota_period                   = lookup(each.value, "cpu_cfs_quota_period", null)
-        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null)
+        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", null) != null ? upper(tostring(each.value.insecure_kubelet_readonly_port_enabled)) : null
         pod_pids_limit                         = lookup(each.value, "pod_pids_limit", null)
       }
     }

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -79,7 +79,7 @@ module "gke" {
       sandbox_enabled                        = true
       cpu_manager_policy                     = "static"
       cpu_cfs_quota                          = true
-      insecure_kubelet_readonly_port_enabled = "FALSE"
+      insecure_kubelet_readonly_port_enabled = false
       local_ssd_ephemeral_count              = 2
       pod_pids_limit                         = 4096
     },

--- a/examples/node_pool_update_variant/main.tf
+++ b/examples/node_pool_update_variant/main.tf
@@ -66,7 +66,7 @@ module "gke" {
       max_count                              = 2
       service_account                        = var.compute_engine_service_account
       auto_upgrade                           = true
-      insecure_kubelet_readonly_port_enabled = "FALSE"
+      insecure_kubelet_readonly_port_enabled = false
     },
     {
       name              = "pool-02"

--- a/examples/private_zonal_with_networking/main.tf
+++ b/examples/private_zonal_with_networking/main.tf
@@ -79,6 +79,8 @@ module "gke" {
   master_ipv4_cidr_block  = "172.16.0.0/28"
   deletion_protection     = false
 
+  insecure_kubelet_readonly_port_enabled = false
+
   master_authorized_networks = [
     {
       cidr_block   = data.google_compute_subnetwork.subnetwork.ip_cidr_range

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -596,7 +596,7 @@ resource "google_container_cluster" "primary" {
       gcfs_config {
         enabled = var.enable_gcfs
       }
-      insecure_kubelet_readonly_port_enabled = var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null
+      insecure_kubelet_readonly_port_enabled = var.insecure_kubelet_readonly_port_enabled != null ? upper(tostring(var.insecure_kubelet_readonly_port_enabled)) : null
     }
   }
 
@@ -938,7 +938,7 @@ resource "google_container_node_pool" "pools" {
         cpu_manager_policy                     = lookup(each.value, "cpu_manager_policy", "static")
         cpu_cfs_quota                          = lookup(each.value, "cpu_cfs_quota", null)
         cpu_cfs_quota_period                   = lookup(each.value, "cpu_cfs_quota_period", null)
-        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null)
+        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", null) != null ? upper(tostring(each.value.insecure_kubelet_readonly_port_enabled)) : null
         pod_pids_limit                         = lookup(each.value, "pod_pids_limit", null)
       }
     }
@@ -1243,7 +1243,7 @@ resource "google_container_node_pool" "windows_pools" {
         cpu_manager_policy                     = lookup(each.value, "cpu_manager_policy", "static")
         cpu_cfs_quota                          = lookup(each.value, "cpu_cfs_quota", null)
         cpu_cfs_quota_period                   = lookup(each.value, "cpu_cfs_quota_period", null)
-        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null)
+        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", null) != null ? upper(tostring(each.value.insecure_kubelet_readonly_port_enabled)) : null
         pod_pids_limit                         = lookup(each.value, "pod_pids_limit", null)
       }
     }

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -596,7 +596,7 @@ resource "google_container_cluster" "primary" {
       gcfs_config {
         enabled = var.enable_gcfs
       }
-      insecure_kubelet_readonly_port_enabled = var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null
+      insecure_kubelet_readonly_port_enabled = var.insecure_kubelet_readonly_port_enabled != null ? upper(tostring(var.insecure_kubelet_readonly_port_enabled)) : null
     }
   }
 
@@ -853,7 +853,7 @@ resource "google_container_node_pool" "pools" {
         cpu_manager_policy                     = lookup(each.value, "cpu_manager_policy", "static")
         cpu_cfs_quota                          = lookup(each.value, "cpu_cfs_quota", null)
         cpu_cfs_quota_period                   = lookup(each.value, "cpu_cfs_quota_period", null)
-        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null)
+        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", null) != null ? upper(tostring(each.value.insecure_kubelet_readonly_port_enabled)) : null
         pod_pids_limit                         = lookup(each.value, "pod_pids_limit", null)
       }
     }
@@ -1157,7 +1157,7 @@ resource "google_container_node_pool" "windows_pools" {
         cpu_manager_policy                     = lookup(each.value, "cpu_manager_policy", "static")
         cpu_cfs_quota                          = lookup(each.value, "cpu_cfs_quota", null)
         cpu_cfs_quota_period                   = lookup(each.value, "cpu_cfs_quota_period", null)
-        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null)
+        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", null) != null ? upper(tostring(each.value.insecure_kubelet_readonly_port_enabled)) : null
         pod_pids_limit                         = lookup(each.value, "pod_pids_limit", null)
       }
     }

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -575,7 +575,7 @@ resource "google_container_cluster" "primary" {
       gcfs_config {
         enabled = var.enable_gcfs
       }
-      insecure_kubelet_readonly_port_enabled = var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null
+      insecure_kubelet_readonly_port_enabled = var.insecure_kubelet_readonly_port_enabled != null ? upper(tostring(var.insecure_kubelet_readonly_port_enabled)) : null
     }
   }
 
@@ -917,7 +917,7 @@ resource "google_container_node_pool" "pools" {
         cpu_manager_policy                     = lookup(each.value, "cpu_manager_policy", "static")
         cpu_cfs_quota                          = lookup(each.value, "cpu_cfs_quota", null)
         cpu_cfs_quota_period                   = lookup(each.value, "cpu_cfs_quota_period", null)
-        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null)
+        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", null) != null ? upper(tostring(each.value.insecure_kubelet_readonly_port_enabled)) : null
         pod_pids_limit                         = lookup(each.value, "pod_pids_limit", null)
       }
     }
@@ -1222,7 +1222,7 @@ resource "google_container_node_pool" "windows_pools" {
         cpu_manager_policy                     = lookup(each.value, "cpu_manager_policy", "static")
         cpu_cfs_quota                          = lookup(each.value, "cpu_cfs_quota", null)
         cpu_cfs_quota_period                   = lookup(each.value, "cpu_cfs_quota_period", null)
-        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null)
+        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", null) != null ? upper(tostring(each.value.insecure_kubelet_readonly_port_enabled)) : null
         pod_pids_limit                         = lookup(each.value, "pod_pids_limit", null)
       }
     }

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -575,7 +575,7 @@ resource "google_container_cluster" "primary" {
       gcfs_config {
         enabled = var.enable_gcfs
       }
-      insecure_kubelet_readonly_port_enabled = var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null
+      insecure_kubelet_readonly_port_enabled = var.insecure_kubelet_readonly_port_enabled != null ? upper(tostring(var.insecure_kubelet_readonly_port_enabled)) : null
     }
   }
 
@@ -832,7 +832,7 @@ resource "google_container_node_pool" "pools" {
         cpu_manager_policy                     = lookup(each.value, "cpu_manager_policy", "static")
         cpu_cfs_quota                          = lookup(each.value, "cpu_cfs_quota", null)
         cpu_cfs_quota_period                   = lookup(each.value, "cpu_cfs_quota_period", null)
-        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null)
+        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", null) != null ? upper(tostring(each.value.insecure_kubelet_readonly_port_enabled)) : null
         pod_pids_limit                         = lookup(each.value, "pod_pids_limit", null)
       }
     }
@@ -1136,7 +1136,7 @@ resource "google_container_node_pool" "windows_pools" {
         cpu_manager_policy                     = lookup(each.value, "cpu_manager_policy", "static")
         cpu_cfs_quota                          = lookup(each.value, "cpu_cfs_quota", null)
         cpu_cfs_quota_period                   = lookup(each.value, "cpu_cfs_quota_period", null)
-        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null)
+        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", null) != null ? upper(tostring(each.value.insecure_kubelet_readonly_port_enabled)) : null
         pod_pids_limit                         = lookup(each.value, "pod_pids_limit", null)
       }
     }

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -539,7 +539,7 @@ resource "google_container_cluster" "primary" {
 
   node_pool_defaults {
     node_config_defaults {
-      insecure_kubelet_readonly_port_enabled = var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null
+      insecure_kubelet_readonly_port_enabled = var.insecure_kubelet_readonly_port_enabled != null ? upper(tostring(var.insecure_kubelet_readonly_port_enabled)) : null
     }
   }
 
@@ -873,7 +873,7 @@ resource "google_container_node_pool" "pools" {
         cpu_manager_policy                     = lookup(each.value, "cpu_manager_policy", "static")
         cpu_cfs_quota                          = lookup(each.value, "cpu_cfs_quota", null)
         cpu_cfs_quota_period                   = lookup(each.value, "cpu_cfs_quota_period", null)
-        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null)
+        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", null) != null ? upper(tostring(each.value.insecure_kubelet_readonly_port_enabled)) : null
         pod_pids_limit                         = lookup(each.value, "pod_pids_limit", null)
       }
     }
@@ -1165,7 +1165,7 @@ resource "google_container_node_pool" "windows_pools" {
         cpu_manager_policy                     = lookup(each.value, "cpu_manager_policy", "static")
         cpu_cfs_quota                          = lookup(each.value, "cpu_cfs_quota", null)
         cpu_cfs_quota_period                   = lookup(each.value, "cpu_cfs_quota_period", null)
-        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null)
+        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", null) != null ? upper(tostring(each.value.insecure_kubelet_readonly_port_enabled)) : null
         pod_pids_limit                         = lookup(each.value, "pod_pids_limit", null)
       }
     }

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -539,7 +539,7 @@ resource "google_container_cluster" "primary" {
 
   node_pool_defaults {
     node_config_defaults {
-      insecure_kubelet_readonly_port_enabled = var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null
+      insecure_kubelet_readonly_port_enabled = var.insecure_kubelet_readonly_port_enabled != null ? upper(tostring(var.insecure_kubelet_readonly_port_enabled)) : null
     }
   }
 
@@ -789,7 +789,7 @@ resource "google_container_node_pool" "pools" {
         cpu_manager_policy                     = lookup(each.value, "cpu_manager_policy", "static")
         cpu_cfs_quota                          = lookup(each.value, "cpu_cfs_quota", null)
         cpu_cfs_quota_period                   = lookup(each.value, "cpu_cfs_quota_period", null)
-        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null)
+        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", null) != null ? upper(tostring(each.value.insecure_kubelet_readonly_port_enabled)) : null
         pod_pids_limit                         = lookup(each.value, "pod_pids_limit", null)
       }
     }
@@ -1080,7 +1080,7 @@ resource "google_container_node_pool" "windows_pools" {
         cpu_manager_policy                     = lookup(each.value, "cpu_manager_policy", "static")
         cpu_cfs_quota                          = lookup(each.value, "cpu_cfs_quota", null)
         cpu_cfs_quota_period                   = lookup(each.value, "cpu_cfs_quota_period", null)
-        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled != null ? var.insecure_kubelet_readonly_port_enabled : null)
+        insecure_kubelet_readonly_port_enabled = lookup(each.value, "insecure_kubelet_readonly_port_enabled", null) != null ? upper(tostring(each.value.insecure_kubelet_readonly_port_enabled)) : null
         pod_pids_limit                         = lookup(each.value, "pod_pids_limit", null)
       }
     }

--- a/test/integration/private_zonal_with_networking/testdata/TestPrivateZonalWithNetworking.json
+++ b/test/integration/private_zonal_with_networking/testdata/TestPrivateZonalWithNetworking.json
@@ -107,6 +107,9 @@
     "diskSizeGb": 100,
     "diskType": "pd-balanced",
     "imageType": "COS_CONTAINERD",
+    "kubeletConfig": {
+      "insecureKubeletReadonlyPortEnabled": false
+    },
     "loggingConfig": {
       "variantConfig": {
         "variant": "DEFAULT"


### PR DESCRIPTION
Add `insecureKubeletReadonlyPortEnabled` to `node_config.kubelet_config` for the default node-pool and for additional pools. It may also be necessary to define the top level `node_config` more broadly for the case where `remove_default_node_pool` is set to false, which should probably be handled separately.

Also, the upstream provider (intentionally) uses an enum of `"TRUE"` / `"FALSE"` vs. a boolean. Update the code to follow this, and add a test case (also suggested by @apeabody) that covers the cluster level setting vs node pool one.

Fixes #2013