### PR TITLE
fix: update resource names to snake_case

### DIFF
--- a/autogen/main/dns.tf.tmpl
+++ b/autogen/main/dns.tf.tmpl
@@ -20,7 +20,7 @@
   Manage kube-dns configmaps
  *****************************************/
 
-resource "kubernetes_config_map_v1_data" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube_dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -44,7 +44,7 @@ EOF
   ]
 }
 
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -68,13 +68,7 @@ EOF
   ]
 }
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers_and_stub_domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {

--- a/autogen/main/masq.tf.tmpl
+++ b/autogen/main/masq.tf.tmpl
@@ -19,7 +19,7 @@
 /******************************************
   Create ip-masq-agent confimap
  *****************************************/
-resource "kubernetes_config_map" "ip-masq-agent" {
+resource "kubernetes_config_map" "ip_masq_agent" {
   count = var.configure_ip_masq ? 1 : 0
 
   metadata {

--- a/autogen/main/moved.tf.tmpl
+++ b/autogen/main/moved.tf.tmpl
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 # Fix the name typo in the previous ConfigMap creation call
 moved {
   from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers

--- a/autogen/main/moved.tf.tmpl
+++ b/autogen/main/moved.tf.tmpl
@@ -32,6 +32,11 @@ moved {
 }
 
 moved {
+  from = kubernetes_config_map.ip-masq-agent
+  to   = kubernetes_config_map.ip_masq_agent
+}
+
+moved {
   from = google_project_iam_member.cluster_service_account-nodeService_account
   to   = google_project_iam_member.cluster_service_account_node_service_account
 }

--- a/autogen/main/moved.tf.tmpl
+++ b/autogen/main/moved.tf.tmpl
@@ -1,0 +1,46 @@
+# Fix the name typo in the previous ConfigMap creation call
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
+  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+}
+
+# Updates for kebab to snake case, to match best practices and Google style.
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns
+  to   = kubernetes_config_map_v1_data.kube_dns
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers-and-stub-domains
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers_and_stub_domains
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-nodeService_account
+  to   = google_project_iam_member.cluster_service_account_node_service_account
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-metric_writer
+  to   = google_project_iam_member.cluster_service_account_metric_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-resourceMetadata-writer
+  to   = google_project_iam_member.cluster_service_account_resource_metadata_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-gcr
+  to   = google_project_iam_member.cluster_service_account_gcr
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-artifact-registry
+  to   = google_project_iam_member.cluster_service_account_artifact_registry
+}

--- a/autogen/main/moved.tf.tmpl
+++ b/autogen/main/moved.tf.tmpl
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
 # Updates for kebab to snake case, to match best practices and Google style.
 moved {
   from = kubernetes_config_map_v1_data.kube-dns
   to   = kubernetes_config_map_v1_data.kube_dns
 }
 
+# Typo fix and snake case at the same time
 moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
   to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
 }
 

--- a/autogen/main/sa.tf.tmpl
+++ b/autogen/main/sa.tf.tmpl
@@ -46,35 +46,35 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
+resource "google_project_iam_member" "cluster_service_account_node_service_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
+resource "google_project_iam_member" "cluster_service_account_metric_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/monitoring.metricWriter"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
+resource "google_project_iam_member" "cluster_service_account_resource_metadata_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/stackdriver.resourceMetadata.writer"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-gcr" {
+resource "google_project_iam_member" "cluster_service_account_gcr" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/storage.objectViewer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
+resource "google_project_iam_member" "cluster_service_account_artifact_registry" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"

--- a/dns.tf
+++ b/dns.tf
@@ -20,7 +20,7 @@
   Manage kube-dns configmaps
  *****************************************/
 
-resource "kubernetes_config_map_v1_data" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube_dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -42,7 +42,7 @@ EOF
   ]
 }
 
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -64,13 +64,7 @@ EOF
   ]
 }
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers_and_stub_domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {

--- a/masq.tf
+++ b/masq.tf
@@ -19,7 +19,7 @@
 /******************************************
   Create ip-masq-agent confimap
  *****************************************/
-resource "kubernetes_config_map" "ip-masq-agent" {
+resource "kubernetes_config_map" "ip_masq_agent" {
   count = var.configure_ip_masq ? 1 : 0
 
   metadata {

--- a/modules/beta-autopilot-private-cluster/dns.tf
+++ b/modules/beta-autopilot-private-cluster/dns.tf
@@ -20,7 +20,7 @@
   Manage kube-dns configmaps
  *****************************************/
 
-resource "kubernetes_config_map_v1_data" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube_dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -41,7 +41,7 @@ EOF
   ]
 }
 
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -62,13 +62,7 @@ EOF
   ]
 }
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers_and_stub_domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {

--- a/modules/beta-autopilot-private-cluster/masq.tf
+++ b/modules/beta-autopilot-private-cluster/masq.tf
@@ -19,7 +19,7 @@
 /******************************************
   Create ip-masq-agent confimap
  *****************************************/
-resource "kubernetes_config_map" "ip-masq-agent" {
+resource "kubernetes_config_map" "ip_masq_agent" {
   count = var.configure_ip_masq ? 1 : 0
 
   metadata {

--- a/modules/beta-autopilot-private-cluster/moved.tf
+++ b/modules/beta-autopilot-private-cluster/moved.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 # Fix the name typo in the previous ConfigMap creation call
 moved {
   from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers

--- a/modules/beta-autopilot-private-cluster/moved.tf
+++ b/modules/beta-autopilot-private-cluster/moved.tf
@@ -32,6 +32,11 @@ moved {
 }
 
 moved {
+  from = kubernetes_config_map.ip-masq-agent
+  to   = kubernetes_config_map.ip_masq_agent
+}
+
+moved {
   from = google_project_iam_member.cluster_service_account-nodeService_account
   to   = google_project_iam_member.cluster_service_account_node_service_account
 }

--- a/modules/beta-autopilot-private-cluster/moved.tf
+++ b/modules/beta-autopilot-private-cluster/moved.tf
@@ -1,0 +1,46 @@
+# Fix the name typo in the previous ConfigMap creation call
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
+  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+}
+
+# Updates for kebab to snake case, to match best practices and Google style.
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns
+  to   = kubernetes_config_map_v1_data.kube_dns
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers-and-stub-domains
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers_and_stub_domains
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-nodeService_account
+  to   = google_project_iam_member.cluster_service_account_node_service_account
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-metric_writer
+  to   = google_project_iam_member.cluster_service_account_metric_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-resourceMetadata-writer
+  to   = google_project_iam_member.cluster_service_account_resource_metadata_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-gcr
+  to   = google_project_iam_member.cluster_service_account_gcr
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-artifact-registry
+  to   = google_project_iam_member.cluster_service_account_artifact_registry
+}

--- a/modules/beta-autopilot-private-cluster/moved.tf
+++ b/modules/beta-autopilot-private-cluster/moved.tf
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
 # Updates for kebab to snake case, to match best practices and Google style.
 moved {
   from = kubernetes_config_map_v1_data.kube-dns
   to   = kubernetes_config_map_v1_data.kube_dns
 }
 
+# Typo fix and snake case at the same time
 moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
   to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
 }
 

--- a/modules/beta-autopilot-private-cluster/sa.tf
+++ b/modules/beta-autopilot-private-cluster/sa.tf
@@ -46,35 +46,35 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
+resource "google_project_iam_member" "cluster_service_account_node_service_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
+resource "google_project_iam_member" "cluster_service_account_metric_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/monitoring.metricWriter"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
+resource "google_project_iam_member" "cluster_service_account_resource_metadata_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/stackdriver.resourceMetadata.writer"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-gcr" {
+resource "google_project_iam_member" "cluster_service_account_gcr" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/storage.objectViewer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
+resource "google_project_iam_member" "cluster_service_account_artifact_registry" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"

--- a/modules/beta-autopilot-public-cluster/dns.tf
+++ b/modules/beta-autopilot-public-cluster/dns.tf
@@ -20,7 +20,7 @@
   Manage kube-dns configmaps
  *****************************************/
 
-resource "kubernetes_config_map_v1_data" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube_dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -41,7 +41,7 @@ EOF
   ]
 }
 
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -62,13 +62,7 @@ EOF
   ]
 }
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers_and_stub_domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {

--- a/modules/beta-autopilot-public-cluster/masq.tf
+++ b/modules/beta-autopilot-public-cluster/masq.tf
@@ -19,7 +19,7 @@
 /******************************************
   Create ip-masq-agent confimap
  *****************************************/
-resource "kubernetes_config_map" "ip-masq-agent" {
+resource "kubernetes_config_map" "ip_masq_agent" {
   count = var.configure_ip_masq ? 1 : 0
 
   metadata {

--- a/modules/beta-autopilot-public-cluster/moved.tf
+++ b/modules/beta-autopilot-public-cluster/moved.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 # Fix the name typo in the previous ConfigMap creation call
 moved {
   from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers

--- a/modules/beta-autopilot-public-cluster/moved.tf
+++ b/modules/beta-autopilot-public-cluster/moved.tf
@@ -32,6 +32,11 @@ moved {
 }
 
 moved {
+  from = kubernetes_config_map.ip-masq-agent
+  to   = kubernetes_config_map.ip_masq_agent
+}
+
+moved {
   from = google_project_iam_member.cluster_service_account-nodeService_account
   to   = google_project_iam_member.cluster_service_account_node_service_account
 }

--- a/modules/beta-autopilot-public-cluster/moved.tf
+++ b/modules/beta-autopilot-public-cluster/moved.tf
@@ -1,0 +1,46 @@
+# Fix the name typo in the previous ConfigMap creation call
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
+  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+}
+
+# Updates for kebab to snake case, to match best practices and Google style.
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns
+  to   = kubernetes_config_map_v1_data.kube_dns
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers-and-stub-domains
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers_and_stub_domains
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-nodeService_account
+  to   = google_project_iam_member.cluster_service_account_node_service_account
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-metric_writer
+  to   = google_project_iam_member.cluster_service_account_metric_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-resourceMetadata-writer
+  to   = google_project_iam_member.cluster_service_account_resource_metadata_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-gcr
+  to   = google_project_iam_member.cluster_service_account_gcr
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-artifact-registry
+  to   = google_project_iam_member.cluster_service_account_artifact_registry
+}

--- a/modules/beta-autopilot-public-cluster/moved.tf
+++ b/modules/beta-autopilot-public-cluster/moved.tf
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
 # Updates for kebab to snake case, to match best practices and Google style.
 moved {
   from = kubernetes_config_map_v1_data.kube-dns
   to   = kubernetes_config_map_v1_data.kube_dns
 }
 
+# Typo fix and snake case at the same time
 moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
   to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
 }
 

--- a/modules/beta-autopilot-public-cluster/sa.tf
+++ b/modules/beta-autopilot-public-cluster/sa.tf
@@ -46,35 +46,35 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
+resource "google_project_iam_member" "cluster_service_account_node_service_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
+resource "google_project_iam_member" "cluster_service_account_metric_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/monitoring.metricWriter"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
+resource "google_project_iam_member" "cluster_service_account_resource_metadata_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/stackdriver.resourceMetadata.writer"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-gcr" {
+resource "google_project_iam_member" "cluster_service_account_gcr" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/storage.objectViewer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
+resource "google_project_iam_member" "cluster_service_account_artifact_registry" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"

--- a/modules/beta-private-cluster-update-variant/dns.tf
+++ b/modules/beta-private-cluster-update-variant/dns.tf
@@ -20,7 +20,7 @@
   Manage kube-dns configmaps
  *****************************************/
 
-resource "kubernetes_config_map_v1_data" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube_dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -42,7 +42,7 @@ EOF
   ]
 }
 
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -64,13 +64,7 @@ EOF
   ]
 }
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers_and_stub_domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {

--- a/modules/beta-private-cluster-update-variant/masq.tf
+++ b/modules/beta-private-cluster-update-variant/masq.tf
@@ -19,7 +19,7 @@
 /******************************************
   Create ip-masq-agent confimap
  *****************************************/
-resource "kubernetes_config_map" "ip-masq-agent" {
+resource "kubernetes_config_map" "ip_masq_agent" {
   count = var.configure_ip_masq ? 1 : 0
 
   metadata {

--- a/modules/beta-private-cluster-update-variant/moved.tf
+++ b/modules/beta-private-cluster-update-variant/moved.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 # Fix the name typo in the previous ConfigMap creation call
 moved {
   from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers

--- a/modules/beta-private-cluster-update-variant/moved.tf
+++ b/modules/beta-private-cluster-update-variant/moved.tf
@@ -32,6 +32,11 @@ moved {
 }
 
 moved {
+  from = kubernetes_config_map.ip-masq-agent
+  to   = kubernetes_config_map.ip_masq_agent
+}
+
+moved {
   from = google_project_iam_member.cluster_service_account-nodeService_account
   to   = google_project_iam_member.cluster_service_account_node_service_account
 }

--- a/modules/beta-private-cluster-update-variant/moved.tf
+++ b/modules/beta-private-cluster-update-variant/moved.tf
@@ -1,0 +1,46 @@
+# Fix the name typo in the previous ConfigMap creation call
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
+  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+}
+
+# Updates for kebab to snake case, to match best practices and Google style.
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns
+  to   = kubernetes_config_map_v1_data.kube_dns
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers-and-stub-domains
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers_and_stub_domains
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-nodeService_account
+  to   = google_project_iam_member.cluster_service_account_node_service_account
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-metric_writer
+  to   = google_project_iam_member.cluster_service_account_metric_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-resourceMetadata-writer
+  to   = google_project_iam_member.cluster_service_account_resource_metadata_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-gcr
+  to   = google_project_iam_member.cluster_service_account_gcr
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-artifact-registry
+  to   = google_project_iam_member.cluster_service_account_artifact_registry
+}

--- a/modules/beta-private-cluster-update-variant/moved.tf
+++ b/modules/beta-private-cluster-update-variant/moved.tf
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
 # Updates for kebab to snake case, to match best practices and Google style.
 moved {
   from = kubernetes_config_map_v1_data.kube-dns
   to   = kubernetes_config_map_v1_data.kube_dns
 }
 
+# Typo fix and snake case at the same time
 moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
   to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
 }
 

--- a/modules/beta-private-cluster-update-variant/sa.tf
+++ b/modules/beta-private-cluster-update-variant/sa.tf
@@ -46,35 +46,35 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
+resource "google_project_iam_member" "cluster_service_account_node_service_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
+resource "google_project_iam_member" "cluster_service_account_metric_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/monitoring.metricWriter"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
+resource "google_project_iam_member" "cluster_service_account_resource_metadata_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/stackdriver.resourceMetadata.writer"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-gcr" {
+resource "google_project_iam_member" "cluster_service_account_gcr" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/storage.objectViewer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
+resource "google_project_iam_member" "cluster_service_account_artifact_registry" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"

--- a/modules/beta-private-cluster/dns.tf
+++ b/modules/beta-private-cluster/dns.tf
@@ -20,7 +20,7 @@
   Manage kube-dns configmaps
  *****************************************/
 
-resource "kubernetes_config_map_v1_data" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube_dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -42,7 +42,7 @@ EOF
   ]
 }
 
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -64,13 +64,7 @@ EOF
   ]
 }
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers_and_stub_domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {

--- a/modules/beta-private-cluster/masq.tf
+++ b/modules/beta-private-cluster/masq.tf
@@ -19,7 +19,7 @@
 /******************************************
   Create ip-masq-agent confimap
  *****************************************/
-resource "kubernetes_config_map" "ip-masq-agent" {
+resource "kubernetes_config_map" "ip_masq_agent" {
   count = var.configure_ip_masq ? 1 : 0
 
   metadata {

--- a/modules/beta-private-cluster/moved.tf
+++ b/modules/beta-private-cluster/moved.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 # Fix the name typo in the previous ConfigMap creation call
 moved {
   from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers

--- a/modules/beta-private-cluster/moved.tf
+++ b/modules/beta-private-cluster/moved.tf
@@ -32,6 +32,11 @@ moved {
 }
 
 moved {
+  from = kubernetes_config_map.ip-masq-agent
+  to   = kubernetes_config_map.ip_masq_agent
+}
+
+moved {
   from = google_project_iam_member.cluster_service_account-nodeService_account
   to   = google_project_iam_member.cluster_service_account_node_service_account
 }

--- a/modules/beta-private-cluster/moved.tf
+++ b/modules/beta-private-cluster/moved.tf
@@ -1,0 +1,46 @@
+# Fix the name typo in the previous ConfigMap creation call
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
+  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+}
+
+# Updates for kebab to snake case, to match best practices and Google style.
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns
+  to   = kubernetes_config_map_v1_data.kube_dns
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers-and-stub-domains
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers_and_stub_domains
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-nodeService_account
+  to   = google_project_iam_member.cluster_service_account_node_service_account
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-metric_writer
+  to   = google_project_iam_member.cluster_service_account_metric_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-resourceMetadata-writer
+  to   = google_project_iam_member.cluster_service_account_resource_metadata_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-gcr
+  to   = google_project_iam_member.cluster_service_account_gcr
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-artifact-registry
+  to   = google_project_iam_member.cluster_service_account_artifact_registry
+}

--- a/modules/beta-private-cluster/moved.tf
+++ b/modules/beta-private-cluster/moved.tf
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
 # Updates for kebab to snake case, to match best practices and Google style.
 moved {
   from = kubernetes_config_map_v1_data.kube-dns
   to   = kubernetes_config_map_v1_data.kube_dns
 }
 
+# Typo fix and snake case at the same time
 moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
   to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
 }
 

--- a/modules/beta-private-cluster/sa.tf
+++ b/modules/beta-private-cluster/sa.tf
@@ -46,35 +46,35 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
+resource "google_project_iam_member" "cluster_service_account_node_service_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
+resource "google_project_iam_member" "cluster_service_account_metric_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/monitoring.metricWriter"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
+resource "google_project_iam_member" "cluster_service_account_resource_metadata_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/stackdriver.resourceMetadata.writer"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-gcr" {
+resource "google_project_iam_member" "cluster_service_account_gcr" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/storage.objectViewer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
+resource "google_project_iam_member" "cluster_service_account_artifact_registry" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"

--- a/modules/beta-public-cluster-update-variant/dns.tf
+++ b/modules/beta-public-cluster-update-variant/dns.tf
@@ -20,7 +20,7 @@
   Manage kube-dns configmaps
  *****************************************/
 
-resource "kubernetes_config_map_v1_data" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube_dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -42,7 +42,7 @@ EOF
   ]
 }
 
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -64,13 +64,7 @@ EOF
   ]
 }
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers_and_stub_domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {

--- a/modules/beta-public-cluster-update-variant/masq.tf
+++ b/modules/beta-public-cluster-update-variant/masq.tf
@@ -19,7 +19,7 @@
 /******************************************
   Create ip-masq-agent confimap
  *****************************************/
-resource "kubernetes_config_map" "ip-masq-agent" {
+resource "kubernetes_config_map" "ip_masq_agent" {
   count = var.configure_ip_masq ? 1 : 0
 
   metadata {

--- a/modules/beta-public-cluster-update-variant/moved.tf
+++ b/modules/beta-public-cluster-update-variant/moved.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 # Fix the name typo in the previous ConfigMap creation call
 moved {
   from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers

--- a/modules/beta-public-cluster-update-variant/moved.tf
+++ b/modules/beta-public-cluster-update-variant/moved.tf
@@ -32,6 +32,11 @@ moved {
 }
 
 moved {
+  from = kubernetes_config_map.ip-masq-agent
+  to   = kubernetes_config_map.ip_masq_agent
+}
+
+moved {
   from = google_project_iam_member.cluster_service_account-nodeService_account
   to   = google_project_iam_member.cluster_service_account_node_service_account
 }

--- a/modules/beta-public-cluster-update-variant/moved.tf
+++ b/modules/beta-public-cluster-update-variant/moved.tf
@@ -1,0 +1,46 @@
+# Fix the name typo in the previous ConfigMap creation call
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
+  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+}
+
+# Updates for kebab to snake case, to match best practices and Google style.
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns
+  to   = kubernetes_config_map_v1_data.kube_dns
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers-and-stub-domains
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers_and_stub_domains
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-nodeService_account
+  to   = google_project_iam_member.cluster_service_account_node_service_account
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-metric_writer
+  to   = google_project_iam_member.cluster_service_account_metric_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-resourceMetadata-writer
+  to   = google_project_iam_member.cluster_service_account_resource_metadata_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-gcr
+  to   = google_project_iam_member.cluster_service_account_gcr
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-artifact-registry
+  to   = google_project_iam_member.cluster_service_account_artifact_registry
+}

--- a/modules/beta-public-cluster-update-variant/moved.tf
+++ b/modules/beta-public-cluster-update-variant/moved.tf
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
 # Updates for kebab to snake case, to match best practices and Google style.
 moved {
   from = kubernetes_config_map_v1_data.kube-dns
   to   = kubernetes_config_map_v1_data.kube_dns
 }
 
+# Typo fix and snake case at the same time
 moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
   to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
 }
 

--- a/modules/beta-public-cluster-update-variant/sa.tf
+++ b/modules/beta-public-cluster-update-variant/sa.tf
@@ -46,35 +46,35 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
+resource "google_project_iam_member" "cluster_service_account_node_service_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
+resource "google_project_iam_member" "cluster_service_account_metric_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/monitoring.metricWriter"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
+resource "google_project_iam_member" "cluster_service_account_resource_metadata_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/stackdriver.resourceMetadata.writer"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-gcr" {
+resource "google_project_iam_member" "cluster_service_account_gcr" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/storage.objectViewer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
+resource "google_project_iam_member" "cluster_service_account_artifact_registry" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"

--- a/modules/beta-public-cluster/dns.tf
+++ b/modules/beta-public-cluster/dns.tf
@@ -20,7 +20,7 @@
   Manage kube-dns configmaps
  *****************************************/
 
-resource "kubernetes_config_map_v1_data" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube_dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -42,7 +42,7 @@ EOF
   ]
 }
 
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -64,13 +64,7 @@ EOF
   ]
 }
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers_and_stub_domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {

--- a/modules/beta-public-cluster/masq.tf
+++ b/modules/beta-public-cluster/masq.tf
@@ -19,7 +19,7 @@
 /******************************************
   Create ip-masq-agent confimap
  *****************************************/
-resource "kubernetes_config_map" "ip-masq-agent" {
+resource "kubernetes_config_map" "ip_masq_agent" {
   count = var.configure_ip_masq ? 1 : 0
 
   metadata {

--- a/modules/beta-public-cluster/moved.tf
+++ b/modules/beta-public-cluster/moved.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 # Fix the name typo in the previous ConfigMap creation call
 moved {
   from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers

--- a/modules/beta-public-cluster/moved.tf
+++ b/modules/beta-public-cluster/moved.tf
@@ -32,6 +32,11 @@ moved {
 }
 
 moved {
+  from = kubernetes_config_map.ip-masq-agent
+  to   = kubernetes_config_map.ip_masq_agent
+}
+
+moved {
   from = google_project_iam_member.cluster_service_account-nodeService_account
   to   = google_project_iam_member.cluster_service_account_node_service_account
 }

--- a/modules/beta-public-cluster/moved.tf
+++ b/modules/beta-public-cluster/moved.tf
@@ -1,0 +1,46 @@
+# Fix the name typo in the previous ConfigMap creation call
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
+  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+}
+
+# Updates for kebab to snake case, to match best practices and Google style.
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns
+  to   = kubernetes_config_map_v1_data.kube_dns
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers-and-stub-domains
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers_and_stub_domains
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-nodeService_account
+  to   = google_project_iam_member.cluster_service_account_node_service_account
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-metric_writer
+  to   = google_project_iam_member.cluster_service_account_metric_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-resourceMetadata-writer
+  to   = google_project_iam_member.cluster_service_account_resource_metadata_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-gcr
+  to   = google_project_iam_member.cluster_service_account_gcr
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-artifact-registry
+  to   = google_project_iam_member.cluster_service_account_artifact_registry
+}

--- a/modules/beta-public-cluster/moved.tf
+++ b/modules/beta-public-cluster/moved.tf
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
 # Updates for kebab to snake case, to match best practices and Google style.
 moved {
   from = kubernetes_config_map_v1_data.kube-dns
   to   = kubernetes_config_map_v1_data.kube_dns
 }
 
+# Typo fix and snake case at the same time
 moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
   to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
 }
 

--- a/modules/beta-public-cluster/sa.tf
+++ b/modules/beta-public-cluster/sa.tf
@@ -46,35 +46,35 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
+resource "google_project_iam_member" "cluster_service_account_node_service_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
+resource "google_project_iam_member" "cluster_service_account_metric_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/monitoring.metricWriter"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
+resource "google_project_iam_member" "cluster_service_account_resource_metadata_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/stackdriver.resourceMetadata.writer"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-gcr" {
+resource "google_project_iam_member" "cluster_service_account_gcr" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/storage.objectViewer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
+resource "google_project_iam_member" "cluster_service_account_artifact_registry" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"

--- a/modules/private-cluster-update-variant/dns.tf
+++ b/modules/private-cluster-update-variant/dns.tf
@@ -20,7 +20,7 @@
   Manage kube-dns configmaps
  *****************************************/
 
-resource "kubernetes_config_map_v1_data" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube_dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -42,7 +42,7 @@ EOF
   ]
 }
 
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -64,13 +64,7 @@ EOF
   ]
 }
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers_and_stub_domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {

--- a/modules/private-cluster-update-variant/masq.tf
+++ b/modules/private-cluster-update-variant/masq.tf
@@ -19,7 +19,7 @@
 /******************************************
   Create ip-masq-agent confimap
  *****************************************/
-resource "kubernetes_config_map" "ip-masq-agent" {
+resource "kubernetes_config_map" "ip_masq_agent" {
   count = var.configure_ip_masq ? 1 : 0
 
   metadata {

--- a/modules/private-cluster-update-variant/moved.tf
+++ b/modules/private-cluster-update-variant/moved.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 # Fix the name typo in the previous ConfigMap creation call
 moved {
   from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers

--- a/modules/private-cluster-update-variant/moved.tf
+++ b/modules/private-cluster-update-variant/moved.tf
@@ -32,6 +32,11 @@ moved {
 }
 
 moved {
+  from = kubernetes_config_map.ip-masq-agent
+  to   = kubernetes_config_map.ip_masq_agent
+}
+
+moved {
   from = google_project_iam_member.cluster_service_account-nodeService_account
   to   = google_project_iam_member.cluster_service_account_node_service_account
 }

--- a/modules/private-cluster-update-variant/moved.tf
+++ b/modules/private-cluster-update-variant/moved.tf
@@ -1,0 +1,46 @@
+# Fix the name typo in the previous ConfigMap creation call
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
+  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+}
+
+# Updates for kebab to snake case, to match best practices and Google style.
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns
+  to   = kubernetes_config_map_v1_data.kube_dns
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers-and-stub-domains
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers_and_stub_domains
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-nodeService_account
+  to   = google_project_iam_member.cluster_service_account_node_service_account
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-metric_writer
+  to   = google_project_iam_member.cluster_service_account_metric_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-resourceMetadata-writer
+  to   = google_project_iam_member.cluster_service_account_resource_metadata_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-gcr
+  to   = google_project_iam_member.cluster_service_account_gcr
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-artifact-registry
+  to   = google_project_iam_member.cluster_service_account_artifact_registry
+}

--- a/modules/private-cluster-update-variant/moved.tf
+++ b/modules/private-cluster-update-variant/moved.tf
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
 # Updates for kebab to snake case, to match best practices and Google style.
 moved {
   from = kubernetes_config_map_v1_data.kube-dns
   to   = kubernetes_config_map_v1_data.kube_dns
 }
 
+# Typo fix and snake case at the same time
 moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
   to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
 }
 

--- a/modules/private-cluster-update-variant/sa.tf
+++ b/modules/private-cluster-update-variant/sa.tf
@@ -46,35 +46,35 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
+resource "google_project_iam_member" "cluster_service_account_node_service_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
+resource "google_project_iam_member" "cluster_service_account_metric_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/monitoring.metricWriter"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
+resource "google_project_iam_member" "cluster_service_account_resource_metadata_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/stackdriver.resourceMetadata.writer"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-gcr" {
+resource "google_project_iam_member" "cluster_service_account_gcr" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/storage.objectViewer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
+resource "google_project_iam_member" "cluster_service_account_artifact_registry" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"

--- a/modules/private-cluster/dns.tf
+++ b/modules/private-cluster/dns.tf
@@ -20,7 +20,7 @@
   Manage kube-dns configmaps
  *****************************************/
 
-resource "kubernetes_config_map_v1_data" "kube-dns" {
+resource "kubernetes_config_map_v1_data" "kube_dns" {
   count = local.custom_kube_dns_config && !local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -42,7 +42,7 @@ EOF
   ]
 }
 
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers" {
   count = !local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {
@@ -64,13 +64,7 @@ EOF
   ]
 }
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
-resource "kubernetes_config_map_v1_data" "kube-dns-upstream-nameservers-and-stub-domains" {
+resource "kubernetes_config_map_v1_data" "kube_dns_upstream_nameservers_and_stub_domains" {
   count = local.custom_kube_dns_config && local.upstream_nameservers_config ? 1 : 0
 
   metadata {

--- a/modules/private-cluster/masq.tf
+++ b/modules/private-cluster/masq.tf
@@ -19,7 +19,7 @@
 /******************************************
   Create ip-masq-agent confimap
  *****************************************/
-resource "kubernetes_config_map" "ip-masq-agent" {
+resource "kubernetes_config_map" "ip_masq_agent" {
   count = var.configure_ip_masq ? 1 : 0
 
   metadata {

--- a/modules/private-cluster/moved.tf
+++ b/modules/private-cluster/moved.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 # Fix the name typo in the previous ConfigMap creation call
 moved {
   from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers

--- a/modules/private-cluster/moved.tf
+++ b/modules/private-cluster/moved.tf
@@ -32,6 +32,11 @@ moved {
 }
 
 moved {
+  from = kubernetes_config_map.ip-masq-agent
+  to   = kubernetes_config_map.ip_masq_agent
+}
+
+moved {
   from = google_project_iam_member.cluster_service_account-nodeService_account
   to   = google_project_iam_member.cluster_service_account_node_service_account
 }

--- a/modules/private-cluster/moved.tf
+++ b/modules/private-cluster/moved.tf
@@ -1,0 +1,46 @@
+# Fix the name typo in the previous ConfigMap creation call
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
+  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+}
+
+# Updates for kebab to snake case, to match best practices and Google style.
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns
+  to   = kubernetes_config_map_v1_data.kube_dns
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers-and-stub-domains
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers_and_stub_domains
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-nodeService_account
+  to   = google_project_iam_member.cluster_service_account_node_service_account
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-metric_writer
+  to   = google_project_iam_member.cluster_service_account_metric_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-resourceMetadata-writer
+  to   = google_project_iam_member.cluster_service_account_resource_metadata_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-gcr
+  to   = google_project_iam_member.cluster_service_account_gcr
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-artifact-registry
+  to   = google_project_iam_member.cluster_service_account_artifact_registry
+}

--- a/modules/private-cluster/moved.tf
+++ b/modules/private-cluster/moved.tf
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
 # Updates for kebab to snake case, to match best practices and Google style.
 moved {
   from = kubernetes_config_map_v1_data.kube-dns
   to   = kubernetes_config_map_v1_data.kube_dns
 }
 
+# Typo fix and snake case at the same time
 moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
   to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
 }
 

--- a/modules/private-cluster/sa.tf
+++ b/modules/private-cluster/sa.tf
@@ -46,35 +46,35 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
+resource "google_project_iam_member" "cluster_service_account_node_service_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
+resource "google_project_iam_member" "cluster_service_account_metric_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/monitoring.metricWriter"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
+resource "google_project_iam_member" "cluster_service_account_resource_metadata_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/stackdriver.resourceMetadata.writer"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-gcr" {
+resource "google_project_iam_member" "cluster_service_account_gcr" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/storage.objectViewer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
+resource "google_project_iam_member" "cluster_service_account_artifact_registry" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"

--- a/moved.tf
+++ b/moved.tf
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 # Fix the name typo in the previous ConfigMap creation call
 moved {
   from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers

--- a/moved.tf
+++ b/moved.tf
@@ -32,6 +32,11 @@ moved {
 }
 
 moved {
+  from = kubernetes_config_map.ip-masq-agent
+  to   = kubernetes_config_map.ip_masq_agent
+}
+
+moved {
   from = google_project_iam_member.cluster_service_account-nodeService_account
   to   = google_project_iam_member.cluster_service_account_node_service_account
 }

--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,46 @@
+# Fix the name typo in the previous ConfigMap creation call
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
+  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+}
+
+# Updates for kebab to snake case, to match best practices and Google style.
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns
+  to   = kubernetes_config_map_v1_data.kube_dns
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
+}
+
+moved {
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers-and-stub-domains
+  to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers_and_stub_domains
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-nodeService_account
+  to   = google_project_iam_member.cluster_service_account_node_service_account
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-metric_writer
+  to   = google_project_iam_member.cluster_service_account_metric_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-resourceMetadata-writer
+  to   = google_project_iam_member.cluster_service_account_resource_metadata_writer
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-gcr
+  to   = google_project_iam_member.cluster_service_account_gcr
+}
+
+moved {
+  from = google_project_iam_member.cluster_service_account-artifact-registry
+  to   = google_project_iam_member.cluster_service_account_artifact_registry
+}

--- a/moved.tf
+++ b/moved.tf
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-# Fix the name typo in the previous ConfigMap creation call
-moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
-  to   = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
-}
-
 # Updates for kebab to snake case, to match best practices and Google style.
 moved {
   from = kubernetes_config_map_v1_data.kube-dns
   to   = kubernetes_config_map_v1_data.kube_dns
 }
 
+# Typo fix and snake case at the same time
 moved {
-  from = kubernetes_config_map_v1_data.kube-dns-upstream-nameservers
+  from = kubernetes_config_map_v1_data.kube-dns-upstream-namservers
   to   = kubernetes_config_map_v1_data.kube_dns_upstream_nameservers
 }
 

--- a/sa.tf
+++ b/sa.tf
@@ -46,35 +46,35 @@ resource "google_service_account" "cluster_service_account" {
   display_name = "Terraform-managed service account for cluster ${var.name}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-nodeService_account" {
+resource "google_project_iam_member" "cluster_service_account_node_service_account" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/container.defaultNodeServiceAccount"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-metric_writer" {
+resource "google_project_iam_member" "cluster_service_account_metric_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/monitoring.metricWriter"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-resourceMetadata-writer" {
+resource "google_project_iam_member" "cluster_service_account_resource_metadata_writer" {
   count   = var.create_service_account ? 1 : 0
   project = google_service_account.cluster_service_account[0].project
   role    = "roles/stackdriver.resourceMetadata.writer"
   member  = google_service_account.cluster_service_account[0].member
 }
 
-resource "google_project_iam_member" "cluster_service_account-gcr" {
+resource "google_project_iam_member" "cluster_service_account_gcr" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/storage.objectViewer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 
-resource "google_project_iam_member" "cluster_service_account-artifact-registry" {
+resource "google_project_iam_member" "cluster_service_account_artifact_registry" {
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"


### PR DESCRIPTION
- Update resource names to snake_case
- Add `moved` blocks for resources and consolidate into `moved.tf`

I considered keeping `-` as a separator between the two parts for the `google_project_iam_member` resources, but ended up landing on just keeping everything snake case.

Followup to #2149