### PR TITLE
feat(TPG>=6.7.0)!: promote `secret_manager_config` to GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Then perform the following commands on the root folder:
 | enable\_mesh\_certificates | Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity. | `bool` | `false` | no |
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
+| enable\_secret\_manager\_addon | Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | `bool` | `true` | no |
 | enable\_tpu | Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | `bool` | `false` | no |
@@ -282,6 +283,7 @@ Then perform the following commands on the root folder:
 | node\_pools\_versions | Node pool versions by node pool name |
 | region | Cluster region |
 | release\_channel | The release channel of this cluster |
+| secret\_manager\_addon\_enabled | Whether Secret Manager add-on is enabled |
 | service\_account | The service account to default running nodes as if not overridden in `node_pools`. |
 | tpu\_ipv4\_cidr\_block | The IP range in CIDR notation used for the TPUs |
 | type | Cluster type (regional / zonal) |

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -243,7 +243,6 @@ resource "google_container_cluster" "primary" {
 
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
-{% if beta_cluster %}
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {
@@ -251,6 +250,7 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+{% if beta_cluster %}
   enable_fqdn_network_policy = var.enable_fqdn_network_policy
 {% endif %}
 {% if autopilot_cluster %}

--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -167,12 +167,12 @@ locals {
   cluster_output_vertical_pod_autoscaling_enabled   = google_container_cluster.primary.vertical_pod_autoscaling != null && length(google_container_cluster.primary.vertical_pod_autoscaling) == 1 ? google_container_cluster.primary.vertical_pod_autoscaling[0].enabled : false
   cluster_output_intranode_visbility_enabled        = google_container_cluster.primary.enable_intranode_visibility
   cluster_output_identity_service_enabled           = google_container_cluster.primary.identity_service_config != null && length(google_container_cluster.primary.identity_service_config) == 1 ? google_container_cluster.primary.identity_service_config[0].enabled : false
+  cluster_output_secret_manager_addon_enabled       = google_container_cluster.primary.secret_manager_config != null && length(google_container_cluster.primary.secret_manager_config) == 1 ? google_container_cluster.primary.secret_manager_config[0].enabled : false
 
 {% if beta_cluster %}
   # BETA features
-  cluster_output_istio_disabled                   = google_container_cluster.primary.addons_config[0].istio_config != null && length(google_container_cluster.primary.addons_config[0].istio_config) == 1 ? google_container_cluster.primary.addons_config[0].istio_config[0].disabled : false
-  cluster_output_pod_security_policy_enabled      = google_container_cluster.primary.pod_security_policy_config != null && length(google_container_cluster.primary.pod_security_policy_config) == 1 ? google_container_cluster.primary.pod_security_policy_config[0].enabled : false
-  cluster_output_secret_manager_addon_enabled     = google_container_cluster.primary.secret_manager_config != null && length(google_container_cluster.primary.secret_manager_config) == 1 ? google_container_cluster.primary.secret_manager_config[0].enabled : false
+  cluster_output_istio_disabled              = google_container_cluster.primary.addons_config[0].istio_config != null && length(google_container_cluster.primary.addons_config[0].istio_config) == 1 ? google_container_cluster.primary.addons_config[0].istio_config[0].disabled : false
+  cluster_output_pod_security_policy_enabled = google_container_cluster.primary.pod_security_policy_config != null && length(google_container_cluster.primary.pod_security_policy_config) == 1 ? google_container_cluster.primary.pod_security_policy_config[0].enabled : false
 
   # /BETA features
   {% endif %}
@@ -225,6 +225,7 @@ locals {
   confidential_node_config                 = var.enable_confidential_nodes == true ? [{ enabled = true }] : []
   cluster_intranode_visibility_enabled     = local.cluster_output_intranode_visbility_enabled
   cluster_identity_service_enabled         = local.cluster_output_identity_service_enabled
+  cluster_secret_manager_addon_enabled     = local.cluster_output_secret_manager_addon_enabled
   {% if autopilot_cluster != true %}
   cluster_mesh_certificates_config = local.workload_identity_enabled ? [{
     enable_certificates = var.enable_mesh_certificates
@@ -233,12 +234,11 @@ locals {
 
 {% if beta_cluster %}
   # BETA features
-  cluster_istio_enabled                    = ! local.cluster_output_istio_disabled
+  cluster_istio_enabled               = !local.cluster_output_istio_disabled
   {% if autopilot_cluster != true %}
-  cluster_telemetry_type_is_set            = var.cluster_telemetry_type != null
+  cluster_telemetry_type_is_set       = var.cluster_telemetry_type != null
   {% endif %}
-  cluster_pod_security_policy_enabled      = local.cluster_output_pod_security_policy_enabled
-  cluster_secret_manager_addon_enabled     = local.cluster_output_secret_manager_addon_enabled
+  cluster_pod_security_policy_enabled = local.cluster_output_pod_security_policy_enabled
 
   # /BETA features
 {% endif %}

--- a/autogen/main/outputs.tf.tmpl
+++ b/autogen/main/outputs.tf.tmpl
@@ -223,11 +223,6 @@ output "pod_security_policy_enabled" {
   description = "Whether pod security policy is enabled"
   value       = local.cluster_pod_security_policy_enabled
 }
-
-output "secret_manager_addon_enabled" {
-  description = "Whether Secret Manager add-on is enabled"
-  value       = local.cluster_secret_manager_addon_enabled
-}
 {% endif %}
 
 output "identity_service_enabled" {
@@ -238,6 +233,11 @@ output "identity_service_enabled" {
 output "intranode_visibility_enabled" {
   description = "Whether intra-node visibility is enabled"
   value       = local.cluster_intranode_visibility_enabled
+}
+
+output "secret_manager_addon_enabled" {
+  description = "Whether Secret Manager add-on is enabled"
+  value       = local.cluster_secret_manager_addon_enabled
 }
 
 output "fleet_membership" {

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -613,6 +613,12 @@ variable "enable_confidential_nodes" {
   description = "An optional flag to enable confidential node config."
   default = false
 }
+
+variable "enable_secret_manager_addon" {
+  description = "Enable the Secret Manager add-on for this cluster"
+  type        = bool
+  default     = false
+}
 {% if beta_cluster %}
 
 variable "workload_vulnerability_mode" {
@@ -631,12 +637,6 @@ variable "enable_fqdn_network_policy" {
   type        = bool
   description = "Enable FQDN Network Policies on the cluster"
   default     = null
-}
-
-variable "enable_secret_manager_addon" {
-  description = "(Beta) Enable the Secret Manager add-on for this cluster"
-  type        = bool
-  default     = false
 }
 {% endif %}
 

--- a/autogen/main/versions.tf.tmpl
+++ b/autogen/main/versions.tf.tmpl
@@ -24,11 +24,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.44.2, !=6.0.0, !=6.0.1, !=6.1.0, !=6.2.0, !=6.3.0, !=6.4.0, !=6.5.0, !=6.6.0, < 7"
+      version = ">= 6.7.0, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.44.2, !=6.0.0, !=6.0.1, !=6.1.0, !=6.2.0, !=6.3.0, !=6.4.0, !=6.5.0, !=6.6.0, < 7"
+      version = ">= 6.7.0, < 7"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -86,7 +86,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.44.2, !=6.0.0, !=6.0.1, !=6.1.0, !=6.2.0, !=6.3.0, !=6.4.0, !=6.5.0, !=6.6.0, < 7"
+      version = ">= 6.7.0, < 7"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/cluster.tf
+++ b/cluster.tf
@@ -189,6 +189,13 @@ resource "google_container_cluster" "primary" {
 
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
+  dynamic "secret_manager_config" {
+    for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
+    content {
+      enabled = secret_manager_config.value
+    }
+  }
+
   dynamic "master_authorized_networks_config" {
     for_each = var.gcp_public_cidrs_access_enabled != null || length(var.master_authorized_networks) > 0 ? [true] : []
     content {

--- a/examples/simple_regional_private/main.tf
+++ b/examples/simple_regional_private/main.tf
@@ -36,22 +36,23 @@ module "gke" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
   version = "~> 33.0"
 
-  project_id                = var.project_id
-  name                      = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
-  regional                  = true
-  region                    = var.region
-  network                   = var.network
-  subnetwork                = var.subnetwork
-  ip_range_pods             = var.ip_range_pods
-  ip_range_services         = var.ip_range_services
-  create_service_account    = false
-  service_account           = var.compute_engine_service_account
-  enable_private_endpoint   = true
-  enable_private_nodes      = true
-  master_ipv4_cidr_block    = "172.16.0.0/28"
-  default_max_pods_per_node = 20
-  remove_default_node_pool  = true
-  deletion_protection       = false
+  project_id                  = var.project_id
+  name                        = "${local.cluster_type}-cluster${var.cluster_name_suffix}"
+  regional                    = true
+  region                      = var.region
+  network                     = var.network
+  subnetwork                  = var.subnetwork
+  ip_range_pods               = var.ip_range_pods
+  ip_range_services           = var.ip_range_services
+  create_service_account      = false
+  service_account             = var.compute_engine_service_account
+  enable_private_endpoint     = true
+  enable_private_nodes        = true
+  enable_secret_manager_addon = true
+  master_ipv4_cidr_block      = "172.16.0.0/28"
+  default_max_pods_per_node   = 20
+  remove_default_node_pool    = true
+  deletion_protection         = false
 
   node_pools = [
     {

--- a/main.tf
+++ b/main.tf
@@ -125,6 +125,7 @@ locals {
   cluster_output_vertical_pod_autoscaling_enabled   = google_container_cluster.primary.vertical_pod_autoscaling != null && length(google_container_cluster.primary.vertical_pod_autoscaling) == 1 ? google_container_cluster.primary.vertical_pod_autoscaling[0].enabled : false
   cluster_output_intranode_visbility_enabled        = google_container_cluster.primary.enable_intranode_visibility
   cluster_output_identity_service_enabled           = google_container_cluster.primary.identity_service_config != null && length(google_container_cluster.primary.identity_service_config) == 1 ? google_container_cluster.primary.identity_service_config[0].enabled : false
+  cluster_output_secret_manager_addon_enabled       = google_container_cluster.primary.secret_manager_config != null && length(google_container_cluster.primary.secret_manager_config) == 1 ? google_container_cluster.primary.secret_manager_config[0].enabled : false
 
   cluster_output_node_pools_names = concat(
     [for np in google_container_node_pool.pools : np.name], [""],
@@ -166,6 +167,7 @@ locals {
   confidential_node_config             = var.enable_confidential_nodes == true ? [{ enabled = true }] : []
   cluster_intranode_visibility_enabled = local.cluster_output_intranode_visbility_enabled
   cluster_identity_service_enabled     = local.cluster_output_identity_service_enabled
+  cluster_secret_manager_addon_enabled = local.cluster_output_secret_manager_addon_enabled
   cluster_mesh_certificates_config = local.workload_identity_enabled ? [{
     enable_certificates = var.enable_mesh_certificates
   }] : []

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -99,7 +99,7 @@ Then perform the following commands on the root folder:
 | enable\_private\_endpoint | Whether the master's internal IP address is used as the cluster endpoint | `bool` | `false` | no |
 | enable\_private\_nodes | Whether nodes have internal IP addresses only | `bool` | `true` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
-| enable\_secret\_manager\_addon | (Beta) Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
+| enable\_secret\_manager\_addon | Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
 | enable\_tpu | Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | `bool` | `true` | no |
 | filestore\_csi\_driver | The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes | `bool` | `false` | no |

--- a/modules/beta-autopilot-private-cluster/main.tf
+++ b/modules/beta-autopilot-private-cluster/main.tf
@@ -91,11 +91,11 @@ locals {
   cluster_output_vertical_pod_autoscaling_enabled   = google_container_cluster.primary.vertical_pod_autoscaling != null && length(google_container_cluster.primary.vertical_pod_autoscaling) == 1 ? google_container_cluster.primary.vertical_pod_autoscaling[0].enabled : false
   cluster_output_intranode_visbility_enabled        = google_container_cluster.primary.enable_intranode_visibility
   cluster_output_identity_service_enabled           = google_container_cluster.primary.identity_service_config != null && length(google_container_cluster.primary.identity_service_config) == 1 ? google_container_cluster.primary.identity_service_config[0].enabled : false
+  cluster_output_secret_manager_addon_enabled       = google_container_cluster.primary.secret_manager_config != null && length(google_container_cluster.primary.secret_manager_config) == 1 ? google_container_cluster.primary.secret_manager_config[0].enabled : false
 
   # BETA features
-  cluster_output_istio_disabled               = google_container_cluster.primary.addons_config[0].istio_config != null && length(google_container_cluster.primary.addons_config[0].istio_config) == 1 ? google_container_cluster.primary.addons_config[0].istio_config[0].disabled : false
-  cluster_output_pod_security_policy_enabled  = google_container_cluster.primary.pod_security_policy_config != null && length(google_container_cluster.primary.pod_security_policy_config) == 1 ? google_container_cluster.primary.pod_security_policy_config[0].enabled : false
-  cluster_output_secret_manager_addon_enabled = google_container_cluster.primary.secret_manager_config != null && length(google_container_cluster.primary.secret_manager_config) == 1 ? google_container_cluster.primary.secret_manager_config[0].enabled : false
+  cluster_output_istio_disabled              = google_container_cluster.primary.addons_config[0].istio_config != null && length(google_container_cluster.primary.addons_config[0].istio_config) == 1 ? google_container_cluster.primary.addons_config[0].istio_config[0].disabled : false
+  cluster_output_pod_security_policy_enabled = google_container_cluster.primary.pod_security_policy_config != null && length(google_container_cluster.primary.pod_security_policy_config) == 1 ? google_container_cluster.primary.pod_security_policy_config[0].enabled : false
 
   # /BETA features
 
@@ -125,11 +125,11 @@ locals {
   confidential_node_config             = var.enable_confidential_nodes == true ? [{ enabled = true }] : []
   cluster_intranode_visibility_enabled = local.cluster_output_intranode_visbility_enabled
   cluster_identity_service_enabled     = local.cluster_output_identity_service_enabled
+  cluster_secret_manager_addon_enabled = local.cluster_output_secret_manager_addon_enabled
 
   # BETA features
-  cluster_istio_enabled                = !local.cluster_output_istio_disabled
-  cluster_pod_security_policy_enabled  = local.cluster_output_pod_security_policy_enabled
-  cluster_secret_manager_addon_enabled = local.cluster_output_secret_manager_addon_enabled
+  cluster_istio_enabled               = !local.cluster_output_istio_disabled
+  cluster_pod_security_policy_enabled = local.cluster_output_pod_security_policy_enabled
 
   # /BETA features
 

--- a/modules/beta-autopilot-private-cluster/outputs.tf
+++ b/modules/beta-autopilot-private-cluster/outputs.tf
@@ -179,11 +179,6 @@ output "pod_security_policy_enabled" {
   value       = local.cluster_pod_security_policy_enabled
 }
 
-output "secret_manager_addon_enabled" {
-  description = "Whether Secret Manager add-on is enabled"
-  value       = local.cluster_secret_manager_addon_enabled
-}
-
 output "identity_service_enabled" {
   description = "Whether Identity Service is enabled"
   value       = local.cluster_identity_service_enabled
@@ -192,6 +187,11 @@ output "identity_service_enabled" {
 output "intranode_visibility_enabled" {
   description = "Whether intra-node visibility is enabled"
   value       = local.cluster_intranode_visibility_enabled
+}
+
+output "secret_manager_addon_enabled" {
+  description = "Whether Secret Manager add-on is enabled"
+  value       = local.cluster_secret_manager_addon_enabled
 }
 
 output "fleet_membership" {

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -382,6 +382,12 @@ variable "enable_confidential_nodes" {
   default     = false
 }
 
+variable "enable_secret_manager_addon" {
+  description = "Enable the Secret Manager add-on for this cluster"
+  type        = bool
+  default     = false
+}
+
 variable "workload_vulnerability_mode" {
   description = "(beta) Sets which mode to use for Protect workload vulnerability scanning feature. Accepted values are DISABLED, BASIC."
   type        = string
@@ -398,12 +404,6 @@ variable "enable_fqdn_network_policy" {
   type        = bool
   description = "Enable FQDN Network Policies on the cluster"
   default     = null
-}
-
-variable "enable_secret_manager_addon" {
-  description = "(Beta) Enable the Secret Manager add-on for this cluster"
-  type        = bool
-  default     = false
 }
 
 variable "enable_cilium_clusterwide_network_policy" {

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -90,7 +90,7 @@ Then perform the following commands on the root folder:
 | enable\_l4\_ilb\_subsetting | Enable L4 ILB Subsetting on the cluster | `bool` | `false` | no |
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
-| enable\_secret\_manager\_addon | (Beta) Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
+| enable\_secret\_manager\_addon | Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
 | enable\_tpu | Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | `bool` | `true` | no |
 | filestore\_csi\_driver | The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes | `bool` | `false` | no |

--- a/modules/beta-autopilot-public-cluster/main.tf
+++ b/modules/beta-autopilot-public-cluster/main.tf
@@ -90,11 +90,11 @@ locals {
   cluster_output_vertical_pod_autoscaling_enabled   = google_container_cluster.primary.vertical_pod_autoscaling != null && length(google_container_cluster.primary.vertical_pod_autoscaling) == 1 ? google_container_cluster.primary.vertical_pod_autoscaling[0].enabled : false
   cluster_output_intranode_visbility_enabled        = google_container_cluster.primary.enable_intranode_visibility
   cluster_output_identity_service_enabled           = google_container_cluster.primary.identity_service_config != null && length(google_container_cluster.primary.identity_service_config) == 1 ? google_container_cluster.primary.identity_service_config[0].enabled : false
+  cluster_output_secret_manager_addon_enabled       = google_container_cluster.primary.secret_manager_config != null && length(google_container_cluster.primary.secret_manager_config) == 1 ? google_container_cluster.primary.secret_manager_config[0].enabled : false
 
   # BETA features
-  cluster_output_istio_disabled               = google_container_cluster.primary.addons_config[0].istio_config != null && length(google_container_cluster.primary.addons_config[0].istio_config) == 1 ? google_container_cluster.primary.addons_config[0].istio_config[0].disabled : false
-  cluster_output_pod_security_policy_enabled  = google_container_cluster.primary.pod_security_policy_config != null && length(google_container_cluster.primary.pod_security_policy_config) == 1 ? google_container_cluster.primary.pod_security_policy_config[0].enabled : false
-  cluster_output_secret_manager_addon_enabled = google_container_cluster.primary.secret_manager_config != null && length(google_container_cluster.primary.secret_manager_config) == 1 ? google_container_cluster.primary.secret_manager_config[0].enabled : false
+  cluster_output_istio_disabled              = google_container_cluster.primary.addons_config[0].istio_config != null && length(google_container_cluster.primary.addons_config[0].istio_config) == 1 ? google_container_cluster.primary.addons_config[0].istio_config[0].disabled : false
+  cluster_output_pod_security_policy_enabled = google_container_cluster.primary.pod_security_policy_config != null && length(google_container_cluster.primary.pod_security_policy_config) == 1 ? google_container_cluster.primary.pod_security_policy_config[0].enabled : false
 
   # /BETA features
 
@@ -124,11 +124,11 @@ locals {
   confidential_node_config             = var.enable_confidential_nodes == true ? [{ enabled = true }] : []
   cluster_intranode_visibility_enabled = local.cluster_output_intranode_visbility_enabled
   cluster_identity_service_enabled     = local.cluster_output_identity_service_enabled
+  cluster_secret_manager_addon_enabled = local.cluster_output_secret_manager_addon_enabled
 
   # BETA features
-  cluster_istio_enabled                = !local.cluster_output_istio_disabled
-  cluster_pod_security_policy_enabled  = local.cluster_output_pod_security_policy_enabled
-  cluster_secret_manager_addon_enabled = local.cluster_output_secret_manager_addon_enabled
+  cluster_istio_enabled               = !local.cluster_output_istio_disabled
+  cluster_pod_security_policy_enabled = local.cluster_output_pod_security_policy_enabled
 
   # /BETA features
 

--- a/modules/beta-autopilot-public-cluster/outputs.tf
+++ b/modules/beta-autopilot-public-cluster/outputs.tf
@@ -169,11 +169,6 @@ output "pod_security_policy_enabled" {
   value       = local.cluster_pod_security_policy_enabled
 }
 
-output "secret_manager_addon_enabled" {
-  description = "Whether Secret Manager add-on is enabled"
-  value       = local.cluster_secret_manager_addon_enabled
-}
-
 output "identity_service_enabled" {
   description = "Whether Identity Service is enabled"
   value       = local.cluster_identity_service_enabled
@@ -182,6 +177,11 @@ output "identity_service_enabled" {
 output "intranode_visibility_enabled" {
   description = "Whether intra-node visibility is enabled"
   value       = local.cluster_intranode_visibility_enabled
+}
+
+output "secret_manager_addon_enabled" {
+  description = "Whether Secret Manager add-on is enabled"
+  value       = local.cluster_secret_manager_addon_enabled
 }
 
 output "fleet_membership" {

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -346,6 +346,12 @@ variable "enable_confidential_nodes" {
   default     = false
 }
 
+variable "enable_secret_manager_addon" {
+  description = "Enable the Secret Manager add-on for this cluster"
+  type        = bool
+  default     = false
+}
+
 variable "workload_vulnerability_mode" {
   description = "(beta) Sets which mode to use for Protect workload vulnerability scanning feature. Accepted values are DISABLED, BASIC."
   type        = string
@@ -362,12 +368,6 @@ variable "enable_fqdn_network_policy" {
   type        = bool
   description = "Enable FQDN Network Policies on the cluster"
   default     = null
-}
-
-variable "enable_secret_manager_addon" {
-  description = "(Beta) Enable the Secret Manager add-on for this cluster"
-  type        = bool
-  default     = false
 }
 
 variable "enable_cilium_clusterwide_network_policy" {

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -214,7 +214,7 @@ Then perform the following commands on the root folder:
 | enable\_private\_endpoint | Whether the master's internal IP address is used as the cluster endpoint | `bool` | `false` | no |
 | enable\_private\_nodes | Whether nodes have internal IP addresses only | `bool` | `true` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
-| enable\_secret\_manager\_addon | (Beta) Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
+| enable\_secret\_manager\_addon | Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | `bool` | `true` | no |
 | enable\_tpu | Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | `bool` | `false` | no |

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -138,11 +138,11 @@ locals {
   cluster_output_vertical_pod_autoscaling_enabled   = google_container_cluster.primary.vertical_pod_autoscaling != null && length(google_container_cluster.primary.vertical_pod_autoscaling) == 1 ? google_container_cluster.primary.vertical_pod_autoscaling[0].enabled : false
   cluster_output_intranode_visbility_enabled        = google_container_cluster.primary.enable_intranode_visibility
   cluster_output_identity_service_enabled           = google_container_cluster.primary.identity_service_config != null && length(google_container_cluster.primary.identity_service_config) == 1 ? google_container_cluster.primary.identity_service_config[0].enabled : false
+  cluster_output_secret_manager_addon_enabled       = google_container_cluster.primary.secret_manager_config != null && length(google_container_cluster.primary.secret_manager_config) == 1 ? google_container_cluster.primary.secret_manager_config[0].enabled : false
 
   # BETA features
-  cluster_output_istio_disabled               = google_container_cluster.primary.addons_config[0].istio_config != null && length(google_container_cluster.primary.addons_config[0].istio_config) == 1 ? google_container_cluster.primary.addons_config[0].istio_config[0].disabled : false
-  cluster_output_pod_security_policy_enabled  = google_container_cluster.primary.pod_security_policy_config != null && length(google_container_cluster.primary.pod_security_policy_config) == 1 ? google_container_cluster.primary.pod_security_policy_config[0].enabled : false
-  cluster_output_secret_manager_addon_enabled = google_container_cluster.primary.secret_manager_config != null && length(google_container_cluster.primary.secret_manager_config) == 1 ? google_container_cluster.primary.secret_manager_config[0].enabled : false
+  cluster_output_istio_disabled              = google_container_cluster.primary.addons_config[0].istio_config != null && length(google_container_cluster.primary.addons_config[0].istio_config) == 1 ? google_container_cluster.primary.addons_config[0].istio_config[0].disabled : false
+  cluster_output_pod_security_policy_enabled = google_container_cluster.primary.pod_security_policy_config != null && length(google_container_cluster.primary.pod_security_policy_config) == 1 ? google_container_cluster.primary.pod_security_policy_config[0].enabled : false
 
   # /BETA features
   cluster_output_node_pools_names = concat(
@@ -185,15 +185,15 @@ locals {
   confidential_node_config             = var.enable_confidential_nodes == true ? [{ enabled = true }] : []
   cluster_intranode_visibility_enabled = local.cluster_output_intranode_visbility_enabled
   cluster_identity_service_enabled     = local.cluster_output_identity_service_enabled
+  cluster_secret_manager_addon_enabled = local.cluster_output_secret_manager_addon_enabled
   cluster_mesh_certificates_config = local.workload_identity_enabled ? [{
     enable_certificates = var.enable_mesh_certificates
   }] : []
 
   # BETA features
-  cluster_istio_enabled                = !local.cluster_output_istio_disabled
-  cluster_telemetry_type_is_set        = var.cluster_telemetry_type != null
-  cluster_pod_security_policy_enabled  = local.cluster_output_pod_security_policy_enabled
-  cluster_secret_manager_addon_enabled = local.cluster_output_secret_manager_addon_enabled
+  cluster_istio_enabled               = !local.cluster_output_istio_disabled
+  cluster_telemetry_type_is_set       = var.cluster_telemetry_type != null
+  cluster_pod_security_policy_enabled = local.cluster_output_pod_security_policy_enabled
 
   # /BETA features
 

--- a/modules/beta-private-cluster-update-variant/outputs.tf
+++ b/modules/beta-private-cluster-update-variant/outputs.tf
@@ -205,11 +205,6 @@ output "pod_security_policy_enabled" {
   value       = local.cluster_pod_security_policy_enabled
 }
 
-output "secret_manager_addon_enabled" {
-  description = "Whether Secret Manager add-on is enabled"
-  value       = local.cluster_secret_manager_addon_enabled
-}
-
 output "identity_service_enabled" {
   description = "Whether Identity Service is enabled"
   value       = local.cluster_identity_service_enabled
@@ -218,6 +213,11 @@ output "identity_service_enabled" {
 output "intranode_visibility_enabled" {
   description = "Whether intra-node visibility is enabled"
   value       = local.cluster_intranode_visibility_enabled
+}
+
+output "secret_manager_addon_enabled" {
+  description = "Whether Secret Manager add-on is enabled"
+  value       = local.cluster_secret_manager_addon_enabled
 }
 
 output "fleet_membership" {

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -588,6 +588,12 @@ variable "enable_confidential_nodes" {
   default     = false
 }
 
+variable "enable_secret_manager_addon" {
+  description = "Enable the Secret Manager add-on for this cluster"
+  type        = bool
+  default     = false
+}
+
 variable "workload_vulnerability_mode" {
   description = "(beta) Sets which mode to use for Protect workload vulnerability scanning feature. Accepted values are DISABLED, BASIC."
   type        = string
@@ -604,12 +610,6 @@ variable "enable_fqdn_network_policy" {
   type        = bool
   description = "Enable FQDN Network Policies on the cluster"
   default     = null
-}
-
-variable "enable_secret_manager_addon" {
-  description = "(Beta) Enable the Secret Manager add-on for this cluster"
-  type        = bool
-  default     = false
 }
 
 variable "enable_cilium_clusterwide_network_policy" {

--- a/modules/beta-private-cluster-update-variant/versions.tf
+++ b/modules/beta-private-cluster-update-variant/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.44.2, !=6.0.0, !=6.0.1, !=6.1.0, !=6.2.0, !=6.3.0, !=6.4.0, !=6.5.0, !=6.6.0, < 7"
+      version = ">= 6.7.0, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.44.2, !=6.0.0, !=6.0.1, !=6.1.0, !=6.2.0, !=6.3.0, !=6.4.0, !=6.5.0, !=6.6.0, < 7"
+      version = ">= 6.7.0, < 7"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -192,7 +192,7 @@ Then perform the following commands on the root folder:
 | enable\_private\_endpoint | Whether the master's internal IP address is used as the cluster endpoint | `bool` | `false` | no |
 | enable\_private\_nodes | Whether nodes have internal IP addresses only | `bool` | `true` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
-| enable\_secret\_manager\_addon | (Beta) Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
+| enable\_secret\_manager\_addon | Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | `bool` | `true` | no |
 | enable\_tpu | Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | `bool` | `false` | no |

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -138,11 +138,11 @@ locals {
   cluster_output_vertical_pod_autoscaling_enabled   = google_container_cluster.primary.vertical_pod_autoscaling != null && length(google_container_cluster.primary.vertical_pod_autoscaling) == 1 ? google_container_cluster.primary.vertical_pod_autoscaling[0].enabled : false
   cluster_output_intranode_visbility_enabled        = google_container_cluster.primary.enable_intranode_visibility
   cluster_output_identity_service_enabled           = google_container_cluster.primary.identity_service_config != null && length(google_container_cluster.primary.identity_service_config) == 1 ? google_container_cluster.primary.identity_service_config[0].enabled : false
+  cluster_output_secret_manager_addon_enabled       = google_container_cluster.primary.secret_manager_config != null && length(google_container_cluster.primary.secret_manager_config) == 1 ? google_container_cluster.primary.secret_manager_config[0].enabled : false
 
   # BETA features
-  cluster_output_istio_disabled               = google_container_cluster.primary.addons_config[0].istio_config != null && length(google_container_cluster.primary.addons_config[0].istio_config) == 1 ? google_container_cluster.primary.addons_config[0].istio_config[0].disabled : false
-  cluster_output_pod_security_policy_enabled  = google_container_cluster.primary.pod_security_policy_config != null && length(google_container_cluster.primary.pod_security_policy_config) == 1 ? google_container_cluster.primary.pod_security_policy_config[0].enabled : false
-  cluster_output_secret_manager_addon_enabled = google_container_cluster.primary.secret_manager_config != null && length(google_container_cluster.primary.secret_manager_config) == 1 ? google_container_cluster.primary.secret_manager_config[0].enabled : false
+  cluster_output_istio_disabled              = google_container_cluster.primary.addons_config[0].istio_config != null && length(google_container_cluster.primary.addons_config[0].istio_config) == 1 ? google_container_cluster.primary.addons_config[0].istio_config[0].disabled : false
+  cluster_output_pod_security_policy_enabled = google_container_cluster.primary.pod_security_policy_config != null && length(google_container_cluster.primary.pod_security_policy_config) == 1 ? google_container_cluster.primary.pod_security_policy_config[0].enabled : false
 
   # /BETA features
   cluster_output_node_pools_names = concat(
@@ -185,15 +185,15 @@ locals {
   confidential_node_config             = var.enable_confidential_nodes == true ? [{ enabled = true }] : []
   cluster_intranode_visibility_enabled = local.cluster_output_intranode_visbility_enabled
   cluster_identity_service_enabled     = local.cluster_output_identity_service_enabled
+  cluster_secret_manager_addon_enabled = local.cluster_output_secret_manager_addon_enabled
   cluster_mesh_certificates_config = local.workload_identity_enabled ? [{
     enable_certificates = var.enable_mesh_certificates
   }] : []
 
   # BETA features
-  cluster_istio_enabled                = !local.cluster_output_istio_disabled
-  cluster_telemetry_type_is_set        = var.cluster_telemetry_type != null
-  cluster_pod_security_policy_enabled  = local.cluster_output_pod_security_policy_enabled
-  cluster_secret_manager_addon_enabled = local.cluster_output_secret_manager_addon_enabled
+  cluster_istio_enabled               = !local.cluster_output_istio_disabled
+  cluster_telemetry_type_is_set       = var.cluster_telemetry_type != null
+  cluster_pod_security_policy_enabled = local.cluster_output_pod_security_policy_enabled
 
   # /BETA features
 

--- a/modules/beta-private-cluster/outputs.tf
+++ b/modules/beta-private-cluster/outputs.tf
@@ -205,11 +205,6 @@ output "pod_security_policy_enabled" {
   value       = local.cluster_pod_security_policy_enabled
 }
 
-output "secret_manager_addon_enabled" {
-  description = "Whether Secret Manager add-on is enabled"
-  value       = local.cluster_secret_manager_addon_enabled
-}
-
 output "identity_service_enabled" {
   description = "Whether Identity Service is enabled"
   value       = local.cluster_identity_service_enabled
@@ -218,6 +213,11 @@ output "identity_service_enabled" {
 output "intranode_visibility_enabled" {
   description = "Whether intra-node visibility is enabled"
   value       = local.cluster_intranode_visibility_enabled
+}
+
+output "secret_manager_addon_enabled" {
+  description = "Whether Secret Manager add-on is enabled"
+  value       = local.cluster_secret_manager_addon_enabled
 }
 
 output "fleet_membership" {

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -588,6 +588,12 @@ variable "enable_confidential_nodes" {
   default     = false
 }
 
+variable "enable_secret_manager_addon" {
+  description = "Enable the Secret Manager add-on for this cluster"
+  type        = bool
+  default     = false
+}
+
 variable "workload_vulnerability_mode" {
   description = "(beta) Sets which mode to use for Protect workload vulnerability scanning feature. Accepted values are DISABLED, BASIC."
   type        = string
@@ -604,12 +610,6 @@ variable "enable_fqdn_network_policy" {
   type        = bool
   description = "Enable FQDN Network Policies on the cluster"
   default     = null
-}
-
-variable "enable_secret_manager_addon" {
-  description = "(Beta) Enable the Secret Manager add-on for this cluster"
-  type        = bool
-  default     = false
 }
 
 variable "enable_cilium_clusterwide_network_policy" {

--- a/modules/beta-private-cluster/versions.tf
+++ b/modules/beta-private-cluster/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.44.2, !=6.0.0, !=6.0.1, !=6.1.0, !=6.2.0, !=6.3.0, !=6.4.0, !=6.5.0, !=6.6.0, < 7"
+      version = ">= 6.7.0, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.44.2, !=6.0.0, !=6.0.1, !=6.1.0, !=6.2.0, !=6.3.0, !=6.4.0, !=6.5.0, !=6.6.0, < 7"
+      version = ">= 6.7.0, < 7"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -205,7 +205,7 @@ Then perform the following commands on the root folder:
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_pod\_security\_policy | enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. Pod Security Policy was removed from GKE clusters with version >= 1.25.0. | `bool` | `false` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
-| enable\_secret\_manager\_addon | (Beta) Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
+| enable\_secret\_manager\_addon | Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | `bool` | `true` | no |
 | enable\_tpu | Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | `bool` | `false` | no |

--- a/modules/beta-public-cluster-update-variant/main.tf
+++ b/modules/beta-public-cluster-update-variant/main.tf
@@ -137,11 +137,11 @@ locals {
   cluster_output_vertical_pod_autoscaling_enabled   = google_container_cluster.primary.vertical_pod_autoscaling != null && length(google_container_cluster.primary.vertical_pod_autoscaling) == 1 ? google_container_cluster.primary.vertical_pod_autoscaling[0].enabled : false
   cluster_output_intranode_visbility_enabled        = google_container_cluster.primary.enable_intranode_visibility
   cluster_output_identity_service_enabled           = google_container_cluster.primary.identity_service_config != null && length(google_container_cluster.primary.identity_service_config) == 1 ? google_container_cluster.primary.identity_service_config[0].enabled : false
+  cluster_output_secret_manager_addon_enabled       = google_container_cluster.primary.secret_manager_config != null && length(google_container_cluster.primary.secret_manager_config) == 1 ? google_container_cluster.primary.secret_manager_config[0].enabled : false
 
   # BETA features
-  cluster_output_istio_disabled               = google_container_cluster.primary.addons_config[0].istio_config != null && length(google_container_cluster.primary.addons_config[0].istio_config) == 1 ? google_container_cluster.primary.addons_config[0].istio_config[0].disabled : false
-  cluster_output_pod_security_policy_enabled  = google_container_cluster.primary.pod_security_policy_config != null && length(google_container_cluster.primary.pod_security_policy_config) == 1 ? google_container_cluster.primary.pod_security_policy_config[0].enabled : false
-  cluster_output_secret_manager_addon_enabled = google_container_cluster.primary.secret_manager_config != null && length(google_container_cluster.primary.secret_manager_config) == 1 ? google_container_cluster.primary.secret_manager_config[0].enabled : false
+  cluster_output_istio_disabled              = google_container_cluster.primary.addons_config[0].istio_config != null && length(google_container_cluster.primary.addons_config[0].istio_config) == 1 ? google_container_cluster.primary.addons_config[0].istio_config[0].disabled : false
+  cluster_output_pod_security_policy_enabled = google_container_cluster.primary.pod_security_policy_config != null && length(google_container_cluster.primary.pod_security_policy_config) == 1 ? google_container_cluster.primary.pod_security_policy_config[0].enabled : false
 
   # /BETA features
   cluster_output_node_pools_names = concat(
@@ -184,15 +184,15 @@ locals {
   confidential_node_config             = var.enable_confidential_nodes == true ? [{ enabled = true }] : []
   cluster_intranode_visibility_enabled = local.cluster_output_intranode_visbility_enabled
   cluster_identity_service_enabled     = local.cluster_output_identity_service_enabled
+  cluster_secret_manager_addon_enabled = local.cluster_output_secret_manager_addon_enabled
   cluster_mesh_certificates_config = local.workload_identity_enabled ? [{
     enable_certificates = var.enable_mesh_certificates
   }] : []
 
   # BETA features
-  cluster_istio_enabled                = !local.cluster_output_istio_disabled
-  cluster_telemetry_type_is_set        = var.cluster_telemetry_type != null
-  cluster_pod_security_policy_enabled  = local.cluster_output_pod_security_policy_enabled
-  cluster_secret_manager_addon_enabled = local.cluster_output_secret_manager_addon_enabled
+  cluster_istio_enabled               = !local.cluster_output_istio_disabled
+  cluster_telemetry_type_is_set       = var.cluster_telemetry_type != null
+  cluster_pod_security_policy_enabled = local.cluster_output_pod_security_policy_enabled
 
   # /BETA features
 

--- a/modules/beta-public-cluster-update-variant/outputs.tf
+++ b/modules/beta-public-cluster-update-variant/outputs.tf
@@ -195,11 +195,6 @@ output "pod_security_policy_enabled" {
   value       = local.cluster_pod_security_policy_enabled
 }
 
-output "secret_manager_addon_enabled" {
-  description = "Whether Secret Manager add-on is enabled"
-  value       = local.cluster_secret_manager_addon_enabled
-}
-
 output "identity_service_enabled" {
   description = "Whether Identity Service is enabled"
   value       = local.cluster_identity_service_enabled
@@ -208,6 +203,11 @@ output "identity_service_enabled" {
 output "intranode_visibility_enabled" {
   description = "Whether intra-node visibility is enabled"
   value       = local.cluster_intranode_visibility_enabled
+}
+
+output "secret_manager_addon_enabled" {
+  description = "Whether Secret Manager add-on is enabled"
+  value       = local.cluster_secret_manager_addon_enabled
 }
 
 output "fleet_membership" {

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -552,6 +552,12 @@ variable "enable_confidential_nodes" {
   default     = false
 }
 
+variable "enable_secret_manager_addon" {
+  description = "Enable the Secret Manager add-on for this cluster"
+  type        = bool
+  default     = false
+}
+
 variable "workload_vulnerability_mode" {
   description = "(beta) Sets which mode to use for Protect workload vulnerability scanning feature. Accepted values are DISABLED, BASIC."
   type        = string
@@ -568,12 +574,6 @@ variable "enable_fqdn_network_policy" {
   type        = bool
   description = "Enable FQDN Network Policies on the cluster"
   default     = null
-}
-
-variable "enable_secret_manager_addon" {
-  description = "(Beta) Enable the Secret Manager add-on for this cluster"
-  type        = bool
-  default     = false
 }
 
 variable "enable_cilium_clusterwide_network_policy" {

--- a/modules/beta-public-cluster-update-variant/versions.tf
+++ b/modules/beta-public-cluster-update-variant/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.44.2, !=6.0.0, !=6.0.1, !=6.1.0, !=6.2.0, !=6.3.0, !=6.4.0, !=6.5.0, !=6.6.0, < 7"
+      version = ">= 6.7.0, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.44.2, !=6.0.0, !=6.0.1, !=6.1.0, !=6.2.0, !=6.3.0, !=6.4.0, !=6.5.0, !=6.6.0, < 7"
+      version = ">= 6.7.0, < 7"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -183,7 +183,7 @@ Then perform the following commands on the root folder:
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_pod\_security\_policy | enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. Pod Security Policy was removed from GKE clusters with version >= 1.25.0. | `bool` | `false` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
-| enable\_secret\_manager\_addon | (Beta) Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
+| enable\_secret\_manager\_addon | Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | `bool` | `true` | no |
 | enable\_tpu | Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | `bool` | `false` | no |

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -137,11 +137,11 @@ locals {
   cluster_output_vertical_pod_autoscaling_enabled   = google_container_cluster.primary.vertical_pod_autoscaling != null && length(google_container_cluster.primary.vertical_pod_autoscaling) == 1 ? google_container_cluster.primary.vertical_pod_autoscaling[0].enabled : false
   cluster_output_intranode_visbility_enabled        = google_container_cluster.primary.enable_intranode_visibility
   cluster_output_identity_service_enabled           = google_container_cluster.primary.identity_service_config != null && length(google_container_cluster.primary.identity_service_config) == 1 ? google_container_cluster.primary.identity_service_config[0].enabled : false
+  cluster_output_secret_manager_addon_enabled       = google_container_cluster.primary.secret_manager_config != null && length(google_container_cluster.primary.secret_manager_config) == 1 ? google_container_cluster.primary.secret_manager_config[0].enabled : false
 
   # BETA features
-  cluster_output_istio_disabled               = google_container_cluster.primary.addons_config[0].istio_config != null && length(google_container_cluster.primary.addons_config[0].istio_config) == 1 ? google_container_cluster.primary.addons_config[0].istio_config[0].disabled : false
-  cluster_output_pod_security_policy_enabled  = google_container_cluster.primary.pod_security_policy_config != null && length(google_container_cluster.primary.pod_security_policy_config) == 1 ? google_container_cluster.primary.pod_security_policy_config[0].enabled : false
-  cluster_output_secret_manager_addon_enabled = google_container_cluster.primary.secret_manager_config != null && length(google_container_cluster.primary.secret_manager_config) == 1 ? google_container_cluster.primary.secret_manager_config[0].enabled : false
+  cluster_output_istio_disabled              = google_container_cluster.primary.addons_config[0].istio_config != null && length(google_container_cluster.primary.addons_config[0].istio_config) == 1 ? google_container_cluster.primary.addons_config[0].istio_config[0].disabled : false
+  cluster_output_pod_security_policy_enabled = google_container_cluster.primary.pod_security_policy_config != null && length(google_container_cluster.primary.pod_security_policy_config) == 1 ? google_container_cluster.primary.pod_security_policy_config[0].enabled : false
 
   # /BETA features
   cluster_output_node_pools_names = concat(
@@ -184,15 +184,15 @@ locals {
   confidential_node_config             = var.enable_confidential_nodes == true ? [{ enabled = true }] : []
   cluster_intranode_visibility_enabled = local.cluster_output_intranode_visbility_enabled
   cluster_identity_service_enabled     = local.cluster_output_identity_service_enabled
+  cluster_secret_manager_addon_enabled = local.cluster_output_secret_manager_addon_enabled
   cluster_mesh_certificates_config = local.workload_identity_enabled ? [{
     enable_certificates = var.enable_mesh_certificates
   }] : []
 
   # BETA features
-  cluster_istio_enabled                = !local.cluster_output_istio_disabled
-  cluster_telemetry_type_is_set        = var.cluster_telemetry_type != null
-  cluster_pod_security_policy_enabled  = local.cluster_output_pod_security_policy_enabled
-  cluster_secret_manager_addon_enabled = local.cluster_output_secret_manager_addon_enabled
+  cluster_istio_enabled               = !local.cluster_output_istio_disabled
+  cluster_telemetry_type_is_set       = var.cluster_telemetry_type != null
+  cluster_pod_security_policy_enabled = local.cluster_output_pod_security_policy_enabled
 
   # /BETA features
 

--- a/modules/beta-public-cluster/outputs.tf
+++ b/modules/beta-public-cluster/outputs.tf
@@ -195,11 +195,6 @@ output "pod_security_policy_enabled" {
   value       = local.cluster_pod_security_policy_enabled
 }
 
-output "secret_manager_addon_enabled" {
-  description = "Whether Secret Manager add-on is enabled"
-  value       = local.cluster_secret_manager_addon_enabled
-}
-
 output "identity_service_enabled" {
   description = "Whether Identity Service is enabled"
   value       = local.cluster_identity_service_enabled
@@ -208,6 +203,11 @@ output "identity_service_enabled" {
 output "intranode_visibility_enabled" {
   description = "Whether intra-node visibility is enabled"
   value       = local.cluster_intranode_visibility_enabled
+}
+
+output "secret_manager_addon_enabled" {
+  description = "Whether Secret Manager add-on is enabled"
+  value       = local.cluster_secret_manager_addon_enabled
 }
 
 output "fleet_membership" {

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -552,6 +552,12 @@ variable "enable_confidential_nodes" {
   default     = false
 }
 
+variable "enable_secret_manager_addon" {
+  description = "Enable the Secret Manager add-on for this cluster"
+  type        = bool
+  default     = false
+}
+
 variable "workload_vulnerability_mode" {
   description = "(beta) Sets which mode to use for Protect workload vulnerability scanning feature. Accepted values are DISABLED, BASIC."
   type        = string
@@ -568,12 +574,6 @@ variable "enable_fqdn_network_policy" {
   type        = bool
   description = "Enable FQDN Network Policies on the cluster"
   default     = null
-}
-
-variable "enable_secret_manager_addon" {
-  description = "(Beta) Enable the Secret Manager add-on for this cluster"
-  type        = bool
-  default     = false
 }
 
 variable "enable_cilium_clusterwide_network_policy" {

--- a/modules/beta-public-cluster/versions.tf
+++ b/modules/beta-public-cluster/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.44.2, !=6.0.0, !=6.0.1, !=6.1.0, !=6.2.0, !=6.3.0, !=6.4.0, !=6.5.0, !=6.6.0, < 7"
+      version = ">= 6.7.0, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.44.2, !=6.0.0, !=6.0.1, !=6.1.0, !=6.2.0, !=6.3.0, !=6.4.0, !=6.5.0, !=6.6.0, < 7"
+      version = ">= 6.7.0, < 7"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -204,6 +204,7 @@ Then perform the following commands on the root folder:
 | enable\_private\_endpoint | Whether the master's internal IP address is used as the cluster endpoint | `bool` | `false` | no |
 | enable\_private\_nodes | Whether nodes have internal IP addresses only | `bool` | `true` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
+| enable\_secret\_manager\_addon | Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | `bool` | `true` | no |
 | enable\_tpu | Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | `bool` | `false` | no |
@@ -318,6 +319,7 @@ Then perform the following commands on the root folder:
 | peering\_name | The name of the peering between this cluster and the Google owned VPC. |
 | region | Cluster region |
 | release\_channel | The release channel of this cluster |
+| secret\_manager\_addon\_enabled | Whether Secret Manager add-on is enabled |
 | service\_account | The service account to default running nodes as if not overridden in `node_pools`. |
 | tpu\_ipv4\_cidr\_block | The IP range in CIDR notation used for the TPUs |
 | type | Cluster type (regional / zonal) |

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -189,6 +189,13 @@ resource "google_container_cluster" "primary" {
 
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
+  dynamic "secret_manager_config" {
+    for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
+    content {
+      enabled = secret_manager_config.value
+    }
+  }
+
   dynamic "master_authorized_networks_config" {
     for_each = var.enable_private_endpoint || var.gcp_public_cidrs_access_enabled != null || length(var.master_authorized_networks) > 0 ? [true] : []
     content {

--- a/modules/private-cluster-update-variant/main.tf
+++ b/modules/private-cluster-update-variant/main.tf
@@ -126,6 +126,7 @@ locals {
   cluster_output_vertical_pod_autoscaling_enabled   = google_container_cluster.primary.vertical_pod_autoscaling != null && length(google_container_cluster.primary.vertical_pod_autoscaling) == 1 ? google_container_cluster.primary.vertical_pod_autoscaling[0].enabled : false
   cluster_output_intranode_visbility_enabled        = google_container_cluster.primary.enable_intranode_visibility
   cluster_output_identity_service_enabled           = google_container_cluster.primary.identity_service_config != null && length(google_container_cluster.primary.identity_service_config) == 1 ? google_container_cluster.primary.identity_service_config[0].enabled : false
+  cluster_output_secret_manager_addon_enabled       = google_container_cluster.primary.secret_manager_config != null && length(google_container_cluster.primary.secret_manager_config) == 1 ? google_container_cluster.primary.secret_manager_config[0].enabled : false
 
   cluster_output_node_pools_names = concat(
     [for np in google_container_node_pool.pools : np.name], [""],
@@ -167,6 +168,7 @@ locals {
   confidential_node_config             = var.enable_confidential_nodes == true ? [{ enabled = true }] : []
   cluster_intranode_visibility_enabled = local.cluster_output_intranode_visbility_enabled
   cluster_identity_service_enabled     = local.cluster_output_identity_service_enabled
+  cluster_secret_manager_addon_enabled = local.cluster_output_secret_manager_addon_enabled
   cluster_mesh_certificates_config = local.workload_identity_enabled ? [{
     enable_certificates = var.enable_mesh_certificates
   }] : []

--- a/modules/private-cluster-update-variant/outputs.tf
+++ b/modules/private-cluster-update-variant/outputs.tf
@@ -200,6 +200,11 @@ output "intranode_visibility_enabled" {
   value       = local.cluster_intranode_visibility_enabled
 }
 
+output "secret_manager_addon_enabled" {
+  description = "Whether Secret Manager add-on is enabled"
+  value       = local.cluster_secret_manager_addon_enabled
+}
+
 output "fleet_membership" {
   description = "Fleet membership (if registered)"
   value       = local.fleet_membership

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -582,6 +582,12 @@ variable "enable_confidential_nodes" {
   default     = false
 }
 
+variable "enable_secret_manager_addon" {
+  description = "Enable the Secret Manager add-on for this cluster"
+  type        = bool
+  default     = false
+}
+
 variable "enable_cilium_clusterwide_network_policy" {
   type        = bool
   description = "Enable Cilium Cluster Wide Network Policies on the cluster"

--- a/modules/private-cluster-update-variant/versions.tf
+++ b/modules/private-cluster-update-variant/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.44.2, !=6.0.0, !=6.0.1, !=6.1.0, !=6.2.0, !=6.3.0, !=6.4.0, !=6.5.0, !=6.6.0, < 7"
+      version = ">= 6.7.0, < 7"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -182,6 +182,7 @@ Then perform the following commands on the root folder:
 | enable\_private\_endpoint | Whether the master's internal IP address is used as the cluster endpoint | `bool` | `false` | no |
 | enable\_private\_nodes | Whether nodes have internal IP addresses only | `bool` | `true` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
+| enable\_secret\_manager\_addon | Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | `bool` | `true` | no |
 | enable\_tpu | Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | enable\_vertical\_pod\_autoscaling | Vertical Pod Autoscaling automatically adjusts the resources of pods controlled by it | `bool` | `false` | no |
@@ -296,6 +297,7 @@ Then perform the following commands on the root folder:
 | peering\_name | The name of the peering between this cluster and the Google owned VPC. |
 | region | Cluster region |
 | release\_channel | The release channel of this cluster |
+| secret\_manager\_addon\_enabled | Whether Secret Manager add-on is enabled |
 | service\_account | The service account to default running nodes as if not overridden in `node_pools`. |
 | tpu\_ipv4\_cidr\_block | The IP range in CIDR notation used for the TPUs |
 | type | Cluster type (regional / zonal) |

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -189,6 +189,13 @@ resource "google_container_cluster" "primary" {
 
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
+  dynamic "secret_manager_config" {
+    for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
+    content {
+      enabled = secret_manager_config.value
+    }
+  }
+
   dynamic "master_authorized_networks_config" {
     for_each = var.enable_private_endpoint || var.gcp_public_cidrs_access_enabled != null || length(var.master_authorized_networks) > 0 ? [true] : []
     content {

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -126,6 +126,7 @@ locals {
   cluster_output_vertical_pod_autoscaling_enabled   = google_container_cluster.primary.vertical_pod_autoscaling != null && length(google_container_cluster.primary.vertical_pod_autoscaling) == 1 ? google_container_cluster.primary.vertical_pod_autoscaling[0].enabled : false
   cluster_output_intranode_visbility_enabled        = google_container_cluster.primary.enable_intranode_visibility
   cluster_output_identity_service_enabled           = google_container_cluster.primary.identity_service_config != null && length(google_container_cluster.primary.identity_service_config) == 1 ? google_container_cluster.primary.identity_service_config[0].enabled : false
+  cluster_output_secret_manager_addon_enabled       = google_container_cluster.primary.secret_manager_config != null && length(google_container_cluster.primary.secret_manager_config) == 1 ? google_container_cluster.primary.secret_manager_config[0].enabled : false
 
   cluster_output_node_pools_names = concat(
     [for np in google_container_node_pool.pools : np.name], [""],
@@ -167,6 +168,7 @@ locals {
   confidential_node_config             = var.enable_confidential_nodes == true ? [{ enabled = true }] : []
   cluster_intranode_visibility_enabled = local.cluster_output_intranode_visbility_enabled
   cluster_identity_service_enabled     = local.cluster_output_identity_service_enabled
+  cluster_secret_manager_addon_enabled = local.cluster_output_secret_manager_addon_enabled
   cluster_mesh_certificates_config = local.workload_identity_enabled ? [{
     enable_certificates = var.enable_mesh_certificates
   }] : []

--- a/modules/private-cluster/outputs.tf
+++ b/modules/private-cluster/outputs.tf
@@ -200,6 +200,11 @@ output "intranode_visibility_enabled" {
   value       = local.cluster_intranode_visibility_enabled
 }
 
+output "secret_manager_addon_enabled" {
+  description = "Whether Secret Manager add-on is enabled"
+  value       = local.cluster_secret_manager_addon_enabled
+}
+
 output "fleet_membership" {
   description = "Fleet membership (if registered)"
   value       = local.fleet_membership

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -582,6 +582,12 @@ variable "enable_confidential_nodes" {
   default     = false
 }
 
+variable "enable_secret_manager_addon" {
+  description = "Enable the Secret Manager add-on for this cluster"
+  type        = bool
+  default     = false
+}
+
 variable "enable_cilium_clusterwide_network_policy" {
   type        = bool
   description = "Enable Cilium Cluster Wide Network Policies on the cluster"

--- a/modules/private-cluster/versions.tf
+++ b/modules/private-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.44.2, !=6.0.0, !=6.0.1, !=6.1.0, !=6.2.0, !=6.3.0, !=6.4.0, !=6.5.0, !=6.6.0, < 7"
+      version = ">= 6.7.0, < 7"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/outputs.tf
+++ b/outputs.tf
@@ -190,6 +190,11 @@ output "intranode_visibility_enabled" {
   value       = local.cluster_intranode_visibility_enabled
 }
 
+output "secret_manager_addon_enabled" {
+  description = "Whether Secret Manager add-on is enabled"
+  value       = local.cluster_secret_manager_addon_enabled
+}
+
 output "fleet_membership" {
   description = "Fleet membership (if registered)"
   value       = local.fleet_membership

--- a/test/integration/simple_regional_private/testdata/TestSimpleRegionalPrivate.json
+++ b/test/integration/simple_regional_private/testdata/TestSimpleRegionalPrivate.json
@@ -242,6 +242,9 @@
       "privateEndpoint": "172.16.0.2",
       "publicEndpoint": "104.198.172.159"
     },
+    "secretManagerConfig": {
+      "enabled": true
+    },
     "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/CLUSTER_NAME",
     "servicesIpv4Cidr": "192.168.64.0/18",
     "shieldedNodes": {

--- a/variables.tf
+++ b/variables.tf
@@ -546,6 +546,12 @@ variable "enable_confidential_nodes" {
   default     = false
 }
 
+variable "enable_secret_manager_addon" {
+  description = "Enable the Secret Manager add-on for this cluster"
+  type        = bool
+  default     = false
+}
+
 variable "enable_cilium_clusterwide_network_policy" {
   type        = bool
   description = "Enable Cilium Cluster Wide Network Policies on the cluster"

--- a/versions.tf
+++ b/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.44.2, !=6.0.0, !=6.0.1, !=6.1.0, !=6.2.0, !=6.3.0, !=6.4.0, !=6.5.0, !=6.6.0, < 7"
+      version = ">= 6.7.0, < 7"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
Promote `secret_manager_config` (GA since 6.1.)
https://github.com/hashicorp/terraform-provider-google/releases/tag/v6.1.0

Fixes #2157

Note: this will likely fail now, but I imagine should be able to go in the following major after 34.0.0. ~After #2126 or another PR goes in that requires >= 6.1.0, this shouldn't be breaking on its own.~ Note: #2126 required >= 6.5.0 for autopilot, but because we'd excluded 6..5 and 6.6, this now is going to require 6.7 after all, I think, so making it a separate breaking change is the right thing.