### PR TITLE
fix(TPG>=5.12.0): Bump for #2142 (#2141)

### DIFF
--- a/modules/workload-identity/versions.tf
+++ b/modules/workload-identity/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.39.0, < 7"
+      version = ">= 5.12.0, < 7"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
#2142 introduced `gcp_sa_create_ignore_already_exists` variable for workload-identity module without bumping to TPG<=5.12.0 and fails on installations with older TPG.