### PR TITLE
fix: node pool options cannot be set to false

### DIFF
--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -54,10 +54,8 @@ locals {
   master_version          = var.regional ? local.master_version_regional : local.master_version_zonal
   {% if autopilot_cluster != true %}
   // Build a map of maps of node pools from a list of objects
-  node_pool_names = [for np in toset(var.node_pools) : np.name]
-  node_pools      = zipmap(local.node_pool_names, tolist(toset(var.node_pools)))
-  windows_node_pool_names = [for np in toset(var.windows_node_pools) : np.name]
-  windows_node_pools      = zipmap(local.windows_node_pool_names, tolist(toset(var.windows_node_pools)))
+  node_pools         = {for np in var.node_pools: np.name => np}
+  windows_node_pools = {for np in var.windows_node_pools: np.name => np}
   {% endif %}
 
   fleet_membership = var.fleet_project != null ? google_container_cluster.primary.fleet[0].membership : null

--- a/main.tf
+++ b/main.tf
@@ -49,10 +49,8 @@ locals {
   master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone.latest_master_version
   master_version          = var.regional ? local.master_version_regional : local.master_version_zonal
   // Build a map of maps of node pools from a list of objects
-  node_pool_names         = [for np in toset(var.node_pools) : np.name]
-  node_pools              = zipmap(local.node_pool_names, tolist(toset(var.node_pools)))
-  windows_node_pool_names = [for np in toset(var.windows_node_pools) : np.name]
-  windows_node_pools      = zipmap(local.windows_node_pool_names, tolist(toset(var.windows_node_pools)))
+  node_pools         = { for np in var.node_pools : np.name => np }
+  windows_node_pools = { for np in var.windows_node_pools : np.name => np }
 
   fleet_membership = var.fleet_project != null ? google_container_cluster.primary.fleet[0].membership : null
 

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -49,10 +49,8 @@ locals {
   master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone.latest_master_version
   master_version          = var.regional ? local.master_version_regional : local.master_version_zonal
   // Build a map of maps of node pools from a list of objects
-  node_pool_names         = [for np in toset(var.node_pools) : np.name]
-  node_pools              = zipmap(local.node_pool_names, tolist(toset(var.node_pools)))
-  windows_node_pool_names = [for np in toset(var.windows_node_pools) : np.name]
-  windows_node_pools      = zipmap(local.windows_node_pool_names, tolist(toset(var.windows_node_pools)))
+  node_pools         = { for np in var.node_pools : np.name => np }
+  windows_node_pools = { for np in var.windows_node_pools : np.name => np }
 
   fleet_membership = var.fleet_project != null ? google_container_cluster.primary.fleet[0].membership : null
 

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -49,10 +49,8 @@ locals {
   master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone.latest_master_version
   master_version          = var.regional ? local.master_version_regional : local.master_version_zonal
   // Build a map of maps of node pools from a list of objects
-  node_pool_names         = [for np in toset(var.node_pools) : np.name]
-  node_pools              = zipmap(local.node_pool_names, tolist(toset(var.node_pools)))
-  windows_node_pool_names = [for np in toset(var.windows_node_pools) : np.name]
-  windows_node_pools      = zipmap(local.windows_node_pool_names, tolist(toset(var.windows_node_pools)))
+  node_pools         = { for np in var.node_pools : np.name => np }
+  windows_node_pools = { for np in var.windows_node_pools : np.name => np }
 
   fleet_membership = var.fleet_project != null ? google_container_cluster.primary.fleet[0].membership : null
 

--- a/modules/beta-public-cluster-update-variant/main.tf
+++ b/modules/beta-public-cluster-update-variant/main.tf
@@ -49,10 +49,8 @@ locals {
   master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone.latest_master_version
   master_version          = var.regional ? local.master_version_regional : local.master_version_zonal
   // Build a map of maps of node pools from a list of objects
-  node_pool_names         = [for np in toset(var.node_pools) : np.name]
-  node_pools              = zipmap(local.node_pool_names, tolist(toset(var.node_pools)))
-  windows_node_pool_names = [for np in toset(var.windows_node_pools) : np.name]
-  windows_node_pools      = zipmap(local.windows_node_pool_names, tolist(toset(var.windows_node_pools)))
+  node_pools         = { for np in var.node_pools : np.name => np }
+  windows_node_pools = { for np in var.windows_node_pools : np.name => np }
 
   fleet_membership = var.fleet_project != null ? google_container_cluster.primary.fleet[0].membership : null
 

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -49,10 +49,8 @@ locals {
   master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone.latest_master_version
   master_version          = var.regional ? local.master_version_regional : local.master_version_zonal
   // Build a map of maps of node pools from a list of objects
-  node_pool_names         = [for np in toset(var.node_pools) : np.name]
-  node_pools              = zipmap(local.node_pool_names, tolist(toset(var.node_pools)))
-  windows_node_pool_names = [for np in toset(var.windows_node_pools) : np.name]
-  windows_node_pools      = zipmap(local.windows_node_pool_names, tolist(toset(var.windows_node_pools)))
+  node_pools         = { for np in var.node_pools : np.name => np }
+  windows_node_pools = { for np in var.windows_node_pools : np.name => np }
 
   fleet_membership = var.fleet_project != null ? google_container_cluster.primary.fleet[0].membership : null
 

--- a/modules/private-cluster-update-variant/main.tf
+++ b/modules/private-cluster-update-variant/main.tf
@@ -49,10 +49,8 @@ locals {
   master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone.latest_master_version
   master_version          = var.regional ? local.master_version_regional : local.master_version_zonal
   // Build a map of maps of node pools from a list of objects
-  node_pool_names         = [for np in toset(var.node_pools) : np.name]
-  node_pools              = zipmap(local.node_pool_names, tolist(toset(var.node_pools)))
-  windows_node_pool_names = [for np in toset(var.windows_node_pools) : np.name]
-  windows_node_pools      = zipmap(local.windows_node_pool_names, tolist(toset(var.windows_node_pools)))
+  node_pools         = { for np in var.node_pools : np.name => np }
+  windows_node_pools = { for np in var.windows_node_pools : np.name => np }
 
   fleet_membership = var.fleet_project != null ? google_container_cluster.primary.fleet[0].membership : null
 

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -49,10 +49,8 @@ locals {
   master_version_zonal    = var.kubernetes_version != "latest" ? var.kubernetes_version : data.google_container_engine_versions.zone.latest_master_version
   master_version          = var.regional ? local.master_version_regional : local.master_version_zonal
   // Build a map of maps of node pools from a list of objects
-  node_pool_names         = [for np in toset(var.node_pools) : np.name]
-  node_pools              = zipmap(local.node_pool_names, tolist(toset(var.node_pools)))
-  windows_node_pool_names = [for np in toset(var.windows_node_pools) : np.name]
-  windows_node_pools      = zipmap(local.windows_node_pool_names, tolist(toset(var.windows_node_pools)))
+  node_pools         = { for np in var.node_pools : np.name => np }
+  windows_node_pools = { for np in var.windows_node_pools : np.name => np }
 
   fleet_membership = var.fleet_project != null ? google_container_cluster.primary.fleet[0].membership : null
 


### PR DESCRIPTION
terraform's `toset` seems to strip falsy values from maps (at least, that's what we're seeing with terraform 1.9.8), so setting `auto_repair` to `false` is not passed through and ends up taking the default `true` value.

Use a for expression instead, it's simpler and works too