### PR TITLE
feat(sa): add support for custom monitoring metrics writer role

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -144,6 +144,12 @@ variable "maintenance_recurrence" {
   default     = ""
 }
 
+variable "monitoring_metric_writer_role" {
+  type        = string
+  description = "Custom monitoring metrics writer role for the GKE node service account"
+  default     = "roles/monitoring.metricWriter"
+}
+
 variable "ip_range_pods" {
   type        = string
   description = "The _name_ of the secondary subnet ip range to use for pods"


### PR DESCRIPTION
# Pull Request: Custom Monitoring Metrics Writer Role Support 

**Description**
This pull request introduces support for assigning a custom monitoring metrics writer role (monitoring_metric_writer_role) to the GKE node service account. Previously, the role was hardcoded to roles/monitoring.metricWriter, which could be restrictive for organizations with compliance or custom role requirements.

**Key changes**

1. Added Variable

- A new variable monitoring_metric_writer_role with a default value of roles/monitoring.metricWriter was added.
- This allows users to specify a custom IAM role if needed.

2.  Backward Compatibility:
- Ensured backward compatibility by maintaining the default role (roles/monitoring.metricWriter) for users who do not override the variable.

**Changes**
1. variables.tf
- Added a new variable monitoring_metric_writer_role with a default value of roles/monitoring.metricWriter.


## **Testing**
### 1. **Local Testing**:
- Verified the changes using terraform validate to ensure syntax correctness.
- Used terraform plan to confirm the resource behaves as expected with both default and custom roles.

### 2. **Test Cases**:
- **Default Role**: Verified that the default role (roles/monitoring.metricWriter) is assigned when no custom role is specified.
- **Custom Role**: Tested with a custom role to ensure the override works as intended.

## **Impact**
- **Backward Compatible**: Existing users do not need to make any changes, as the default behavior remains unchanged.
- **Enhanced Flexibility**: Users can now assign custom roles for monitoring metrics, meeting organizational compliance requirements.

**Checklist**

- [ ✅ ] Added a new variable for the custom role.
- [ ✅  ] Updated documentation in 'variables.tf'.
- [ ✅ ] Verified the changes with local testing.
- [ ✅ ] Ensured backward compatibility.
- [ ✅ ] Ready for review and feedback.


![photo_2025-01-09 08 47 43](https://github.com/user-attachments/assets/3570e661-26eb-45b3-b688-bdb9dfc9fb3f)

 

