### PR TITLE
fix!: re-align node_config_defaults to cluster types

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Then perform the following commands on the root folder:
 | kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | `string` | `"latest"` | no |
 | logging\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, APISERVER, CONTROLLER\_MANAGER, KCP\_CONNECTION, KCP\_SSHD, SCHEDULER, and WORKLOADS. Empty list is default GKE configuration. | `list(string)` | `[]` | no |
 | logging\_service | The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none | `string` | `"logging.googleapis.com/kubernetes"` | no |
+| logging\_variant | (Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX\_THROUGHPUT. | `string` | `null` | no |
 | maintenance\_end\_time | Time window specified for recurring maintenance operations in RFC3339 format | `string` | `""` | no |
 | maintenance\_exclusions | List of maintenance exclusions. A cluster can have up to three | `list(object({ name = string, start_time = string, end_time = string, exclusion_scope = string }))` | `[]` | no |
 | maintenance\_recurrence | Frequency of the recurring maintenance window in RFC5545 format. | `string` | `""` | no |

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -706,26 +706,18 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  {% if autopilot_cluster != true %}
   node_pool_defaults {
     node_config_defaults {
-      {% if autopilot_cluster %}
       logging_variant = var.logging_variant
-      dynamic "gcfs_config" {
-        for_each = var.enable_gcfs != null ? [true] : []
-        content {
-          enabled = var.enable_gcfs
-        }
-      }
-      {% endif %}
-      {% if autopilot_cluster != true %}
       gcfs_config {
         enabled = var.enable_gcfs
       }
       insecure_kubelet_readonly_port_enabled = var.insecure_kubelet_readonly_port_enabled != null ? upper(tostring(var.insecure_kubelet_readonly_port_enabled)) : null
-      {% endif %}
     }
   }
 
+  {% endif %}
   {% if beta_cluster %}
   depends_on = [google_project_iam_member.service_agent]
   {% endif %}

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -607,17 +607,14 @@ variable "enable_confidential_nodes" {
   description = "An optional flag to enable confidential node config."
   default = false
 }
+{% if autopilot_cluster != true %}
 
 variable "enable_gcfs" {
   type        = bool
   description = "Enable image streaming on cluster level."
-  {% if autopilot_cluster != true %}
   default     = false
-  {% endif %}
-  {% if autopilot_cluster %}
-  default     = true
-  {% endif %}
 }
+{% endif %}
 
 variable "enable_secret_manager_addon" {
   description = "Enable the Secret Manager add-on for this cluster"
@@ -1022,7 +1019,7 @@ variable "fleet_project_grant_service_agent" {
   default = false
 }
 {% endif %}
-{% if beta_cluster and autopilot_cluster %}
+{% if autopilot_cluster != true %}
 
 variable "logging_variant" {
   description = "(Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT."

--- a/cluster.tf
+++ b/cluster.tf
@@ -537,6 +537,7 @@ resource "google_container_cluster" "primary" {
 
   node_pool_defaults {
     node_config_defaults {
+      logging_variant = var.logging_variant
       gcfs_config {
         enabled = var.enable_gcfs
       }

--- a/examples/island_cluster_anywhere_in_gcp_design/main.tf
+++ b/examples/island_cluster_anywhere_in_gcp_design/main.tf
@@ -65,7 +65,6 @@ module "gke" {
       disk_size_gb              = 100
       disk_type                 = "pd-standard"
       image_type                = "COS_CONTAINERD"
-      logging_variant           = "DEFAULT"
       auto_repair               = true
       auto_upgrade              = true
       service_account           = google_service_account.gke-sa[each.key].email

--- a/examples/island_cluster_with_vm_router/main.tf
+++ b/examples/island_cluster_with_vm_router/main.tf
@@ -181,7 +181,6 @@ module "gke" {
       disk_size_gb              = 100
       disk_type                 = "pd-standard"
       image_type                = "COS_CONTAINERD"
-      logging_variant           = "DEFAULT"
       auto_repair               = true
       auto_upgrade              = true
       service_account           = google_service_account.gke-sa.email

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -44,6 +44,7 @@ module "gke" {
   cluster_autoscaling               = var.cluster_autoscaling
   deletion_protection               = false
   service_account                   = "default"
+  logging_variant                   = "MAX_THROUGHPUT"
 
   node_pools = [
     {
@@ -53,6 +54,7 @@ module "gke" {
       service_account = var.compute_engine_service_account
       auto_upgrade    = true
       enable_gcfs     = false
+      logging_variant = "DEFAULT"
     },
     {
       name              = "pool-02"

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -93,7 +93,6 @@ Then perform the following commands on the root folder:
 | enable\_confidential\_nodes | An optional flag to enable confidential node config. | `bool` | `false` | no |
 | enable\_cost\_allocation | Enables Cost Allocation Feature and the cluster name and namespace of your GKE workloads appear in the labels field of the billing export to BigQuery | `bool` | `false` | no |
 | enable\_fqdn\_network\_policy | Enable FQDN Network Policies on the cluster | `bool` | `null` | no |
-| enable\_gcfs | Enable image streaming on cluster level. | `bool` | `true` | no |
 | enable\_l4\_ilb\_subsetting | Enable L4 ILB Subsetting on the cluster | `bool` | `false` | no |
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_private\_endpoint | Whether the master's internal IP address is used as the cluster endpoint | `bool` | `false` | no |
@@ -122,7 +121,6 @@ Then perform the following commands on the root folder:
 | issue\_client\_certificate | Issues a client certificate to authenticate to the cluster endpoint. To maximize the security of your cluster, leave this option disabled. Client certificates don't automatically rotate and aren't easily revocable. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | `string` | `"latest"` | no |
 | logging\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, APISERVER, CONTROLLER\_MANAGER, KCP\_CONNECTION, KCP\_SSHD, SCHEDULER, and WORKLOADS. Empty list is default GKE configuration. | `list(string)` | `[]` | no |
-| logging\_variant | (Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX\_THROUGHPUT. | `string` | `null` | no |
 | maintenance\_end\_time | Time window specified for recurring maintenance operations in RFC3339 format | `string` | `""` | no |
 | maintenance\_exclusions | List of maintenance exclusions. A cluster can have up to three | `list(object({ name = string, start_time = string, end_time = string, exclusion_scope = string }))` | `[]` | no |
 | maintenance\_recurrence | Frequency of the recurring maintenance window in RFC5545 format. | `string` | `""` | no |

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -375,17 +375,5 @@ resource "google_container_cluster" "primary" {
     }
   }
 
-  node_pool_defaults {
-    node_config_defaults {
-      logging_variant = var.logging_variant
-      dynamic "gcfs_config" {
-        for_each = var.enable_gcfs != null ? [true] : []
-        content {
-          enabled = var.enable_gcfs
-        }
-      }
-    }
-  }
-
   depends_on = [google_project_iam_member.service_agent]
 }

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -394,12 +394,6 @@ variable "enable_confidential_nodes" {
   default     = false
 }
 
-variable "enable_gcfs" {
-  type        = bool
-  description = "Enable image streaming on cluster level."
-  default     = true
-}
-
 variable "enable_secret_manager_addon" {
   description = "Enable the Secret Manager add-on for this cluster"
   type        = bool
@@ -602,12 +596,6 @@ variable "fleet_project_grant_service_agent" {
   description = "(Optional) Grant the fleet project service identity the `roles/gkehub.serviceAgent` and `roles/gkehub.crossProjectServiceAgent` roles."
   type        = bool
   default     = false
-}
-
-variable "logging_variant" {
-  description = "(Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT."
-  type        = string
-  default     = null
 }
 
 variable "monitoring_metric_writer_role" {

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -87,7 +87,6 @@ Then perform the following commands on the root folder:
 | enable\_confidential\_nodes | An optional flag to enable confidential node config. | `bool` | `false` | no |
 | enable\_cost\_allocation | Enables Cost Allocation Feature and the cluster name and namespace of your GKE workloads appear in the labels field of the billing export to BigQuery | `bool` | `false` | no |
 | enable\_fqdn\_network\_policy | Enable FQDN Network Policies on the cluster | `bool` | `null` | no |
-| enable\_gcfs | Enable image streaming on cluster level. | `bool` | `true` | no |
 | enable\_l4\_ilb\_subsetting | Enable L4 ILB Subsetting on the cluster | `bool` | `false` | no |
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
@@ -114,7 +113,6 @@ Then perform the following commands on the root folder:
 | issue\_client\_certificate | Issues a client certificate to authenticate to the cluster endpoint. To maximize the security of your cluster, leave this option disabled. Client certificates don't automatically rotate and aren't easily revocable. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | `string` | `"latest"` | no |
 | logging\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, APISERVER, CONTROLLER\_MANAGER, KCP\_CONNECTION, KCP\_SSHD, SCHEDULER, and WORKLOADS. Empty list is default GKE configuration. | `list(string)` | `[]` | no |
-| logging\_variant | (Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX\_THROUGHPUT. | `string` | `null` | no |
 | maintenance\_end\_time | Time window specified for recurring maintenance operations in RFC3339 format | `string` | `""` | no |
 | maintenance\_exclusions | List of maintenance exclusions. A cluster can have up to three | `list(object({ name = string, start_time = string, end_time = string, exclusion_scope = string }))` | `[]` | no |
 | maintenance\_recurrence | Frequency of the recurring maintenance window in RFC5545 format. | `string` | `""` | no |

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -345,17 +345,5 @@ resource "google_container_cluster" "primary" {
     }
   }
 
-  node_pool_defaults {
-    node_config_defaults {
-      logging_variant = var.logging_variant
-      dynamic "gcfs_config" {
-        for_each = var.enable_gcfs != null ? [true] : []
-        content {
-          enabled = var.enable_gcfs
-        }
-      }
-    }
-  }
-
   depends_on = [google_project_iam_member.service_agent]
 }

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -358,12 +358,6 @@ variable "enable_confidential_nodes" {
   default     = false
 }
 
-variable "enable_gcfs" {
-  type        = bool
-  description = "Enable image streaming on cluster level."
-  default     = true
-}
-
 variable "enable_secret_manager_addon" {
   description = "Enable the Secret Manager add-on for this cluster"
   type        = bool
@@ -566,12 +560,6 @@ variable "fleet_project_grant_service_agent" {
   description = "(Optional) Grant the fleet project service identity the `roles/gkehub.serviceAgent` and `roles/gkehub.crossProjectServiceAgent` roles."
   type        = bool
   default     = false
-}
-
-variable "logging_variant" {
-  description = "(Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT."
-  type        = string
-  default     = null
 }
 
 variable "monitoring_metric_writer_role" {

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -244,6 +244,7 @@ Then perform the following commands on the root folder:
 | kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | `string` | `"latest"` | no |
 | logging\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, APISERVER, CONTROLLER\_MANAGER, KCP\_CONNECTION, KCP\_SSHD, SCHEDULER, and WORKLOADS. Empty list is default GKE configuration. | `list(string)` | `[]` | no |
 | logging\_service | The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none | `string` | `"logging.googleapis.com/kubernetes"` | no |
+| logging\_variant | (Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX\_THROUGHPUT. | `string` | `null` | no |
 | maintenance\_end\_time | Time window specified for recurring maintenance operations in RFC3339 format | `string` | `""` | no |
 | maintenance\_exclusions | List of maintenance exclusions. A cluster can have up to three | `list(object({ name = string, start_time = string, end_time = string, exclusion_scope = string }))` | `[]` | no |
 | maintenance\_recurrence | Frequency of the recurring maintenance window in RFC5545 format. | `string` | `""` | no |

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -612,6 +612,7 @@ resource "google_container_cluster" "primary" {
 
   node_pool_defaults {
     node_config_defaults {
+      logging_variant = var.logging_variant
       gcfs_config {
         enabled = var.enable_gcfs
       }

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -969,6 +969,12 @@ variable "fleet_project_grant_service_agent" {
   default     = false
 }
 
+variable "logging_variant" {
+  description = "(Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT."
+  type        = string
+  default     = null
+}
+
 variable "monitoring_metric_writer_role" {
   description = "The monitoring metrics writer role to assign to the GKE node service account"
   type        = string

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -222,6 +222,7 @@ Then perform the following commands on the root folder:
 | kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | `string` | `"latest"` | no |
 | logging\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, APISERVER, CONTROLLER\_MANAGER, KCP\_CONNECTION, KCP\_SSHD, SCHEDULER, and WORKLOADS. Empty list is default GKE configuration. | `list(string)` | `[]` | no |
 | logging\_service | The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none | `string` | `"logging.googleapis.com/kubernetes"` | no |
+| logging\_variant | (Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX\_THROUGHPUT. | `string` | `null` | no |
 | maintenance\_end\_time | Time window specified for recurring maintenance operations in RFC3339 format | `string` | `""` | no |
 | maintenance\_exclusions | List of maintenance exclusions. A cluster can have up to three | `list(object({ name = string, start_time = string, end_time = string, exclusion_scope = string }))` | `[]` | no |
 | maintenance\_recurrence | Frequency of the recurring maintenance window in RFC5545 format. | `string` | `""` | no |

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -612,6 +612,7 @@ resource "google_container_cluster" "primary" {
 
   node_pool_defaults {
     node_config_defaults {
+      logging_variant = var.logging_variant
       gcfs_config {
         enabled = var.enable_gcfs
       }

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -969,6 +969,12 @@ variable "fleet_project_grant_service_agent" {
   default     = false
 }
 
+variable "logging_variant" {
+  description = "(Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT."
+  type        = string
+  default     = null
+}
+
 variable "monitoring_metric_writer_role" {
   description = "The monitoring metrics writer role to assign to the GKE node service account"
   type        = string

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -236,6 +236,7 @@ Then perform the following commands on the root folder:
 | kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | `string` | `"latest"` | no |
 | logging\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, APISERVER, CONTROLLER\_MANAGER, KCP\_CONNECTION, KCP\_SSHD, SCHEDULER, and WORKLOADS. Empty list is default GKE configuration. | `list(string)` | `[]` | no |
 | logging\_service | The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none | `string` | `"logging.googleapis.com/kubernetes"` | no |
+| logging\_variant | (Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX\_THROUGHPUT. | `string` | `null` | no |
 | maintenance\_end\_time | Time window specified for recurring maintenance operations in RFC3339 format | `string` | `""` | no |
 | maintenance\_exclusions | List of maintenance exclusions. A cluster can have up to three | `list(object({ name = string, start_time = string, end_time = string, exclusion_scope = string }))` | `[]` | no |
 | maintenance\_recurrence | Frequency of the recurring maintenance window in RFC5545 format. | `string` | `""` | no |

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -582,6 +582,7 @@ resource "google_container_cluster" "primary" {
 
   node_pool_defaults {
     node_config_defaults {
+      logging_variant = var.logging_variant
       gcfs_config {
         enabled = var.enable_gcfs
       }

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -933,6 +933,12 @@ variable "fleet_project_grant_service_agent" {
   default     = false
 }
 
+variable "logging_variant" {
+  description = "(Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT."
+  type        = string
+  default     = null
+}
+
 variable "monitoring_metric_writer_role" {
   description = "The monitoring metrics writer role to assign to the GKE node service account"
   type        = string

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -214,6 +214,7 @@ Then perform the following commands on the root folder:
 | kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | `string` | `"latest"` | no |
 | logging\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, APISERVER, CONTROLLER\_MANAGER, KCP\_CONNECTION, KCP\_SSHD, SCHEDULER, and WORKLOADS. Empty list is default GKE configuration. | `list(string)` | `[]` | no |
 | logging\_service | The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none | `string` | `"logging.googleapis.com/kubernetes"` | no |
+| logging\_variant | (Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX\_THROUGHPUT. | `string` | `null` | no |
 | maintenance\_end\_time | Time window specified for recurring maintenance operations in RFC3339 format | `string` | `""` | no |
 | maintenance\_exclusions | List of maintenance exclusions. A cluster can have up to three | `list(object({ name = string, start_time = string, end_time = string, exclusion_scope = string }))` | `[]` | no |
 | maintenance\_recurrence | Frequency of the recurring maintenance window in RFC5545 format. | `string` | `""` | no |

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -582,6 +582,7 @@ resource "google_container_cluster" "primary" {
 
   node_pool_defaults {
     node_config_defaults {
+      logging_variant = var.logging_variant
       gcfs_config {
         enabled = var.enable_gcfs
       }

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -933,6 +933,12 @@ variable "fleet_project_grant_service_agent" {
   default     = false
 }
 
+variable "logging_variant" {
+  description = "(Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT."
+  type        = string
+  default     = null
+}
+
 variable "monitoring_metric_writer_role" {
   description = "The monitoring metrics writer role to assign to the GKE node service account"
   type        = string

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -233,6 +233,7 @@ Then perform the following commands on the root folder:
 | kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | `string` | `"latest"` | no |
 | logging\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, APISERVER, CONTROLLER\_MANAGER, KCP\_CONNECTION, KCP\_SSHD, SCHEDULER, and WORKLOADS. Empty list is default GKE configuration. | `list(string)` | `[]` | no |
 | logging\_service | The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none | `string` | `"logging.googleapis.com/kubernetes"` | no |
+| logging\_variant | (Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX\_THROUGHPUT. | `string` | `null` | no |
 | maintenance\_end\_time | Time window specified for recurring maintenance operations in RFC3339 format | `string` | `""` | no |
 | maintenance\_exclusions | List of maintenance exclusions. A cluster can have up to three | `list(object({ name = string, start_time = string, end_time = string, exclusion_scope = string }))` | `[]` | no |
 | maintenance\_recurrence | Frequency of the recurring maintenance window in RFC5545 format. | `string` | `""` | no |

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -567,6 +567,7 @@ resource "google_container_cluster" "primary" {
 
   node_pool_defaults {
     node_config_defaults {
+      logging_variant = var.logging_variant
       gcfs_config {
         enabled = var.enable_gcfs
       }

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -903,6 +903,12 @@ variable "fleet_project" {
   default     = null
 }
 
+variable "logging_variant" {
+  description = "(Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT."
+  type        = string
+  default     = null
+}
+
 variable "monitoring_metric_writer_role" {
   description = "The monitoring metrics writer role to assign to the GKE node service account"
   type        = string

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -211,6 +211,7 @@ Then perform the following commands on the root folder:
 | kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | `string` | `"latest"` | no |
 | logging\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, APISERVER, CONTROLLER\_MANAGER, KCP\_CONNECTION, KCP\_SSHD, SCHEDULER, and WORKLOADS. Empty list is default GKE configuration. | `list(string)` | `[]` | no |
 | logging\_service | The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none | `string` | `"logging.googleapis.com/kubernetes"` | no |
+| logging\_variant | (Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX\_THROUGHPUT. | `string` | `null` | no |
 | maintenance\_end\_time | Time window specified for recurring maintenance operations in RFC3339 format | `string` | `""` | no |
 | maintenance\_exclusions | List of maintenance exclusions. A cluster can have up to three | `list(object({ name = string, start_time = string, end_time = string, exclusion_scope = string }))` | `[]` | no |
 | maintenance\_recurrence | Frequency of the recurring maintenance window in RFC5545 format. | `string` | `""` | no |

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -567,6 +567,7 @@ resource "google_container_cluster" "primary" {
 
   node_pool_defaults {
     node_config_defaults {
+      logging_variant = var.logging_variant
       gcfs_config {
         enabled = var.enable_gcfs
       }

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -903,6 +903,12 @@ variable "fleet_project" {
   default     = null
 }
 
+variable "logging_variant" {
+  description = "(Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT."
+  type        = string
+  default     = null
+}
+
 variable "monitoring_metric_writer_role" {
   description = "The monitoring metrics writer role to assign to the GKE node service account"
   type        = string

--- a/test/integration/node_pool/testdata/TestNodePool.json
+++ b/test/integration/node_pool/testdata/TestNodePool.json
@@ -191,7 +191,7 @@
       "gcfsConfig": {},
       "loggingConfig": {
         "variantConfig": {
-          "variant": "DEFAULT"
+          "variant": "MAX_THROUGHPUT"
         }
       },
       "nodeKubeletConfig": {}

--- a/test/integration/private_zonal_with_networking/testdata/TestPrivateZonalWithNetworking.json
+++ b/test/integration/private_zonal_with_networking/testdata/TestPrivateZonalWithNetworking.json
@@ -216,7 +216,7 @@
         "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
         "imageType": "COS_CONTAINERD",
         "kubeletConfig": {
-          "insecureKubeletReadonlyPortEnabled": true
+          "insecureKubeletReadonlyPortEnabled": false
         },
         "labels": {
           "cluster_name": "CLUSTER_NAME",

--- a/test/integration/simple_regional_with_gateway_api/testdata/TestSimpleRegionalWithGatewayAPI.json
+++ b/test/integration/simple_regional_with_gateway_api/testdata/TestSimpleRegionalWithGatewayAPI.json
@@ -38,7 +38,6 @@
       "publicEndpoint": "KUBERNETES_ENDPOINT"
     }
   },
-  "currentNodeCount": 3,
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"

--- a/test/integration/stub_domains/testdata/TestStubDomains.json
+++ b/test/integration/stub_domains/testdata/TestStubDomains.json
@@ -36,7 +36,6 @@
       "publicEndpoint": "KUBERNETES_ENDPOINT"
     }
   },
-  "currentNodeCount": 3,
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"

--- a/test/integration/stub_domains_upstream_nameservers/testdata/TestStubDomainsUpstreamNameservers.json
+++ b/test/integration/stub_domains_upstream_nameservers/testdata/TestStubDomainsUpstreamNameservers.json
@@ -36,7 +36,6 @@
       "publicEndpoint": "KUBERNETES_ENDPOINT"
     }
   },
-  "currentNodeCount": 3,
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"

--- a/test/integration/upstream_nameservers/testdata/TestUpstreamNameservers.json
+++ b/test/integration/upstream_nameservers/testdata/TestUpstreamNameservers.json
@@ -36,7 +36,6 @@
       "publicEndpoint": "KUBERNETES_ENDPOINT"
     }
   },
-  "currentNodeCount": 3,
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"

--- a/test/integration/workload_metadata_config/testdata/TestWorkloadMetadataConfig.json
+++ b/test/integration/workload_metadata_config/testdata/TestWorkloadMetadataConfig.json
@@ -35,7 +35,6 @@
       "privateEndpoint": "KUBERNETES_ENDPOINT"
     }
   },
-  "currentNodeCount": 1,
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_DECRYPTED",
     "state": "DECRYPTED"

--- a/variables.tf
+++ b/variables.tf
@@ -867,6 +867,12 @@ variable "fleet_project" {
   default     = null
 }
 
+variable "logging_variant" {
+  description = "(Optional) The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT."
+  type        = string
+  default     = null
+}
+
 variable "monitoring_metric_writer_role" {
   description = "The monitoring metrics writer role to assign to the GKE node service account"
   type        = string


### PR DESCRIPTION
- add `logging_variant` to Standard, remove from Autopilot
- remove `enable_gcfs` from Autopilot (always enabled depending on version)
- do not create `node_pool_defaults.node_config_defaults` block on Autopilot