### PR TITLE
feat: add serviceUsageConsumer to SA for GCFS

### DIFF
--- a/autogen/main/sa.tf.tmpl
+++ b/autogen/main/sa.tf.tmpl
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,13 @@ resource "google_project_iam_member" "cluster_service_account_artifact_registry"
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
+resource "google_project_iam_member" "cluster_service_account_service_usage_consumer" {
+  for_each = var.create_service_account {% if autopilot_cluster != true %}&& var.enable_gcfs {% endif %}? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/serviceusage.serviceUsageConsumer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 {% if beta_cluster %}

--- a/modules/beta-autopilot-private-cluster/sa.tf
+++ b/modules/beta-autopilot-private-cluster/sa.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,13 @@ resource "google_project_iam_member" "cluster_service_account_artifact_registry"
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
+resource "google_project_iam_member" "cluster_service_account_service_usage_consumer" {
+  for_each = var.create_service_account ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/serviceusage.serviceUsageConsumer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 

--- a/modules/beta-autopilot-public-cluster/sa.tf
+++ b/modules/beta-autopilot-public-cluster/sa.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,13 @@ resource "google_project_iam_member" "cluster_service_account_artifact_registry"
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
+resource "google_project_iam_member" "cluster_service_account_service_usage_consumer" {
+  for_each = var.create_service_account ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/serviceusage.serviceUsageConsumer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 

--- a/modules/beta-private-cluster-update-variant/sa.tf
+++ b/modules/beta-private-cluster-update-variant/sa.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,13 @@ resource "google_project_iam_member" "cluster_service_account_artifact_registry"
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
+resource "google_project_iam_member" "cluster_service_account_service_usage_consumer" {
+  for_each = var.create_service_account && var.enable_gcfs ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/serviceusage.serviceUsageConsumer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 

--- a/modules/beta-private-cluster/sa.tf
+++ b/modules/beta-private-cluster/sa.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,13 @@ resource "google_project_iam_member" "cluster_service_account_artifact_registry"
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
+resource "google_project_iam_member" "cluster_service_account_service_usage_consumer" {
+  for_each = var.create_service_account && var.enable_gcfs ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/serviceusage.serviceUsageConsumer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 

--- a/modules/beta-public-cluster-update-variant/sa.tf
+++ b/modules/beta-public-cluster-update-variant/sa.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,13 @@ resource "google_project_iam_member" "cluster_service_account_artifact_registry"
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
+resource "google_project_iam_member" "cluster_service_account_service_usage_consumer" {
+  for_each = var.create_service_account && var.enable_gcfs ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/serviceusage.serviceUsageConsumer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 

--- a/modules/beta-public-cluster/sa.tf
+++ b/modules/beta-public-cluster/sa.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +78,13 @@ resource "google_project_iam_member" "cluster_service_account_artifact_registry"
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
+resource "google_project_iam_member" "cluster_service_account_service_usage_consumer" {
+  for_each = var.create_service_account && var.enable_gcfs ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/serviceusage.serviceUsageConsumer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }
 

--- a/modules/private-cluster-update-variant/sa.tf
+++ b/modules/private-cluster-update-variant/sa.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,5 +78,12 @@ resource "google_project_iam_member" "cluster_service_account_artifact_registry"
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
+resource "google_project_iam_member" "cluster_service_account_service_usage_consumer" {
+  for_each = var.create_service_account && var.enable_gcfs ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/serviceusage.serviceUsageConsumer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }

--- a/modules/private-cluster/sa.tf
+++ b/modules/private-cluster/sa.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,5 +78,12 @@ resource "google_project_iam_member" "cluster_service_account_artifact_registry"
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
+resource "google_project_iam_member" "cluster_service_account_service_usage_consumer" {
+  for_each = var.create_service_account && var.enable_gcfs ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/serviceusage.serviceUsageConsumer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }

--- a/sa.tf
+++ b/sa.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2022-2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,5 +78,12 @@ resource "google_project_iam_member" "cluster_service_account_artifact_registry"
   for_each = var.create_service_account && var.grant_registry_access ? toset(local.registry_projects_list) : []
   project  = each.key
   role     = "roles/artifactregistry.reader"
+  member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
+}
+
+resource "google_project_iam_member" "cluster_service_account_service_usage_consumer" {
+  for_each = var.create_service_account && var.enable_gcfs ? toset(local.registry_projects_list) : []
+  project  = each.key
+  role     = "roles/serviceusage.serviceUsageConsumer"
   member   = "serviceAccount:${google_service_account.cluster_service_account[0].email}"
 }


### PR DESCRIPTION
- When creating cluster SA enable [`roles/serviceusage.serviceUsageConsumer`](https://cloud.google.com/kubernetes-engine/docs/how-to/image-streaming#requirements) if standard cluster with enable_gcfs, or autopilot cluster

Fixes: #2251 