### PR TITLE
feat(cgroup): Add option to set cgroup for autopilot modules

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -279,7 +279,7 @@ resource "google_container_cluster" "primary" {
   }
 {% if autopilot_cluster %}
   dynamic "node_pool_auto_config" {
-    for_each = length(var.network_tags) > 0 || var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules || var.insecure_kubelet_readonly_port_enabled != null ? [1] : []
+    for_each = length(var.network_tags) > 0 || var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules || var.insecure_kubelet_readonly_port_enabled != null || var.node_pools_cgroup_mode != null ? [1] : []
     content {
       network_tags {
         tags = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules ? concat(var.network_tags, [local.cluster_network_tag]) : length(var.network_tags) > 0 ? var.network_tags : null
@@ -290,6 +290,14 @@ resource "google_container_cluster" "primary" {
         content {
           insecure_kubelet_readonly_port_enabled = upper(tostring(var.insecure_kubelet_readonly_port_enabled))
         }
+      }
+
+      dynamic "linux_node_config" {
+        for_each = (var.node_pools_cgroup_mode != null) ? [1] : []
+
+	      content {
+	        cgroup_mode = var.node_pools_cgroup_mode
+	      }
       }
     }
   }

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -279,7 +279,7 @@ resource "google_container_cluster" "primary" {
   }
 {% if autopilot_cluster %}
   dynamic "node_pool_auto_config" {
-    for_each = length(var.network_tags) > 0 || var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules || var.insecure_kubelet_readonly_port_enabled != null || var.node_pools_cgroup_mode != "" ? [1] : []
+    for_each = length(var.network_tags) > 0 || var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules || var.insecure_kubelet_readonly_port_enabled != null || var.node_pools_cgroup_mode != null ? [1] : []
     content {
       network_tags {
         tags = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules ? concat(var.network_tags, [local.cluster_network_tag]) : length(var.network_tags) > 0 ? var.network_tags : null
@@ -293,7 +293,7 @@ resource "google_container_cluster" "primary" {
       }
 
       dynamic "linux_node_config" {
-        for_each = (var.node_pools_cgroup_mode != "") ? [1] : []
+        for_each = (var.node_pools_cgroup_mode != null) ? [1] : []
 
 	      content {
 	        cgroup_mode = var.node_pools_cgroup_mode

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -279,7 +279,7 @@ resource "google_container_cluster" "primary" {
   }
 {% if autopilot_cluster %}
   dynamic "node_pool_auto_config" {
-    for_each = length(var.network_tags) > 0 || var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules || var.insecure_kubelet_readonly_port_enabled != null || var.node_pools_cgroup_mode != null ? [1] : []
+    for_each = length(var.network_tags) > 0 || var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules || var.insecure_kubelet_readonly_port_enabled != null || var.node_pools_cgroup_mode != "" ? [1] : []
     content {
       network_tags {
         tags = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules ? concat(var.network_tags, [local.cluster_network_tag]) : length(var.network_tags) > 0 ? var.network_tags : null
@@ -293,7 +293,7 @@ resource "google_container_cluster" "primary" {
       }
 
       dynamic "linux_node_config" {
-        for_each = (var.node_pools_cgroup_mode != null) ? [1] : []
+        for_each = (var.node_pools_cgroup_mode != "") ? [1] : []
 
 	      content {
 	        cgroup_mode = var.node_pools_cgroup_mode

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -537,10 +537,10 @@ variable "node_pools_cgroup_mode" {
   type        = string
   description = "String contains cgroup node config for Autopilot node pools"
 
-  default = null
+  default = ""
 
   validation {
-    condition = var.node_pools_cgroup_mode == null || contains(
+    condition = var.node_pools_cgroup_mode == "" || contains(
       [
         "CGROUP_MODE_UNSPECIFIED",
         "CGROUP_MODE_V1",
@@ -548,7 +548,7 @@ variable "node_pools_cgroup_mode" {
       ],
       var.node_pools_cgroup_mode
     )
-    error_message = "The value for node_pools_cgroup_mode must be one of: CGROUP_MODE_UNSPECIFIED, CGROUP_MODE_V1, CGROUP_MODE_V2, or null."
+    error_message = "The value for node_pools_cgroup_mode must be one of: CGROUP_MODE_UNSPECIFIED, CGROUP_MODE_V1, CGROUP_MODE_V2"
   }
 }
 {% endif %}

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -532,6 +532,26 @@ variable "identity_namespace" {
   default     = "enabled"
 }
 
+{% if autopilot_cluster == true %}
+variable "node_pools_cgroup_mode" {
+  type        = string
+  description = "String contains cgroup node config for Autopilot node pools"
+
+  default = null
+
+  validation {
+    condition = var.node_pools_cgroup_mode == null || contains(
+      [
+        "CGROUP_MODE_UNSPECIFIED",
+        "CGROUP_MODE_V1",
+        "CGROUP_MODE_V2"
+      ],
+      var.node_pools_cgroup_mode
+    )
+    error_message = "The value for node_pools_cgroup_mode must be one of: CGROUP_MODE_UNSPECIFIED, CGROUP_MODE_V1, CGROUP_MODE_V2, or null."
+  }
+}
+{% endif %}
 {% if autopilot_cluster != true %}
 variable "enable_mesh_certificates" {
   type = bool

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -537,16 +537,16 @@ variable "node_pools_cgroup_mode" {
   type        = string
   description = "String contains cgroup node config for Autopilot node pools"
 
-  default = ""
+  default = null
 
   validation {
-    condition = var.node_pools_cgroup_mode == "" || contains(
+    condition = var.node_pools_cgroup_mode == null || contains(
       [
         "CGROUP_MODE_UNSPECIFIED",
         "CGROUP_MODE_V1",
         "CGROUP_MODE_V2"
       ],
-      var.node_pools_cgroup_mode
+      var.node_pools_cgroup_mode != null ? var.node_pools_cgroup_mode : ""
     )
     error_message = "The value for node_pools_cgroup_mode must be one of: CGROUP_MODE_UNSPECIFIED, CGROUP_MODE_V1, CGROUP_MODE_V2"
   }

--- a/examples/simple_autopilot_private/main.tf
+++ b/examples/simple_autopilot_private/main.tf
@@ -50,6 +50,7 @@ module "gke" {
   enable_private_endpoint                = true
   enable_private_nodes                   = true
   network_tags                           = [local.cluster_type]
+  node_pools_cgroup_mode                 = "CGROUP_MODE_V2"
   deletion_protection                    = false
   insecure_kubelet_readonly_port_enabled = false
 }

--- a/examples/simple_autopilot_private_cmek/main.tf
+++ b/examples/simple_autopilot_private_cmek/main.tf
@@ -71,6 +71,7 @@ module "gke" {
   enable_private_endpoint         = true
   enable_private_nodes            = true
   network_tags                    = [local.cluster_type]
+  node_pools_cgroup_mode          = "CGROUP_MODE_V2"
   deletion_protection             = false
   boot_disk_kms_key               = values(module.kms.keys)[0]
   depends_on                      = [google_kms_crypto_key_iam_member.main]

--- a/examples/simple_autopilot_private_non_default_sa/main.tf
+++ b/examples/simple_autopilot_private_non_default_sa/main.tf
@@ -49,6 +49,7 @@ module "gke" {
   enable_vertical_pod_autoscaling = true
   enable_private_endpoint         = true
   enable_private_nodes            = true
+  node_pools_cgroup_mode          = "CGROUP_MODE_V2"
   deletion_protection             = false
 
   master_authorized_networks = [

--- a/examples/simple_autopilot_public/main.tf
+++ b/examples/simple_autopilot_public/main.tf
@@ -47,6 +47,7 @@ module "gke" {
   release_channel                 = "RAPID"
   enable_vertical_pod_autoscaling = true
   network_tags                    = [local.cluster_type]
+  node_pools_cgroup_mode          = "CGROUP_MODE_V2"
   deletion_protection             = false
   enable_l4_ilb_subsetting        = true
   stateful_ha                     = false

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -134,7 +134,7 @@ Then perform the following commands on the root folder:
 | network | The VPC network to host the cluster in (required) | `string` | n/a | yes |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
 | network\_tags | (Optional) - List of network tags applied to auto-provisioned node pools. | `list(string)` | `[]` | no |
-| node\_pools\_cgroup\_mode | String contains cgroup node config for Autopilot node pools | `string` | `""` | no |
+| node\_pools\_cgroup\_mode | String contains cgroup node config for Autopilot node pools | `string` | `null` | no |
 | non\_masquerade\_cidrs | List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading. | `list(string)` | <pre>[<br>  "10.0.0.0/8",<br>  "172.16.0.0/12",<br>  "192.168.0.0/16"<br>]</pre> | no |
 | notification\_config\_topic | The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}. | `string` | `""` | no |
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -134,7 +134,7 @@ Then perform the following commands on the root folder:
 | network | The VPC network to host the cluster in (required) | `string` | n/a | yes |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
 | network\_tags | (Optional) - List of network tags applied to auto-provisioned node pools. | `list(string)` | `[]` | no |
-| node\_pools\_cgroup\_mode | String contains cgroup node config for Autopilot node pools | `string` | `null` | no |
+| node\_pools\_cgroup\_mode | String contains cgroup node config for Autopilot node pools | `string` | `""` | no |
 | non\_masquerade\_cidrs | List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading. | `list(string)` | <pre>[<br>  "10.0.0.0/8",<br>  "172.16.0.0/12",<br>  "192.168.0.0/16"<br>]</pre> | no |
 | notification\_config\_topic | The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}. | `string` | `""` | no |
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -134,6 +134,7 @@ Then perform the following commands on the root folder:
 | network | The VPC network to host the cluster in (required) | `string` | n/a | yes |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
 | network\_tags | (Optional) - List of network tags applied to auto-provisioned node pools. | `list(string)` | `[]` | no |
+| node\_pools\_cgroup\_mode | String contains cgroup node config for Autopilot node pools | `string` | `null` | no |
 | non\_masquerade\_cidrs | List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading. | `list(string)` | <pre>[<br>  "10.0.0.0/8",<br>  "172.16.0.0/12",<br>  "192.168.0.0/16"<br>]</pre> | no |
 | notification\_config\_topic | The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}. | `string` | `""` | no |
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -135,7 +135,7 @@ resource "google_container_cluster" "primary" {
     }
   }
   dynamic "node_pool_auto_config" {
-    for_each = length(var.network_tags) > 0 || var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules || var.insecure_kubelet_readonly_port_enabled != null || var.node_pools_cgroup_mode != "" ? [1] : []
+    for_each = length(var.network_tags) > 0 || var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules || var.insecure_kubelet_readonly_port_enabled != null || var.node_pools_cgroup_mode != null ? [1] : []
     content {
       network_tags {
         tags = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules ? concat(var.network_tags, [local.cluster_network_tag]) : length(var.network_tags) > 0 ? var.network_tags : null
@@ -149,7 +149,7 @@ resource "google_container_cluster" "primary" {
       }
 
       dynamic "linux_node_config" {
-        for_each = (var.node_pools_cgroup_mode != "") ? [1] : []
+        for_each = (var.node_pools_cgroup_mode != null) ? [1] : []
 
         content {
           cgroup_mode = var.node_pools_cgroup_mode

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -135,7 +135,7 @@ resource "google_container_cluster" "primary" {
     }
   }
   dynamic "node_pool_auto_config" {
-    for_each = length(var.network_tags) > 0 || var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules || var.insecure_kubelet_readonly_port_enabled != null ? [1] : []
+    for_each = length(var.network_tags) > 0 || var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules || var.insecure_kubelet_readonly_port_enabled != null || var.node_pools_cgroup_mode != null ? [1] : []
     content {
       network_tags {
         tags = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules ? concat(var.network_tags, [local.cluster_network_tag]) : length(var.network_tags) > 0 ? var.network_tags : null
@@ -145,6 +145,14 @@ resource "google_container_cluster" "primary" {
         for_each = var.insecure_kubelet_readonly_port_enabled != null ? [1] : []
         content {
           insecure_kubelet_readonly_port_enabled = upper(tostring(var.insecure_kubelet_readonly_port_enabled))
+        }
+      }
+
+      dynamic "linux_node_config" {
+        for_each = (var.node_pools_cgroup_mode != null) ? [1] : []
+
+        content {
+          cgroup_mode = var.node_pools_cgroup_mode
         }
       }
     }

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -135,7 +135,7 @@ resource "google_container_cluster" "primary" {
     }
   }
   dynamic "node_pool_auto_config" {
-    for_each = length(var.network_tags) > 0 || var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules || var.insecure_kubelet_readonly_port_enabled != null || var.node_pools_cgroup_mode != null ? [1] : []
+    for_each = length(var.network_tags) > 0 || var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules || var.insecure_kubelet_readonly_port_enabled != null || var.node_pools_cgroup_mode != "" ? [1] : []
     content {
       network_tags {
         tags = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules ? concat(var.network_tags, [local.cluster_network_tag]) : length(var.network_tags) > 0 ? var.network_tags : null
@@ -149,7 +149,7 @@ resource "google_container_cluster" "primary" {
       }
 
       dynamic "linux_node_config" {
-        for_each = (var.node_pools_cgroup_mode != null) ? [1] : []
+        for_each = (var.node_pools_cgroup_mode != "") ? [1] : []
 
         content {
           cgroup_mode = var.node_pools_cgroup_mode

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -329,16 +329,16 @@ variable "node_pools_cgroup_mode" {
   type        = string
   description = "String contains cgroup node config for Autopilot node pools"
 
-  default = ""
+  default = null
 
   validation {
-    condition = var.node_pools_cgroup_mode == "" || contains(
+    condition = var.node_pools_cgroup_mode == null || contains(
       [
         "CGROUP_MODE_UNSPECIFIED",
         "CGROUP_MODE_V1",
         "CGROUP_MODE_V2"
       ],
-      var.node_pools_cgroup_mode
+      var.node_pools_cgroup_mode != null ? var.node_pools_cgroup_mode : ""
     )
     error_message = "The value for node_pools_cgroup_mode must be one of: CGROUP_MODE_UNSPECIFIED, CGROUP_MODE_V1, CGROUP_MODE_V2"
   }

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -329,10 +329,10 @@ variable "node_pools_cgroup_mode" {
   type        = string
   description = "String contains cgroup node config for Autopilot node pools"
 
-  default = null
+  default = ""
 
   validation {
-    condition = var.node_pools_cgroup_mode == null || contains(
+    condition = var.node_pools_cgroup_mode == "" || contains(
       [
         "CGROUP_MODE_UNSPECIFIED",
         "CGROUP_MODE_V1",
@@ -340,7 +340,7 @@ variable "node_pools_cgroup_mode" {
       ],
       var.node_pools_cgroup_mode
     )
-    error_message = "The value for node_pools_cgroup_mode must be one of: CGROUP_MODE_UNSPECIFIED, CGROUP_MODE_V1, CGROUP_MODE_V2, or null."
+    error_message = "The value for node_pools_cgroup_mode must be one of: CGROUP_MODE_UNSPECIFIED, CGROUP_MODE_V1, CGROUP_MODE_V2"
   }
 }
 

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -325,6 +325,24 @@ variable "identity_namespace" {
   default     = "enabled"
 }
 
+variable "node_pools_cgroup_mode" {
+  type        = string
+  description = "String contains cgroup node config for Autopilot node pools"
+
+  default = null
+
+  validation {
+    condition = var.node_pools_cgroup_mode == null || contains(
+      [
+        "CGROUP_MODE_UNSPECIFIED",
+        "CGROUP_MODE_V1",
+        "CGROUP_MODE_V2"
+      ],
+      var.node_pools_cgroup_mode
+    )
+    error_message = "The value for node_pools_cgroup_mode must be one of: CGROUP_MODE_UNSPECIFIED, CGROUP_MODE_V1, CGROUP_MODE_V2, or null."
+  }
+}
 
 variable "release_channel" {
   type        = string

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -124,7 +124,7 @@ Then perform the following commands on the root folder:
 | network | The VPC network to host the cluster in (required) | `string` | n/a | yes |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
 | network\_tags | (Optional) - List of network tags applied to auto-provisioned node pools. | `list(string)` | `[]` | no |
-| node\_pools\_cgroup\_mode | String contains cgroup node config for Autopilot node pools | `string` | `""` | no |
+| node\_pools\_cgroup\_mode | String contains cgroup node config for Autopilot node pools | `string` | `null` | no |
 | non\_masquerade\_cidrs | List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading. | `list(string)` | <pre>[<br>  "10.0.0.0/8",<br>  "172.16.0.0/12",<br>  "192.168.0.0/16"<br>]</pre> | no |
 | notification\_config\_topic | The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}. | `string` | `""` | no |
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -124,7 +124,7 @@ Then perform the following commands on the root folder:
 | network | The VPC network to host the cluster in (required) | `string` | n/a | yes |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
 | network\_tags | (Optional) - List of network tags applied to auto-provisioned node pools. | `list(string)` | `[]` | no |
-| node\_pools\_cgroup\_mode | String contains cgroup node config for Autopilot node pools | `string` | `null` | no |
+| node\_pools\_cgroup\_mode | String contains cgroup node config for Autopilot node pools | `string` | `""` | no |
 | non\_masquerade\_cidrs | List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading. | `list(string)` | <pre>[<br>  "10.0.0.0/8",<br>  "172.16.0.0/12",<br>  "192.168.0.0/16"<br>]</pre> | no |
 | notification\_config\_topic | The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}. | `string` | `""` | no |
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -124,6 +124,7 @@ Then perform the following commands on the root folder:
 | network | The VPC network to host the cluster in (required) | `string` | n/a | yes |
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
 | network\_tags | (Optional) - List of network tags applied to auto-provisioned node pools. | `list(string)` | `[]` | no |
+| node\_pools\_cgroup\_mode | String contains cgroup node config for Autopilot node pools | `string` | `null` | no |
 | non\_masquerade\_cidrs | List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading. | `list(string)` | <pre>[<br>  "10.0.0.0/8",<br>  "172.16.0.0/12",<br>  "192.168.0.0/16"<br>]</pre> | no |
 | notification\_config\_topic | The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}. | `string` | `""` | no |
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -135,7 +135,7 @@ resource "google_container_cluster" "primary" {
     }
   }
   dynamic "node_pool_auto_config" {
-    for_each = length(var.network_tags) > 0 || var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules || var.insecure_kubelet_readonly_port_enabled != null || var.node_pools_cgroup_mode != "" ? [1] : []
+    for_each = length(var.network_tags) > 0 || var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules || var.insecure_kubelet_readonly_port_enabled != null || var.node_pools_cgroup_mode != null ? [1] : []
     content {
       network_tags {
         tags = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules ? concat(var.network_tags, [local.cluster_network_tag]) : length(var.network_tags) > 0 ? var.network_tags : null
@@ -149,7 +149,7 @@ resource "google_container_cluster" "primary" {
       }
 
       dynamic "linux_node_config" {
-        for_each = (var.node_pools_cgroup_mode != "") ? [1] : []
+        for_each = (var.node_pools_cgroup_mode != null) ? [1] : []
 
         content {
           cgroup_mode = var.node_pools_cgroup_mode

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -135,7 +135,7 @@ resource "google_container_cluster" "primary" {
     }
   }
   dynamic "node_pool_auto_config" {
-    for_each = length(var.network_tags) > 0 || var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules || var.insecure_kubelet_readonly_port_enabled != null ? [1] : []
+    for_each = length(var.network_tags) > 0 || var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules || var.insecure_kubelet_readonly_port_enabled != null || var.node_pools_cgroup_mode != null ? [1] : []
     content {
       network_tags {
         tags = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules ? concat(var.network_tags, [local.cluster_network_tag]) : length(var.network_tags) > 0 ? var.network_tags : null
@@ -145,6 +145,14 @@ resource "google_container_cluster" "primary" {
         for_each = var.insecure_kubelet_readonly_port_enabled != null ? [1] : []
         content {
           insecure_kubelet_readonly_port_enabled = upper(tostring(var.insecure_kubelet_readonly_port_enabled))
+        }
+      }
+
+      dynamic "linux_node_config" {
+        for_each = (var.node_pools_cgroup_mode != null) ? [1] : []
+
+        content {
+          cgroup_mode = var.node_pools_cgroup_mode
         }
       }
     }

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -135,7 +135,7 @@ resource "google_container_cluster" "primary" {
     }
   }
   dynamic "node_pool_auto_config" {
-    for_each = length(var.network_tags) > 0 || var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules || var.insecure_kubelet_readonly_port_enabled != null || var.node_pools_cgroup_mode != null ? [1] : []
+    for_each = length(var.network_tags) > 0 || var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules || var.insecure_kubelet_readonly_port_enabled != null || var.node_pools_cgroup_mode != "" ? [1] : []
     content {
       network_tags {
         tags = var.add_cluster_firewall_rules || var.add_master_webhook_firewall_rules || var.add_shadow_firewall_rules ? concat(var.network_tags, [local.cluster_network_tag]) : length(var.network_tags) > 0 ? var.network_tags : null
@@ -149,7 +149,7 @@ resource "google_container_cluster" "primary" {
       }
 
       dynamic "linux_node_config" {
-        for_each = (var.node_pools_cgroup_mode != null) ? [1] : []
+        for_each = (var.node_pools_cgroup_mode != "") ? [1] : []
 
         content {
           cgroup_mode = var.node_pools_cgroup_mode

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -293,16 +293,16 @@ variable "node_pools_cgroup_mode" {
   type        = string
   description = "String contains cgroup node config for Autopilot node pools"
 
-  default = ""
+  default = null
 
   validation {
-    condition = var.node_pools_cgroup_mode == "" || contains(
+    condition = var.node_pools_cgroup_mode == null || contains(
       [
         "CGROUP_MODE_UNSPECIFIED",
         "CGROUP_MODE_V1",
         "CGROUP_MODE_V2"
       ],
-      var.node_pools_cgroup_mode
+      var.node_pools_cgroup_mode != null ? var.node_pools_cgroup_mode : ""
     )
     error_message = "The value for node_pools_cgroup_mode must be one of: CGROUP_MODE_UNSPECIFIED, CGROUP_MODE_V1, CGROUP_MODE_V2"
   }

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -289,6 +289,24 @@ variable "identity_namespace" {
   default     = "enabled"
 }
 
+variable "node_pools_cgroup_mode" {
+  type        = string
+  description = "String contains cgroup node config for Autopilot node pools"
+
+  default = null
+
+  validation {
+    condition = var.node_pools_cgroup_mode == null || contains(
+      [
+        "CGROUP_MODE_UNSPECIFIED",
+        "CGROUP_MODE_V1",
+        "CGROUP_MODE_V2"
+      ],
+      var.node_pools_cgroup_mode
+    )
+    error_message = "The value for node_pools_cgroup_mode must be one of: CGROUP_MODE_UNSPECIFIED, CGROUP_MODE_V1, CGROUP_MODE_V2, or null."
+  }
+}
 
 variable "release_channel" {
   type        = string

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -293,10 +293,10 @@ variable "node_pools_cgroup_mode" {
   type        = string
   description = "String contains cgroup node config for Autopilot node pools"
 
-  default = null
+  default = ""
 
   validation {
-    condition = var.node_pools_cgroup_mode == null || contains(
+    condition = var.node_pools_cgroup_mode == "" || contains(
       [
         "CGROUP_MODE_UNSPECIFIED",
         "CGROUP_MODE_V1",
@@ -304,7 +304,7 @@ variable "node_pools_cgroup_mode" {
       ],
       var.node_pools_cgroup_mode
     )
-    error_message = "The value for node_pools_cgroup_mode must be one of: CGROUP_MODE_UNSPECIFIED, CGROUP_MODE_V1, CGROUP_MODE_V2, or null."
+    error_message = "The value for node_pools_cgroup_mode must be one of: CGROUP_MODE_UNSPECIFIED, CGROUP_MODE_V1, CGROUP_MODE_V2"
   }
 }
 


### PR DESCRIPTION
## Description

Added `node_pools_cgroup_mode` parameter for autopilot clusters. The variable is string with follow possible values: 
- CGROUP_MODE_UNSPECIFIED 
- CGROUP_MODE_V1
- CGROUP_MODE_V2

By default value is empty and linux_node_config (and cgroup_mode) blocks will be not created.

## Checks
- `docker_test_lint` - ✅  (no issues related to my changes)
- `docker_generate_docs` - ✅ 

## Related issues
https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/2264
