### PR TITLE
chore(CI): E2_STANDARD_2 machine type

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -488,4 +488,4 @@ substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
   _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.23'
 options:
-  machineType: 'E2-STANDARD-2'
+  machineType: 'E2_STANDARD_2'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -487,5 +487,3 @@ tags:
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
   _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.23'
-options:
-  machineType: 'E2_STANDARD_2'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -488,4 +488,4 @@ substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
   _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.23'
 options:
-  machineType: 'E2_HIGHCPU_32'
+  machineType: 'E2-STANDARD-2'


### PR DESCRIPTION
With [blueprint-test v0.17.5](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/releases/tag/infra%2Fblueprint-test%2Fv0.17.5) we can move to a smaller runner