### PR TITLE
fix(autopilot): remove ip-masq configmap

### DIFF
--- a/autogen/main/README.md
+++ b/autogen/main/README.md
@@ -1,6 +1,6 @@
 # Terraform Kubernetes Engine Module
 
-This module handles opinionated Google Cloud Platform Kubernetes Engine cluster creation and configuration with Node Pools, IP MASQ, Network Policy, etc.{% if private_cluster %} This particular submodule creates a [private cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters){% endif %}{% if beta_cluster %}Beta features are enabled in this submodule.{% endif %}
+This module handles opinionated Google Cloud Platform Kubernetes Engine cluster creation and configuration with Node Pools, {% if autopilot_cluster != true%}IP MASQ, {% endif %}Network Policy, etc.{% if private_cluster %} This particular submodule creates a [private cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters){% endif %}{% if beta_cluster %}Beta features are enabled in this submodule.{% endif %}
 
 The resources/services/activations/deletions that this module will create/trigger are:
 
@@ -8,7 +8,9 @@ The resources/services/activations/deletions that this module will create/trigge
 - Create GKE Node Pool(s) with provided configuration and attach to cluster
 - Replace the default kube-dns configmap if `stub_domains` are provided
 - Activate network policy if `network_policy` is true
+{% if autopilot_cluster != true%}
 - Add `ip-masq-agent` configmap with provided `non_masquerade_cidrs` if `configure_ip_masq` is true
+{% endif %}
 
 Sub modules are provided for creating private clusters, beta private clusters, and beta public clusters as well.  Beta sub modules allow for the use of various GKE beta features. See the modules directory for the various sub modules.
 

--- a/autogen/main/masq.tf.tmpl
+++ b/autogen/main/masq.tf.tmpl
@@ -15,6 +15,7 @@
  */
 
 {{ autogeneration_note }}
+{% if autopilot_cluster != true%}
 
 /******************************************
   Create ip-masq-agent confimap
@@ -47,3 +48,4 @@ EOF
     {% endif %}
   ]
 }
+{% endif %}

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -410,6 +410,7 @@ variable "upstream_nameservers" {
 }
 {% endif %}
 
+{% if autopilot_cluster != true%}
 variable "non_masquerade_cidrs" {
   type        = list(string)
   description = "List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading."
@@ -433,6 +434,7 @@ variable "configure_ip_masq" {
   description = "Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server."
   default     = false
 }
+{% endif %}
 
 {% if beta_cluster and autopilot_cluster != true%}
 variable "cluster_telemetry_type" {

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -1,13 +1,12 @@
 # Terraform Kubernetes Engine Module
 
-This module handles opinionated Google Cloud Platform Kubernetes Engine cluster creation and configuration with Node Pools, IP MASQ, Network Policy, etc. This particular submodule creates a [private cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters)Beta features are enabled in this submodule.
+This module handles opinionated Google Cloud Platform Kubernetes Engine cluster creation and configuration with Node Pools, Network Policy, etc. This particular submodule creates a [private cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters)Beta features are enabled in this submodule.
 The resources/services/activations/deletions that this module will create/trigger are:
 
 - Create a GKE cluster with the provided addons
 - Create GKE Node Pool(s) with provided configuration and attach to cluster
 - Replace the default kube-dns configmap if `stub_domains` are provided
 - Activate network policy if `network_policy` is true
-- Add `ip-masq-agent` configmap with provided `non_masquerade_cidrs` if `configure_ip_masq` is true
 
 Sub modules are provided for creating private clusters, beta private clusters, and beta public clusters as well.  Beta sub modules allow for the use of various GKE beta features. See the modules directory for the various sub modules.
 
@@ -83,7 +82,6 @@ Then perform the following commands on the root folder:
 | boot\_disk\_kms\_key | The Customer Managed Encryption Key used to encrypt the boot disk attached to each node in the node pool, if not overridden in `node_pools`. This should be of the form projects/[KEY\_PROJECT\_ID]/locations/[LOCATION]/keyRings/[RING\_NAME]/cryptoKeys/[KEY\_NAME]. For more information about protecting resources with Cloud KMS Keys please see: https://cloud.google.com/compute/docs/disks/customer-managed-encryption | `string` | `null` | no |
 | cluster\_ipv4\_cidr | The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR. | `string` | `null` | no |
 | cluster\_resource\_labels | The GCE resource labels (a map of key/value pairs) to be applied to the cluster | `map(string)` | `{}` | no |
-| configure\_ip\_masq | Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server. | `bool` | `false` | no |
 | create\_service\_account | Defines if service account specified to run nodes should be created. | `bool` | `true` | no |
 | database\_encryption | Application-layer Secrets Encryption settings. The object format is {state = string, key\_name = string}. Valid values of state are: "ENCRYPTED"; "DECRYPTED". key\_name is the name of a CloudKMS key. | `list(object({ state = string, key_name = string }))` | <pre>[<br>  {<br>    "key_name": "",<br>    "state": "DECRYPTED"<br>  }<br>]</pre> | no |
 | deletion\_protection | Whether or not to allow Terraform to destroy the cluster. | `bool` | `true` | no |
@@ -121,8 +119,6 @@ Then perform the following commands on the root folder:
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
 | insecure\_kubelet\_readonly\_port\_enabled | Whether or not to set `insecure_kubelet_readonly_port_enabled` for node pool defaults and autopilot clusters. | `bool` | `null` | no |
-| ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
-| ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | `string` | n/a | yes |
 | ip\_range\_services | The _name_ of the secondary subnet range to use for services | `string` | n/a | yes |
 | issue\_client\_certificate | Issues a client certificate to authenticate to the cluster endpoint. To maximize the security of your cluster, leave this option disabled. Client certificates don't automatically rotate and aren't easily revocable. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
@@ -142,7 +138,6 @@ Then perform the following commands on the root folder:
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
 | network\_tags | (Optional) - List of network tags applied to auto-provisioned node pools. | `list(string)` | `[]` | no |
 | node\_pools\_cgroup\_mode | Specifies the Linux cgroup mode for autopilot Kubernetes nodes in the cluster. Accepted values are `CGROUP_MODE_UNSPECIFIED`, `CGROUP_MODE_V1`, and `CGROUP_MODE_V2`, which determine the control group hierarchy used for resource management. | `string` | `null` | no |
-| non\_masquerade\_cidrs | List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading. | `list(string)` | <pre>[<br>  "10.0.0.0/8",<br>  "172.16.0.0/12",<br>  "192.168.0.0/16"<br>]</pre> | no |
 | notification\_config\_topic | The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}. | `string` | `""` | no |
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |
 | private\_endpoint\_subnetwork | The subnetwork to use for the hosted master network. | `string` | `null` | no |

--- a/modules/beta-autopilot-private-cluster/masq.tf
+++ b/modules/beta-autopilot-private-cluster/masq.tf
@@ -15,32 +15,3 @@
  */
 
 // This file was automatically generated from a template in ./autogen/main
-
-/******************************************
-  Create ip-masq-agent confimap
- *****************************************/
-resource "kubernetes_config_map" "ip_masq_agent" {
-  count = var.configure_ip_masq ? 1 : 0
-
-  metadata {
-    name      = "ip-masq-agent"
-    namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
-  }
-
-  data = {
-    config = <<EOF
-nonMasqueradeCIDRs:
-  - ${join("\n  - ", var.non_masquerade_cidrs)}
-resyncInterval: ${var.ip_masq_resync_interval}
-masqLinkLocal: ${var.ip_masq_link_local}
-EOF
-  }
-
-  depends_on = [
-    google_container_cluster.primary,
-  ]
-}

--- a/modules/beta-autopilot-private-cluster/metadata.yaml
+++ b/modules/beta-autopilot-private-cluster/metadata.yaml
@@ -240,25 +240,6 @@ spec:
         description: (Optional) - List of network tags applied to auto-provisioned node pools.
         varType: list(string)
         defaultValue: []
-      - name: non_masquerade_cidrs
-        description: List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading.
-        varType: list(string)
-        defaultValue:
-          - 10.0.0.0/8
-          - 172.16.0.0/12
-          - 192.168.0.0/16
-      - name: ip_masq_resync_interval
-        description: The interval at which the agent attempts to sync its ConfigMap file from the disk.
-        varType: string
-        defaultValue: 60s
-      - name: ip_masq_link_local
-        description: Whether to masquerade traffic to the link-local prefix (169.254.0.0/16).
-        varType: bool
-        defaultValue: false
-      - name: configure_ip_masq
-        description: Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server.
-        varType: bool
-        defaultValue: false
       - name: create_service_account
         description: Defines if service account specified to run nodes should be created.
         varType: bool

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -207,29 +207,6 @@ variable "network_tags" {
 }
 
 
-variable "non_masquerade_cidrs" {
-  type        = list(string)
-  description = "List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading."
-  default     = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
-}
-
-variable "ip_masq_resync_interval" {
-  type        = string
-  description = "The interval at which the agent attempts to sync its ConfigMap file from the disk."
-  default     = "60s"
-}
-
-variable "ip_masq_link_local" {
-  type        = bool
-  description = "Whether to masquerade traffic to the link-local prefix (169.254.0.0/16)."
-  default     = false
-}
-
-variable "configure_ip_masq" {
-  type        = bool
-  description = "Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server."
-  default     = false
-}
 
 variable "create_service_account" {
   type        = bool

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -1,13 +1,12 @@
 # Terraform Kubernetes Engine Module
 
-This module handles opinionated Google Cloud Platform Kubernetes Engine cluster creation and configuration with Node Pools, IP MASQ, Network Policy, etc.Beta features are enabled in this submodule.
+This module handles opinionated Google Cloud Platform Kubernetes Engine cluster creation and configuration with Node Pools, Network Policy, etc.Beta features are enabled in this submodule.
 The resources/services/activations/deletions that this module will create/trigger are:
 
 - Create a GKE cluster with the provided addons
 - Create GKE Node Pool(s) with provided configuration and attach to cluster
 - Replace the default kube-dns configmap if `stub_domains` are provided
 - Activate network policy if `network_policy` is true
-- Add `ip-masq-agent` configmap with provided `non_masquerade_cidrs` if `configure_ip_masq` is true
 
 Sub modules are provided for creating private clusters, beta private clusters, and beta public clusters as well.  Beta sub modules allow for the use of various GKE beta features. See the modules directory for the various sub modules.
 
@@ -77,7 +76,6 @@ Then perform the following commands on the root folder:
 | boot\_disk\_kms\_key | The Customer Managed Encryption Key used to encrypt the boot disk attached to each node in the node pool, if not overridden in `node_pools`. This should be of the form projects/[KEY\_PROJECT\_ID]/locations/[LOCATION]/keyRings/[RING\_NAME]/cryptoKeys/[KEY\_NAME]. For more information about protecting resources with Cloud KMS Keys please see: https://cloud.google.com/compute/docs/disks/customer-managed-encryption | `string` | `null` | no |
 | cluster\_ipv4\_cidr | The IP address range of the kubernetes pods in this cluster. Default is an automatically assigned CIDR. | `string` | `null` | no |
 | cluster\_resource\_labels | The GCE resource labels (a map of key/value pairs) to be applied to the cluster | `map(string)` | `{}` | no |
-| configure\_ip\_masq | Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server. | `bool` | `false` | no |
 | create\_service\_account | Defines if service account specified to run nodes should be created. | `bool` | `true` | no |
 | database\_encryption | Application-layer Secrets Encryption settings. The object format is {state = string, key\_name = string}. Valid values of state are: "ENCRYPTED"; "DECRYPTED". key\_name is the name of a CloudKMS key. | `list(object({ state = string, key_name = string }))` | <pre>[<br>  {<br>    "key_name": "",<br>    "state": "DECRYPTED"<br>  }<br>]</pre> | no |
 | deletion\_protection | Whether or not to allow Terraform to destroy the cluster. | `bool` | `true` | no |
@@ -112,8 +110,6 @@ Then perform the following commands on the root folder:
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
 | insecure\_kubelet\_readonly\_port\_enabled | Whether or not to set `insecure_kubelet_readonly_port_enabled` for node pool defaults and autopilot clusters. | `bool` | `null` | no |
-| ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
-| ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | `string` | n/a | yes |
 | ip\_range\_services | The _name_ of the secondary subnet range to use for services | `string` | n/a | yes |
 | issue\_client\_certificate | Issues a client certificate to authenticate to the cluster endpoint. To maximize the security of your cluster, leave this option disabled. Client certificates don't automatically rotate and aren't easily revocable. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
@@ -131,7 +127,6 @@ Then perform the following commands on the root folder:
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
 | network\_tags | (Optional) - List of network tags applied to auto-provisioned node pools. | `list(string)` | `[]` | no |
 | node\_pools\_cgroup\_mode | Specifies the Linux cgroup mode for autopilot Kubernetes nodes in the cluster. Accepted values are `CGROUP_MODE_UNSPECIFIED`, `CGROUP_MODE_V1`, and `CGROUP_MODE_V2`, which determine the control group hierarchy used for resource management. | `string` | `null` | no |
-| non\_masquerade\_cidrs | List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading. | `list(string)` | <pre>[<br>  "10.0.0.0/8",<br>  "172.16.0.0/12",<br>  "192.168.0.0/16"<br>]</pre> | no |
 | notification\_config\_topic | The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}. | `string` | `""` | no |
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |

--- a/modules/beta-autopilot-public-cluster/masq.tf
+++ b/modules/beta-autopilot-public-cluster/masq.tf
@@ -15,32 +15,3 @@
  */
 
 // This file was automatically generated from a template in ./autogen/main
-
-/******************************************
-  Create ip-masq-agent confimap
- *****************************************/
-resource "kubernetes_config_map" "ip_masq_agent" {
-  count = var.configure_ip_masq ? 1 : 0
-
-  metadata {
-    name      = "ip-masq-agent"
-    namespace = "kube-system"
-
-    labels = {
-      maintained_by = "terraform"
-    }
-  }
-
-  data = {
-    config = <<EOF
-nonMasqueradeCIDRs:
-  - ${join("\n  - ", var.non_masquerade_cidrs)}
-resyncInterval: ${var.ip_masq_resync_interval}
-masqLinkLocal: ${var.ip_masq_link_local}
-EOF
-  }
-
-  depends_on = [
-    google_container_cluster.primary,
-  ]
-}

--- a/modules/beta-autopilot-public-cluster/metadata.yaml
+++ b/modules/beta-autopilot-public-cluster/metadata.yaml
@@ -240,25 +240,6 @@ spec:
         description: (Optional) - List of network tags applied to auto-provisioned node pools.
         varType: list(string)
         defaultValue: []
-      - name: non_masquerade_cidrs
-        description: List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading.
-        varType: list(string)
-        defaultValue:
-          - 10.0.0.0/8
-          - 172.16.0.0/12
-          - 192.168.0.0/16
-      - name: ip_masq_resync_interval
-        description: The interval at which the agent attempts to sync its ConfigMap file from the disk.
-        varType: string
-        defaultValue: 60s
-      - name: ip_masq_link_local
-        description: Whether to masquerade traffic to the link-local prefix (169.254.0.0/16).
-        varType: bool
-        defaultValue: false
-      - name: configure_ip_masq
-        description: Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server.
-        varType: bool
-        defaultValue: false
       - name: create_service_account
         description: Defines if service account specified to run nodes should be created.
         varType: bool

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -207,29 +207,6 @@ variable "network_tags" {
 }
 
 
-variable "non_masquerade_cidrs" {
-  type        = list(string)
-  description = "List of strings in CIDR notation that specify the IP address ranges that do not use IP masquerading."
-  default     = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"]
-}
-
-variable "ip_masq_resync_interval" {
-  type        = string
-  description = "The interval at which the agent attempts to sync its ConfigMap file from the disk."
-  default     = "60s"
-}
-
-variable "ip_masq_link_local" {
-  type        = bool
-  description = "Whether to masquerade traffic to the link-local prefix (169.254.0.0/16)."
-  default     = false
-}
-
-variable "configure_ip_masq" {
-  type        = bool
-  description = "Enables the installation of ip masquerading, which is usually no longer required when using aliasied IP addresses. IP masquerading uses a kubectl call, so when you have a private cluster, you will need access to the API server."
-  default     = false
-}
 
 variable "create_service_account" {
   type        = bool


### PR DESCRIPTION
- Autopilot does not use `ip-masq-agent` configMap for IP masquerade, removed.
- The Autopilot `EgressNATPolicy` method can't practically be implemented with the current Kubernetes provider method. (Can be opened as a Enhancement request)

Ref: https://cloud.google.com/kubernetes-engine/docs/concepts/ip-masquerade-agent


Closes: #2348 
Closes: #1895
Closes: #1578

BEGIN_COMMIT_OVERRIDE
fix(autopilot)!: remove ip-masq configmap (#2364)
END_COMMIT_OVERRIDE
