### PR TITLE
feat: ip_range_services to optional value (#1949)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Then perform the following commands on the root folder:
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | `string` | n/a | yes |
-| ip\_range\_services | The _name_ of the secondary subnet range to use for services | `string` | n/a | yes |
+| ip\_range\_services | The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used. | `string` | `null` | no |
 | issue\_client\_certificate | Issues a client certificate to authenticate to the cluster endpoint. To maximize the security of your cluster, leave this option disabled. Client certificates don't automatically rotate and aren't easily revocable. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | `string` | `"latest"` | no |
 | logging\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, APISERVER, CONTROLLER\_MANAGER, KCP\_CONNECTION, KCP\_SSHD, KCP\_HPA, SCHEDULER, and WORKLOADS. Empty list is default GKE configuration. | `list(string)` | `[]` | no |

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -530,10 +530,10 @@ resource "google_container_cluster" "primary" {
     precondition {
       {% if autopilot_cluster %}
       condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 27 : true
-      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.27 or upper."
+      error_message = "Setting ip_range_services is required for this GKE version. Please set ip_range_services or use kubernetes_version 1.27 or later."
       {% else %}
       condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 29 : true
-      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.29 or upper."
+      error_message = "Setting ip_range_services is required for this GKE version. Please set ip_range_services or use kubernetes_version 1.29 or later."
       {% endif %}
     }
 

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -526,11 +526,21 @@ resource "google_container_cluster" "primary" {
     }
   }
 
-  {% if autopilot_cluster != true %}
   lifecycle {
+    precondition {
+      {% if autopilot_cluster %}
+      condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 27 : true
+      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.27 or upper."
+      {% else %}
+      condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 29 : true
+      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.29 or upper."
+      {% endif %}
+    }
+
+    {% if autopilot_cluster != true %}
     ignore_changes = [node_pool, initial_node_count, resource_labels["asmv"]]
+    {% endif %}
   }
-  {% endif %}
 
   {% if autopilot_cluster != true %}
   dynamic "dns_config" {

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -176,7 +176,8 @@ variable "additional_ip_range_pods" {
 
 variable "ip_range_services" {
   type        = string
-  description = "The _name_ of the secondary subnet range to use for services"
+  description = "The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used."
+  default     = null
 }
 
 variable "stack_type" {

--- a/autogen/safer-cluster/variables.tf.tmpl
+++ b/autogen/safer-cluster/variables.tf.tmpl
@@ -138,7 +138,8 @@ variable "ip_range_pods" {
 
 variable "ip_range_services" {
   type        = string
-  description = "The _name_ of the secondary subnet range to use for services"
+  description = "The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used."
+  default     = null
 }
 
 variable "initial_node_count" {

--- a/cluster.tf
+++ b/cluster.tf
@@ -399,7 +399,7 @@ resource "google_container_cluster" "primary" {
   lifecycle {
     precondition {
       condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 29 : true
-      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.29 or upper."
+      error_message = "Setting ip_range_services is required for this GKE version. Please set ip_range_services or use kubernetes_version 1.29 or later."
     }
 
     ignore_changes = [node_pool, initial_node_count, resource_labels["asmv"]]

--- a/cluster.tf
+++ b/cluster.tf
@@ -397,6 +397,11 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
+    precondition {
+      condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 29 : true
+      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.29 or upper."
+    }
+
     ignore_changes = [node_pool, initial_node_count, resource_labels["asmv"]]
   }
 

--- a/examples/simple_autopilot_private/main.tf
+++ b/examples/simple_autopilot_private/main.tf
@@ -20,7 +20,6 @@ locals {
   subnet_name            = "simple-autopilot-private-subnet"
   master_auth_subnetwork = "simple-autopilot-private-master-subnet"
   pods_range_name        = "ip-range-pods-simple-autopilot-private"
-  svc_range_name         = "ip-range-svc-simple-autopilot-private"
   subnet_names           = [for subnet_self_link in module.gcp-network.subnets_self_links : split("/", subnet_self_link)[length(split("/", subnet_self_link)) - 1]]
 }
 
@@ -44,7 +43,6 @@ module "gke" {
   network                                = module.gcp-network.network_name
   subnetwork                             = local.subnet_names[index(module.gcp-network.subnets_names, local.subnet_name)]
   ip_range_pods                          = local.pods_range_name
-  ip_range_services                      = local.svc_range_name
   release_channel                        = "REGULAR"
   enable_vertical_pod_autoscaling        = true
   enable_private_endpoint                = true

--- a/examples/simple_autopilot_private/network.tf
+++ b/examples/simple_autopilot_private/network.tf
@@ -41,10 +41,6 @@ module "gcp-network" {
         range_name    = local.pods_range_name
         ip_cidr_range = "192.168.0.0/18"
       },
-      {
-        range_name    = local.svc_range_name
-        ip_cidr_range = "192.168.64.0/18"
-      },
     ]
   }
 }

--- a/examples/simple_regional_private/README.md
+++ b/examples/simple_regional_private/README.md
@@ -10,7 +10,6 @@ This example illustrates how to create a simple private cluster.
 | cluster\_name\_suffix | A suffix to append to the default cluster name | `string` | `""` | no |
 | compute\_engine\_service\_account | Service account to associate to the nodes in the cluster | `any` | n/a | yes |
 | ip\_range\_pods | The secondary ip range to use for pods | `any` | n/a | yes |
-| ip\_range\_services | The secondary ip range to use for services | `any` | n/a | yes |
 | network | The VPC network to host the cluster in | `any` | n/a | yes |
 | project\_id | The project ID to host the cluster in | `any` | n/a | yes |
 | region | The region to host the cluster in | `any` | n/a | yes |
@@ -24,7 +23,6 @@ This example illustrates how to create a simple private cluster.
 | client\_token | n/a |
 | cluster\_name | Cluster name |
 | ip\_range\_pods | The secondary IP range used for pods |
-| ip\_range\_services | The secondary IP range used for services |
 | kubernetes\_endpoint | n/a |
 | location | n/a |
 | master\_kubernetes\_version | The master Kubernetes version |

--- a/examples/simple_regional_private/main.tf
+++ b/examples/simple_regional_private/main.tf
@@ -43,7 +43,6 @@ module "gke" {
   network                     = var.network
   subnetwork                  = var.subnetwork
   ip_range_pods               = var.ip_range_pods
-  ip_range_services           = var.ip_range_services
   create_service_account      = false
   service_account             = var.compute_engine_service_account
   enable_private_endpoint     = true

--- a/examples/simple_regional_private/test_outputs.tf
+++ b/examples/simple_regional_private/test_outputs.tf
@@ -47,11 +47,6 @@ output "ip_range_pods" {
   value       = var.ip_range_pods
 }
 
-output "ip_range_services" {
-  description = "The secondary IP range used for services"
-  value       = var.ip_range_services
-}
-
 output "zones" {
   description = "List of zones in which the cluster resides"
   value       = module.gke.zones

--- a/examples/simple_regional_private/variables.tf
+++ b/examples/simple_regional_private/variables.tf
@@ -39,10 +39,6 @@ variable "ip_range_pods" {
   description = "The secondary ip range to use for pods"
 }
 
-variable "ip_range_services" {
-  description = "The secondary ip range to use for services"
-}
-
 variable "compute_engine_service_account" {
   description = "Service account to associate to the nodes in the cluster"
 }

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -248,9 +248,8 @@ spec:
         varType: list(string)
         defaultValue: []
       - name: ip_range_services
-        description: The _name_ of the secondary subnet range to use for services
+        description: The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used.
         varType: string
-        required: true
       - name: stack_type
         description: The stack type to use for this cluster. Either `IPV4` or `IPV4_IPV6`. Defaults to `IPV4`.
         varType: string

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -120,7 +120,7 @@ Then perform the following commands on the root folder:
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
 | insecure\_kubelet\_readonly\_port\_enabled | Whether or not to set `insecure_kubelet_readonly_port_enabled` for node pool defaults and autopilot clusters. | `bool` | `null` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | `string` | n/a | yes |
-| ip\_range\_services | The _name_ of the secondary subnet range to use for services | `string` | n/a | yes |
+| ip\_range\_services | The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used. | `string` | `null` | no |
 | issue\_client\_certificate | Issues a client certificate to authenticate to the cluster endpoint. To maximize the security of your cluster, leave this option disabled. Client certificates don't automatically rotate and aren't easily revocable. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | `string` | `"latest"` | no |
 | logging\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, APISERVER, CONTROLLER\_MANAGER, KCP\_CONNECTION, KCP\_SSHD, KCP\_HPA, SCHEDULER, and WORKLOADS. Empty list is default GKE configuration. | `list(string)` | `[]` | no |

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -307,6 +307,13 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  lifecycle {
+    precondition {
+      condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 27 : true
+      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.27 or upper."
+    }
+
+  }
 
   timeouts {
     create = lookup(var.timeouts, "create", "45m")

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -310,7 +310,7 @@ resource "google_container_cluster" "primary" {
   lifecycle {
     precondition {
       condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 27 : true
-      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.27 or upper."
+      error_message = "Setting ip_range_services is required for this GKE version. Please set ip_range_services or use kubernetes_version 1.27 or later."
     }
 
   }

--- a/modules/beta-autopilot-private-cluster/metadata.yaml
+++ b/modules/beta-autopilot-private-cluster/metadata.yaml
@@ -213,9 +213,8 @@ spec:
         varType: list(string)
         defaultValue: []
       - name: ip_range_services
-        description: The _name_ of the secondary subnet range to use for services
+        description: The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used.
         varType: string
-        required: true
       - name: stack_type
         description: The stack type to use for this cluster. Either `IPV4` or `IPV4_IPV6`. Defaults to `IPV4`.
         varType: string

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -166,7 +166,8 @@ variable "additional_ip_range_pods" {
 
 variable "ip_range_services" {
   type        = string
-  description = "The _name_ of the secondary subnet range to use for services"
+  description = "The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used."
+  default     = null
 }
 
 variable "stack_type" {

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -111,7 +111,7 @@ Then perform the following commands on the root folder:
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
 | insecure\_kubelet\_readonly\_port\_enabled | Whether or not to set `insecure_kubelet_readonly_port_enabled` for node pool defaults and autopilot clusters. | `bool` | `null` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | `string` | n/a | yes |
-| ip\_range\_services | The _name_ of the secondary subnet range to use for services | `string` | n/a | yes |
+| ip\_range\_services | The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used. | `string` | `null` | no |
 | issue\_client\_certificate | Issues a client certificate to authenticate to the cluster endpoint. To maximize the security of your cluster, leave this option disabled. Client certificates don't automatically rotate and aren't easily revocable. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | `string` | `"latest"` | no |
 | logging\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, APISERVER, CONTROLLER\_MANAGER, KCP\_CONNECTION, KCP\_SSHD, KCP\_HPA, SCHEDULER, and WORKLOADS. Empty list is default GKE configuration. | `list(string)` | `[]` | no |

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -307,6 +307,13 @@ resource "google_container_cluster" "primary" {
     }
   }
 
+  lifecycle {
+    precondition {
+      condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 27 : true
+      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.27 or upper."
+    }
+
+  }
 
   timeouts {
     create = lookup(var.timeouts, "create", "45m")

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -310,7 +310,7 @@ resource "google_container_cluster" "primary" {
   lifecycle {
     precondition {
       condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 27 : true
-      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.27 or upper."
+      error_message = "Setting ip_range_services is required for this GKE version. Please set ip_range_services or use kubernetes_version 1.27 or later."
     }
 
   }

--- a/modules/beta-autopilot-public-cluster/metadata.yaml
+++ b/modules/beta-autopilot-public-cluster/metadata.yaml
@@ -213,9 +213,8 @@ spec:
         varType: list(string)
         defaultValue: []
       - name: ip_range_services
-        description: The _name_ of the secondary subnet range to use for services
+        description: The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used.
         varType: string
-        required: true
       - name: stack_type
         description: The stack type to use for this cluster. Either `IPV4` or `IPV4_IPV6`. Defaults to `IPV4`.
         varType: string

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -166,7 +166,8 @@ variable "additional_ip_range_pods" {
 
 variable "ip_range_services" {
   type        = string
-  description = "The _name_ of the secondary subnet range to use for services"
+  description = "The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used."
+  default     = null
 }
 
 variable "stack_type" {

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -243,7 +243,7 @@ Then perform the following commands on the root folder:
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | `string` | n/a | yes |
-| ip\_range\_services | The _name_ of the secondary subnet range to use for services | `string` | n/a | yes |
+| ip\_range\_services | The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used. | `string` | `null` | no |
 | issue\_client\_certificate | Issues a client certificate to authenticate to the cluster endpoint. To maximize the security of your cluster, leave this option disabled. Client certificates don't automatically rotate and aren't easily revocable. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | istio | (Beta) Enable Istio addon | `bool` | `false` | no |
 | istio\_auth | (Beta) The authentication type between services in Istio. | `string` | `"AUTH_MUTUAL_TLS"` | no |

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -434,6 +434,11 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
+    precondition {
+      condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 29 : true
+      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.29 or upper."
+    }
+
     ignore_changes = [node_pool, initial_node_count, resource_labels["asmv"]]
   }
 

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -436,7 +436,7 @@ resource "google_container_cluster" "primary" {
   lifecycle {
     precondition {
       condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 29 : true
-      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.29 or upper."
+      error_message = "Setting ip_range_services is required for this GKE version. Please set ip_range_services or use kubernetes_version 1.29 or later."
     }
 
     ignore_changes = [node_pool, initial_node_count, resource_labels["asmv"]]

--- a/modules/beta-private-cluster-update-variant/metadata.yaml
+++ b/modules/beta-private-cluster-update-variant/metadata.yaml
@@ -214,9 +214,8 @@ spec:
         varType: list(string)
         defaultValue: []
       - name: ip_range_services
-        description: The _name_ of the secondary subnet range to use for services
+        description: The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used.
         varType: string
-        required: true
       - name: stack_type
         description: The stack type to use for this cluster. Either `IPV4` or `IPV4_IPV6`. Defaults to `IPV4`.
         varType: string

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -157,7 +157,8 @@ variable "additional_ip_range_pods" {
 
 variable "ip_range_services" {
   type        = string
-  description = "The _name_ of the secondary subnet range to use for services"
+  description = "The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used."
+  default     = null
 }
 
 variable "stack_type" {

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -221,7 +221,7 @@ Then perform the following commands on the root folder:
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | `string` | n/a | yes |
-| ip\_range\_services | The _name_ of the secondary subnet range to use for services | `string` | n/a | yes |
+| ip\_range\_services | The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used. | `string` | `null` | no |
 | issue\_client\_certificate | Issues a client certificate to authenticate to the cluster endpoint. To maximize the security of your cluster, leave this option disabled. Client certificates don't automatically rotate and aren't easily revocable. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | istio | (Beta) Enable Istio addon | `bool` | `false` | no |
 | istio\_auth | (Beta) The authentication type between services in Istio. | `string` | `"AUTH_MUTUAL_TLS"` | no |

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -434,6 +434,11 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
+    precondition {
+      condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 29 : true
+      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.29 or upper."
+    }
+
     ignore_changes = [node_pool, initial_node_count, resource_labels["asmv"]]
   }
 

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -436,7 +436,7 @@ resource "google_container_cluster" "primary" {
   lifecycle {
     precondition {
       condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 29 : true
-      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.29 or upper."
+      error_message = "Setting ip_range_services is required for this GKE version. Please set ip_range_services or use kubernetes_version 1.29 or later."
     }
 
     ignore_changes = [node_pool, initial_node_count, resource_labels["asmv"]]

--- a/modules/beta-private-cluster/metadata.yaml
+++ b/modules/beta-private-cluster/metadata.yaml
@@ -214,9 +214,8 @@ spec:
         varType: list(string)
         defaultValue: []
       - name: ip_range_services
-        description: The _name_ of the secondary subnet range to use for services
+        description: The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used.
         varType: string
-        required: true
       - name: stack_type
         description: The stack type to use for this cluster. Either `IPV4` or `IPV4_IPV6`. Defaults to `IPV4`.
         varType: string

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -157,7 +157,8 @@ variable "additional_ip_range_pods" {
 
 variable "ip_range_services" {
   type        = string
-  description = "The _name_ of the secondary subnet range to use for services"
+  description = "The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used."
+  default     = null
 }
 
 variable "stack_type" {

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -234,7 +234,7 @@ Then perform the following commands on the root folder:
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | `string` | n/a | yes |
-| ip\_range\_services | The _name_ of the secondary subnet range to use for services | `string` | n/a | yes |
+| ip\_range\_services | The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used. | `string` | `null` | no |
 | issue\_client\_certificate | Issues a client certificate to authenticate to the cluster endpoint. To maximize the security of your cluster, leave this option disabled. Client certificates don't automatically rotate and aren't easily revocable. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | istio | (Beta) Enable Istio addon | `bool` | `false` | no |
 | istio\_auth | (Beta) The authentication type between services in Istio. | `string` | `"AUTH_MUTUAL_TLS"` | no |

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -434,6 +434,11 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
+    precondition {
+      condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 29 : true
+      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.29 or upper."
+    }
+
     ignore_changes = [node_pool, initial_node_count, resource_labels["asmv"]]
   }
 

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -436,7 +436,7 @@ resource "google_container_cluster" "primary" {
   lifecycle {
     precondition {
       condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 29 : true
-      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.29 or upper."
+      error_message = "Setting ip_range_services is required for this GKE version. Please set ip_range_services or use kubernetes_version 1.29 or later."
     }
 
     ignore_changes = [node_pool, initial_node_count, resource_labels["asmv"]]

--- a/modules/beta-public-cluster-update-variant/metadata.yaml
+++ b/modules/beta-public-cluster-update-variant/metadata.yaml
@@ -214,9 +214,8 @@ spec:
         varType: list(string)
         defaultValue: []
       - name: ip_range_services
-        description: The _name_ of the secondary subnet range to use for services
+        description: The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used.
         varType: string
-        required: true
       - name: stack_type
         description: The stack type to use for this cluster. Either `IPV4` or `IPV4_IPV6`. Defaults to `IPV4`.
         varType: string

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -157,7 +157,8 @@ variable "additional_ip_range_pods" {
 
 variable "ip_range_services" {
   type        = string
-  description = "The _name_ of the secondary subnet range to use for services"
+  description = "The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used."
+  default     = null
 }
 
 variable "stack_type" {

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -212,7 +212,7 @@ Then perform the following commands on the root folder:
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | `string` | n/a | yes |
-| ip\_range\_services | The _name_ of the secondary subnet range to use for services | `string` | n/a | yes |
+| ip\_range\_services | The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used. | `string` | `null` | no |
 | issue\_client\_certificate | Issues a client certificate to authenticate to the cluster endpoint. To maximize the security of your cluster, leave this option disabled. Client certificates don't automatically rotate and aren't easily revocable. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | istio | (Beta) Enable Istio addon | `bool` | `false` | no |
 | istio\_auth | (Beta) The authentication type between services in Istio. | `string` | `"AUTH_MUTUAL_TLS"` | no |

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -434,6 +434,11 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
+    precondition {
+      condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 29 : true
+      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.29 or upper."
+    }
+
     ignore_changes = [node_pool, initial_node_count, resource_labels["asmv"]]
   }
 

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -436,7 +436,7 @@ resource "google_container_cluster" "primary" {
   lifecycle {
     precondition {
       condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 29 : true
-      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.29 or upper."
+      error_message = "Setting ip_range_services is required for this GKE version. Please set ip_range_services or use kubernetes_version 1.29 or later."
     }
 
     ignore_changes = [node_pool, initial_node_count, resource_labels["asmv"]]

--- a/modules/beta-public-cluster/metadata.yaml
+++ b/modules/beta-public-cluster/metadata.yaml
@@ -214,9 +214,8 @@ spec:
         varType: list(string)
         defaultValue: []
       - name: ip_range_services
-        description: The _name_ of the secondary subnet range to use for services
+        description: The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used.
         varType: string
-        required: true
       - name: stack_type
         description: The stack type to use for this cluster. Either `IPV4` or `IPV4_IPV6`. Defaults to `IPV4`.
         varType: string

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -157,7 +157,8 @@ variable "additional_ip_range_pods" {
 
 variable "ip_range_services" {
   type        = string
-  description = "The _name_ of the secondary subnet range to use for services"
+  description = "The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used."
+  default     = null
 }
 
 variable "stack_type" {

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -235,7 +235,7 @@ Then perform the following commands on the root folder:
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | `string` | n/a | yes |
-| ip\_range\_services | The _name_ of the secondary subnet range to use for services | `string` | n/a | yes |
+| ip\_range\_services | The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used. | `string` | `null` | no |
 | issue\_client\_certificate | Issues a client certificate to authenticate to the cluster endpoint. To maximize the security of your cluster, leave this option disabled. Client certificates don't automatically rotate and aren't easily revocable. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | `string` | `"latest"` | no |
 | logging\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, APISERVER, CONTROLLER\_MANAGER, KCP\_CONNECTION, KCP\_SSHD, KCP\_HPA, SCHEDULER, and WORKLOADS. Empty list is default GKE configuration. | `list(string)` | `[]` | no |

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -399,7 +399,7 @@ resource "google_container_cluster" "primary" {
   lifecycle {
     precondition {
       condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 29 : true
-      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.29 or upper."
+      error_message = "Setting ip_range_services is required for this GKE version. Please set ip_range_services or use kubernetes_version 1.29 or later."
     }
 
     ignore_changes = [node_pool, initial_node_count, resource_labels["asmv"]]

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -397,6 +397,11 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
+    precondition {
+      condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 29 : true
+      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.29 or upper."
+    }
+
     ignore_changes = [node_pool, initial_node_count, resource_labels["asmv"]]
   }
 

--- a/modules/private-cluster-update-variant/metadata.yaml
+++ b/modules/private-cluster-update-variant/metadata.yaml
@@ -214,9 +214,8 @@ spec:
         varType: list(string)
         defaultValue: []
       - name: ip_range_services
-        description: The _name_ of the secondary subnet range to use for services
+        description: The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used.
         varType: string
-        required: true
       - name: stack_type
         description: The stack type to use for this cluster. Either `IPV4` or `IPV4_IPV6`. Defaults to `IPV4`.
         varType: string

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -157,7 +157,8 @@ variable "additional_ip_range_pods" {
 
 variable "ip_range_services" {
   type        = string
-  description = "The _name_ of the secondary subnet range to use for services"
+  description = "The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used."
+  default     = null
 }
 
 variable "stack_type" {

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -213,7 +213,7 @@ Then perform the following commands on the root folder:
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |
 | ip\_masq\_resync\_interval | The interval at which the agent attempts to sync its ConfigMap file from the disk. | `string` | `"60s"` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | `string` | n/a | yes |
-| ip\_range\_services | The _name_ of the secondary subnet range to use for services | `string` | n/a | yes |
+| ip\_range\_services | The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used. | `string` | `null` | no |
 | issue\_client\_certificate | Issues a client certificate to authenticate to the cluster endpoint. To maximize the security of your cluster, leave this option disabled. Client certificates don't automatically rotate and aren't easily revocable. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
 | kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. | `string` | `"latest"` | no |
 | logging\_enabled\_components | List of services to monitor: SYSTEM\_COMPONENTS, APISERVER, CONTROLLER\_MANAGER, KCP\_CONNECTION, KCP\_SSHD, KCP\_HPA, SCHEDULER, and WORKLOADS. Empty list is default GKE configuration. | `list(string)` | `[]` | no |

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -399,7 +399,7 @@ resource "google_container_cluster" "primary" {
   lifecycle {
     precondition {
       condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 29 : true
-      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.29 or upper."
+      error_message = "Setting ip_range_services is required for this GKE version. Please set ip_range_services or use kubernetes_version 1.29 or later."
     }
 
     ignore_changes = [node_pool, initial_node_count, resource_labels["asmv"]]

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -397,6 +397,11 @@ resource "google_container_cluster" "primary" {
   }
 
   lifecycle {
+    precondition {
+      condition     = var.ip_range_services == null && var.kubernetes_version != "latest" ? tonumber(split(".", var.kubernetes_version)[0]) >= 1 && tonumber(split(".", var.kubernetes_version)[1]) >= 29 : true
+      error_message = "The ip_range_services is require for this gke version. Please set ip_range_services or use kubernetes_version 1.29 or upper."
+    }
+
     ignore_changes = [node_pool, initial_node_count, resource_labels["asmv"]]
   }
 

--- a/modules/private-cluster/metadata.yaml
+++ b/modules/private-cluster/metadata.yaml
@@ -214,9 +214,8 @@ spec:
         varType: list(string)
         defaultValue: []
       - name: ip_range_services
-        description: The _name_ of the secondary subnet range to use for services
+        description: The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used.
         varType: string
-        required: true
       - name: stack_type
         description: The stack type to use for this cluster. Either `IPV4` or `IPV4_IPV6`. Defaults to `IPV4`.
         varType: string

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -157,7 +157,8 @@ variable "additional_ip_range_pods" {
 
 variable "ip_range_services" {
   type        = string
-  description = "The _name_ of the secondary subnet range to use for services"
+  description = "The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used."
+  default     = null
 }
 
 variable "stack_type" {

--- a/modules/safer-cluster-update-variant/README.md
+++ b/modules/safer-cluster-update-variant/README.md
@@ -240,7 +240,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | http\_load\_balancing | Enable httpload balancer addon. The addon allows whoever can create Ingress objects to expose an application to a public IP. Network policies or Gatekeeper policies should be used to verify that only authorized applications are exposed. | `bool` | `true` | no |
 | initial\_node\_count | The number of nodes to create in this cluster's default node pool. | `number` | `0` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | `string` | n/a | yes |
-| ip\_range\_services | The _name_ of the secondary subnet range to use for services | `string` | n/a | yes |
+| ip\_range\_services | The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used. | `string` | `null` | no |
 | istio | (Beta) Enable Istio addon | `bool` | `false` | no |
 | istio\_auth | (Beta) The authentication type between services in Istio. | `string` | `"AUTH_MUTUAL_TLS"` | no |
 | kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. The module enforces certain minimum versions to ensure that specific features are available. | `string` | `null` | no |

--- a/modules/safer-cluster-update-variant/metadata.yaml
+++ b/modules/safer-cluster-update-variant/metadata.yaml
@@ -203,9 +203,8 @@ spec:
         varType: string
         required: true
       - name: ip_range_services
-        description: The _name_ of the secondary subnet range to use for services
+        description: The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used.
         varType: string
-        required: true
       - name: initial_node_count
         description: The number of nodes to create in this cluster's default node pool.
         varType: number

--- a/modules/safer-cluster-update-variant/variables.tf
+++ b/modules/safer-cluster-update-variant/variables.tf
@@ -138,7 +138,8 @@ variable "ip_range_pods" {
 
 variable "ip_range_services" {
   type        = string
-  description = "The _name_ of the secondary subnet range to use for services"
+  description = "The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used."
+  default     = null
 }
 
 variable "initial_node_count" {

--- a/modules/safer-cluster/README.md
+++ b/modules/safer-cluster/README.md
@@ -240,7 +240,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | http\_load\_balancing | Enable httpload balancer addon. The addon allows whoever can create Ingress objects to expose an application to a public IP. Network policies or Gatekeeper policies should be used to verify that only authorized applications are exposed. | `bool` | `true` | no |
 | initial\_node\_count | The number of nodes to create in this cluster's default node pool. | `number` | `0` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | `string` | n/a | yes |
-| ip\_range\_services | The _name_ of the secondary subnet range to use for services | `string` | n/a | yes |
+| ip\_range\_services | The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used. | `string` | `null` | no |
 | istio | (Beta) Enable Istio addon | `bool` | `false` | no |
 | istio\_auth | (Beta) The authentication type between services in Istio. | `string` | `"AUTH_MUTUAL_TLS"` | no |
 | kubernetes\_version | The Kubernetes version of the masters. If set to 'latest' it will pull latest available version in the selected region. The module enforces certain minimum versions to ensure that specific features are available. | `string` | `null` | no |

--- a/modules/safer-cluster/metadata.yaml
+++ b/modules/safer-cluster/metadata.yaml
@@ -203,9 +203,8 @@ spec:
         varType: string
         required: true
       - name: ip_range_services
-        description: The _name_ of the secondary subnet range to use for services
+        description: The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used.
         varType: string
-        required: true
       - name: initial_node_count
         description: The number of nodes to create in this cluster's default node pool.
         varType: number

--- a/modules/safer-cluster/variables.tf
+++ b/modules/safer-cluster/variables.tf
@@ -138,7 +138,8 @@ variable "ip_range_pods" {
 
 variable "ip_range_services" {
   type        = string
-  description = "The _name_ of the secondary subnet range to use for services"
+  description = "The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used."
+  default     = null
 }
 
 variable "initial_node_count" {

--- a/test/fixtures/simple_regional_private/example.tf
+++ b/test/fixtures/simple_regional_private/example.tf
@@ -23,7 +23,6 @@ module "example" {
   network                        = google_compute_network.main.name
   subnetwork                     = google_compute_subnetwork.main.name
   ip_range_pods                  = google_compute_subnetwork.main.secondary_ip_range[0].range_name
-  ip_range_services              = google_compute_subnetwork.main.secondary_ip_range[1].range_name
   compute_engine_service_account = var.compute_engine_service_accounts[1]
 }
 

--- a/test/integration/simple_autopilot_private/testdata/TestSimpleAutopilotPrivate.json
+++ b/test/integration/simple_autopilot_private/testdata/TestSimpleAutopilotPrivate.json
@@ -88,9 +88,8 @@
       "clusterIpv4Cidr": "192.168.0.0/18",
       "clusterIpv4CidrBlock": "192.168.0.0/18",
       "clusterSecondaryRangeName": "ip-range-pods-simple-autopilot-private",
-      "servicesIpv4Cidr": "192.168.64.0/18",
-      "servicesIpv4CidrBlock": "192.168.64.0/18",
-      "servicesSecondaryRangeName": "ip-range-svc-simple-autopilot-private",
+      "servicesIpv4Cidr": "34.118.224.0/20",
+      "servicesIpv4CidrBlock": "34.118.224.0/20",
       "stackType": "IPV4",
       "useIpAliases": true
     },

--- a/test/integration/simple_regional_private/testdata/TestSimpleRegionalPrivate.json
+++ b/test/integration/simple_regional_private/testdata/TestSimpleRegionalPrivate.json
@@ -44,9 +44,8 @@
       "clusterIpv4Cidr": "192.168.0.0/18",
       "clusterIpv4CidrBlock": "192.168.0.0/18",
       "clusterSecondaryRangeName": "cft-gke-test-pods-6anh",
-      "servicesIpv4Cidr": "192.168.64.0/18",
-      "servicesIpv4CidrBlock": "192.168.64.0/18",
-      "servicesSecondaryRangeName": "cft-gke-test-services-6anh",
+      "servicesIpv4Cidr": "34.118.224.0/20",
+      "servicesIpv4CidrBlock": "34.118.224.0/20",
       "stackType": "IPV4",
       "useIpAliases": true
     },

--- a/variables.tf
+++ b/variables.tf
@@ -157,7 +157,8 @@ variable "additional_ip_range_pods" {
 
 variable "ip_range_services" {
   type        = string
-  description = "The _name_ of the secondary subnet range to use for services"
+  description = "The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used."
+  default     = null
 }
 
 variable "stack_type" {


### PR DESCRIPTION
Based on #1989 by @0Delta , fixed the comments that were not addressed in the original PR and updated tests.

Fixes #1949.

As of GKE version 1.29 and Autopilot 1.27, the service ip range is given a default of 34.118.224.0/20 per cluster.
Versions earlier than the specified version may be omitted, but will be rejected by the validator.

This change has a big impact, but has not been thoroughly discussed yet.
We hope to merge it after sufficient discussion and making the necessary corrections.