### PR TITLE
feat: add support for in_transit_encryption_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Then perform the following commands on the root folder:
 | hpa\_profile | Enable the Horizontal Pod Autoscaling profile for this cluster. Values are "NONE" and "PERFORMANCE". | `string` | `""` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
+| in\_transit\_encryption\_config | Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`. | `string` | `null` | no |
 | initial\_node\_count | The number of nodes to create in this cluster's default node pool. | `number` | `0` | no |
 | insecure\_kubelet\_readonly\_port\_enabled | Whether or not to set `insecure_kubelet_readonly_port_enabled` for node pool defaults and autopilot clusters. Note: this can be set at the node pool level separately within `node_pools`. | `bool` | `null` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -254,6 +254,8 @@ resource "google_container_cluster" "primary" {
   disable_l4_lb_firewall_reconciliation = var.disable_l4_lb_firewall_reconciliation
 
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
+  
+  in_transit_encryption_config = var.in_transit_encryption_config
 
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -696,6 +696,12 @@ variable "enable_cilium_clusterwide_network_policy" {
   default       = false
 }
 
+variable "in_transit_encryption_config" {
+  type        = string
+  description = "Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`."
+  default     = null
+}
+
 variable "security_posture_mode" {
   description = "Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`."
   type        = string

--- a/cluster.tf
+++ b/cluster.tf
@@ -194,6 +194,8 @@ resource "google_container_cluster" "primary" {
 
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
+  in_transit_encryption_config = var.in_transit_encryption_config
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -204,6 +204,9 @@ spec:
         identity_namespace:
           name: identity_namespace
           title: Identity Namespace
+        in_transit_encryption_config:
+          name: in_transit_encryption_config
+          title: In Transit Encryption Config
         initial_node_count:
           name: initial_node_count
           title: Initial Node Count

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -540,6 +540,9 @@ spec:
         description: Enable Cilium Cluster Wide Network Policies on the cluster
         varType: bool
         defaultValue: false
+      - name: in_transit_encryption_config
+        description: Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`.
+        varType: string
       - name: security_posture_mode
         description: Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`.
         varType: string

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -118,6 +118,7 @@ Then perform the following commands on the root folder:
 | hpa\_profile | Enable the Horizontal Pod Autoscaling profile for this cluster. Values are "NONE" and "PERFORMANCE". | `string` | `""` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
+| in\_transit\_encryption\_config | Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`. | `string` | `null` | no |
 | insecure\_kubelet\_readonly\_port\_enabled | Whether or not to set `insecure_kubelet_readonly_port_enabled` for node pool defaults and autopilot clusters. | `bool` | `null` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | `string` | n/a | yes |
 | ip\_range\_services | The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used. | `string` | `null` | no |

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -114,6 +114,8 @@ resource "google_container_cluster" "primary" {
 
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
+  in_transit_encryption_config = var.in_transit_encryption_config
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/modules/beta-autopilot-private-cluster/metadata.display.yaml
+++ b/modules/beta-autopilot-private-cluster/metadata.display.yaml
@@ -166,6 +166,9 @@ spec:
         identity_namespace:
           name: identity_namespace
           title: Identity Namespace
+        in_transit_encryption_config:
+          name: in_transit_encryption_config
+          title: In Transit Encryption Config
         insecure_kubelet_readonly_port_enabled:
           name: insecure_kubelet_readonly_port_enabled
           title: Insecure Kubelet Readonly Port Enabled

--- a/modules/beta-autopilot-private-cluster/metadata.yaml
+++ b/modules/beta-autopilot-private-cluster/metadata.yaml
@@ -375,6 +375,9 @@ spec:
         description: Enable Cilium Cluster Wide Network Policies on the cluster
         varType: bool
         defaultValue: false
+      - name: in_transit_encryption_config
+        description: Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`.
+        varType: string
       - name: security_posture_mode
         description: Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`.
         varType: string

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -423,6 +423,12 @@ variable "enable_cilium_clusterwide_network_policy" {
   default     = false
 }
 
+variable "in_transit_encryption_config" {
+  type        = string
+  description = "Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`."
+  default     = null
+}
+
 variable "security_posture_mode" {
   description = "Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`."
   type        = string

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -109,6 +109,7 @@ Then perform the following commands on the root folder:
 | hpa\_profile | Enable the Horizontal Pod Autoscaling profile for this cluster. Values are "NONE" and "PERFORMANCE". | `string` | `""` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
+| in\_transit\_encryption\_config | Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`. | `string` | `null` | no |
 | insecure\_kubelet\_readonly\_port\_enabled | Whether or not to set `insecure_kubelet_readonly_port_enabled` for node pool defaults and autopilot clusters. | `bool` | `null` | no |
 | ip\_range\_pods | The _name_ of the secondary subnet ip range to use for pods | `string` | n/a | yes |
 | ip\_range\_services | The _name_ of the secondary subnet range to use for services. If not provided, the default `34.118.224.0/20` range will be used. | `string` | `null` | no |

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -114,6 +114,8 @@ resource "google_container_cluster" "primary" {
 
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
+  in_transit_encryption_config = var.in_transit_encryption_config
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/modules/beta-autopilot-public-cluster/metadata.display.yaml
+++ b/modules/beta-autopilot-public-cluster/metadata.display.yaml
@@ -157,6 +157,9 @@ spec:
         identity_namespace:
           name: identity_namespace
           title: Identity Namespace
+        in_transit_encryption_config:
+          name: in_transit_encryption_config
+          title: In Transit Encryption Config
         insecure_kubelet_readonly_port_enabled:
           name: insecure_kubelet_readonly_port_enabled
           title: Insecure Kubelet Readonly Port Enabled

--- a/modules/beta-autopilot-public-cluster/metadata.yaml
+++ b/modules/beta-autopilot-public-cluster/metadata.yaml
@@ -353,6 +353,9 @@ spec:
         description: Enable Cilium Cluster Wide Network Policies on the cluster
         varType: bool
         defaultValue: false
+      - name: in_transit_encryption_config
+        description: Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`.
+        varType: string
       - name: security_posture_mode
         description: Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`.
         varType: string

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -387,6 +387,12 @@ variable "enable_cilium_clusterwide_network_policy" {
   default     = false
 }
 
+variable "in_transit_encryption_config" {
+  type        = string
+  description = "Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`."
+  default     = null
+}
+
 variable "security_posture_mode" {
   description = "Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`."
   type        = string

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -238,6 +238,7 @@ Then perform the following commands on the root folder:
 | hpa\_profile | Enable the Horizontal Pod Autoscaling profile for this cluster. Values are "NONE" and "PERFORMANCE". | `string` | `""` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
+| in\_transit\_encryption\_config | Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`. | `string` | `null` | no |
 | initial\_node\_count | The number of nodes to create in this cluster's default node pool. | `number` | `0` | no |
 | insecure\_kubelet\_readonly\_port\_enabled | Whether or not to set `insecure_kubelet_readonly_port_enabled` for node pool defaults and autopilot clusters. Note: this can be set at the node pool level separately within `node_pools`. | `bool` | `null` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -207,6 +207,8 @@ resource "google_container_cluster" "primary" {
 
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
+  in_transit_encryption_config = var.in_transit_encryption_config
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/modules/beta-private-cluster-update-variant/metadata.display.yaml
+++ b/modules/beta-private-cluster-update-variant/metadata.display.yaml
@@ -229,6 +229,9 @@ spec:
         identity_namespace:
           name: identity_namespace
           title: Identity Namespace
+        in_transit_encryption_config:
+          name: in_transit_encryption_config
+          title: In Transit Encryption Config
         initial_node_count:
           name: initial_node_count
           title: Initial Node Count

--- a/modules/beta-private-cluster-update-variant/metadata.yaml
+++ b/modules/beta-private-cluster-update-variant/metadata.yaml
@@ -539,6 +539,9 @@ spec:
         description: Enable Cilium Cluster Wide Network Policies on the cluster
         varType: bool
         defaultValue: false
+      - name: in_transit_encryption_config
+        description: Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`.
+        varType: string
       - name: security_posture_mode
         description: Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`.
         varType: string

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -653,6 +653,12 @@ variable "enable_cilium_clusterwide_network_policy" {
   default     = false
 }
 
+variable "in_transit_encryption_config" {
+  type        = string
+  description = "Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`."
+  default     = null
+}
+
 variable "security_posture_mode" {
   description = "Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`."
   type        = string

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -216,6 +216,7 @@ Then perform the following commands on the root folder:
 | hpa\_profile | Enable the Horizontal Pod Autoscaling profile for this cluster. Values are "NONE" and "PERFORMANCE". | `string` | `""` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
+| in\_transit\_encryption\_config | Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`. | `string` | `null` | no |
 | initial\_node\_count | The number of nodes to create in this cluster's default node pool. | `number` | `0` | no |
 | insecure\_kubelet\_readonly\_port\_enabled | Whether or not to set `insecure_kubelet_readonly_port_enabled` for node pool defaults and autopilot clusters. Note: this can be set at the node pool level separately within `node_pools`. | `bool` | `null` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -207,6 +207,8 @@ resource "google_container_cluster" "primary" {
 
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
+  in_transit_encryption_config = var.in_transit_encryption_config
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/modules/beta-private-cluster/metadata.display.yaml
+++ b/modules/beta-private-cluster/metadata.display.yaml
@@ -229,6 +229,9 @@ spec:
         identity_namespace:
           name: identity_namespace
           title: Identity Namespace
+        in_transit_encryption_config:
+          name: in_transit_encryption_config
+          title: In Transit Encryption Config
         initial_node_count:
           name: initial_node_count
           title: Initial Node Count

--- a/modules/beta-private-cluster/metadata.yaml
+++ b/modules/beta-private-cluster/metadata.yaml
@@ -539,6 +539,9 @@ spec:
         description: Enable Cilium Cluster Wide Network Policies on the cluster
         varType: bool
         defaultValue: false
+      - name: in_transit_encryption_config
+        description: Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`.
+        varType: string
       - name: security_posture_mode
         description: Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`.
         varType: string

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -653,6 +653,12 @@ variable "enable_cilium_clusterwide_network_policy" {
   default     = false
 }
 
+variable "in_transit_encryption_config" {
+  type        = string
+  description = "Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`."
+  default     = null
+}
+
 variable "security_posture_mode" {
   description = "Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`."
   type        = string

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -229,6 +229,7 @@ Then perform the following commands on the root folder:
 | hpa\_profile | Enable the Horizontal Pod Autoscaling profile for this cluster. Values are "NONE" and "PERFORMANCE". | `string` | `""` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
+| in\_transit\_encryption\_config | Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`. | `string` | `null` | no |
 | initial\_node\_count | The number of nodes to create in this cluster's default node pool. | `number` | `0` | no |
 | insecure\_kubelet\_readonly\_port\_enabled | Whether or not to set `insecure_kubelet_readonly_port_enabled` for node pool defaults and autopilot clusters. Note: this can be set at the node pool level separately within `node_pools`. | `bool` | `null` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -207,6 +207,8 @@ resource "google_container_cluster" "primary" {
 
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
+  in_transit_encryption_config = var.in_transit_encryption_config
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/modules/beta-public-cluster-update-variant/metadata.display.yaml
+++ b/modules/beta-public-cluster-update-variant/metadata.display.yaml
@@ -220,6 +220,9 @@ spec:
         identity_namespace:
           name: identity_namespace
           title: Identity Namespace
+        in_transit_encryption_config:
+          name: in_transit_encryption_config
+          title: In Transit Encryption Config
         initial_node_count:
           name: initial_node_count
           title: Initial Node Count

--- a/modules/beta-public-cluster-update-variant/metadata.yaml
+++ b/modules/beta-public-cluster-update-variant/metadata.yaml
@@ -517,6 +517,9 @@ spec:
         description: Enable Cilium Cluster Wide Network Policies on the cluster
         varType: bool
         defaultValue: false
+      - name: in_transit_encryption_config
+        description: Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`.
+        varType: string
       - name: security_posture_mode
         description: Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`.
         varType: string

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -617,6 +617,12 @@ variable "enable_cilium_clusterwide_network_policy" {
   default     = false
 }
 
+variable "in_transit_encryption_config" {
+  type        = string
+  description = "Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`."
+  default     = null
+}
+
 variable "security_posture_mode" {
   description = "Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`."
   type        = string

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -207,6 +207,7 @@ Then perform the following commands on the root folder:
 | hpa\_profile | Enable the Horizontal Pod Autoscaling profile for this cluster. Values are "NONE" and "PERFORMANCE". | `string` | `""` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
+| in\_transit\_encryption\_config | Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`. | `string` | `null` | no |
 | initial\_node\_count | The number of nodes to create in this cluster's default node pool. | `number` | `0` | no |
 | insecure\_kubelet\_readonly\_port\_enabled | Whether or not to set `insecure_kubelet_readonly_port_enabled` for node pool defaults and autopilot clusters. Note: this can be set at the node pool level separately within `node_pools`. | `bool` | `null` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -207,6 +207,8 @@ resource "google_container_cluster" "primary" {
 
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
+  in_transit_encryption_config = var.in_transit_encryption_config
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/modules/beta-public-cluster/metadata.display.yaml
+++ b/modules/beta-public-cluster/metadata.display.yaml
@@ -220,6 +220,9 @@ spec:
         identity_namespace:
           name: identity_namespace
           title: Identity Namespace
+        in_transit_encryption_config:
+          name: in_transit_encryption_config
+          title: In Transit Encryption Config
         initial_node_count:
           name: initial_node_count
           title: Initial Node Count

--- a/modules/beta-public-cluster/metadata.yaml
+++ b/modules/beta-public-cluster/metadata.yaml
@@ -517,6 +517,9 @@ spec:
         description: Enable Cilium Cluster Wide Network Policies on the cluster
         varType: bool
         defaultValue: false
+      - name: in_transit_encryption_config
+        description: Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`.
+        varType: string
       - name: security_posture_mode
         description: Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`.
         varType: string

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -617,6 +617,12 @@ variable "enable_cilium_clusterwide_network_policy" {
   default     = false
 }
 
+variable "in_transit_encryption_config" {
+  type        = string
+  description = "Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`."
+  default     = null
+}
+
 variable "security_posture_mode" {
   description = "Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`."
   type        = string

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -230,6 +230,7 @@ Then perform the following commands on the root folder:
 | hpa\_profile | Enable the Horizontal Pod Autoscaling profile for this cluster. Values are "NONE" and "PERFORMANCE". | `string` | `""` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
+| in\_transit\_encryption\_config | Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`. | `string` | `null` | no |
 | initial\_node\_count | The number of nodes to create in this cluster's default node pool. | `number` | `0` | no |
 | insecure\_kubelet\_readonly\_port\_enabled | Whether or not to set `insecure_kubelet_readonly_port_enabled` for node pool defaults and autopilot clusters. Note: this can be set at the node pool level separately within `node_pools`. | `bool` | `null` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -194,6 +194,8 @@ resource "google_container_cluster" "primary" {
 
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
+  in_transit_encryption_config = var.in_transit_encryption_config
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/modules/private-cluster-update-variant/metadata.display.yaml
+++ b/modules/private-cluster-update-variant/metadata.display.yaml
@@ -214,6 +214,9 @@ spec:
         identity_namespace:
           name: identity_namespace
           title: Identity Namespace
+        in_transit_encryption_config:
+          name: in_transit_encryption_config
+          title: In Transit Encryption Config
         initial_node_count:
           name: initial_node_count
           title: Initial Node Count

--- a/modules/private-cluster-update-variant/metadata.yaml
+++ b/modules/private-cluster-update-variant/metadata.yaml
@@ -528,6 +528,9 @@ spec:
         description: Enable Cilium Cluster Wide Network Policies on the cluster
         varType: bool
         defaultValue: false
+      - name: in_transit_encryption_config
+        description: Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`.
+        varType: string
       - name: security_posture_mode
         description: Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`.
         varType: string

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -635,6 +635,12 @@ variable "enable_cilium_clusterwide_network_policy" {
   default     = false
 }
 
+variable "in_transit_encryption_config" {
+  type        = string
+  description = "Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`."
+  default     = null
+}
+
 variable "security_posture_mode" {
   description = "Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`."
   type        = string

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -208,6 +208,7 @@ Then perform the following commands on the root folder:
 | hpa\_profile | Enable the Horizontal Pod Autoscaling profile for this cluster. Values are "NONE" and "PERFORMANCE". | `string` | `""` | no |
 | http\_load\_balancing | Enable httpload balancer addon | `bool` | `true` | no |
 | identity\_namespace | The workload pool to attach all Kubernetes service accounts to. (Default value of `enabled` automatically sets project-based pool `[project_id].svc.id.goog`) | `string` | `"enabled"` | no |
+| in\_transit\_encryption\_config | Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`. | `string` | `null` | no |
 | initial\_node\_count | The number of nodes to create in this cluster's default node pool. | `number` | `0` | no |
 | insecure\_kubelet\_readonly\_port\_enabled | Whether or not to set `insecure_kubelet_readonly_port_enabled` for node pool defaults and autopilot clusters. Note: this can be set at the node pool level separately within `node_pools`. | `bool` | `null` | no |
 | ip\_masq\_link\_local | Whether to masquerade traffic to the link-local prefix (169.254.0.0/16). | `bool` | `false` | no |

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -194,6 +194,8 @@ resource "google_container_cluster" "primary" {
 
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
 
+  in_transit_encryption_config = var.in_transit_encryption_config
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/modules/private-cluster/metadata.display.yaml
+++ b/modules/private-cluster/metadata.display.yaml
@@ -214,6 +214,9 @@ spec:
         identity_namespace:
           name: identity_namespace
           title: Identity Namespace
+        in_transit_encryption_config:
+          name: in_transit_encryption_config
+          title: In Transit Encryption Config
         initial_node_count:
           name: initial_node_count
           title: Initial Node Count

--- a/modules/private-cluster/metadata.yaml
+++ b/modules/private-cluster/metadata.yaml
@@ -528,6 +528,9 @@ spec:
         description: Enable Cilium Cluster Wide Network Policies on the cluster
         varType: bool
         defaultValue: false
+      - name: in_transit_encryption_config
+        description: Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`.
+        varType: string
       - name: security_posture_mode
         description: Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`.
         varType: string

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -635,6 +635,12 @@ variable "enable_cilium_clusterwide_network_policy" {
   default     = false
 }
 
+variable "in_transit_encryption_config" {
+  type        = string
+  description = "Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`."
+  default     = null
+}
+
 variable "security_posture_mode" {
   description = "Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -599,6 +599,12 @@ variable "enable_cilium_clusterwide_network_policy" {
   default     = false
 }
 
+variable "in_transit_encryption_config" {
+  type        = string
+  description = "Defines the config of in-transit encryption. Valid values are `IN_TRANSIT_ENCRYPTION_DISABLED` and `IN_TRANSIT_ENCRYPTION_INTER_NODE_TRANSPARENT`."
+  default     = null
+}
+
 variable "security_posture_mode" {
   description = "Security posture mode. Accepted values are `DISABLED` and `BASIC`. Defaults to `DISABLED`."
   type        = string


### PR DESCRIPTION
This property is set by default for clusters created in Google console. Unsetting it is not allowed, thus it prevents importing existing clusters.

This property was added in Google provider 6.36.0: https://github.com/hashicorp/terraform-provider-google/blob/main/CHANGELOG.md#6360-may-20-2025