### PR TITLE
feat: Add ability to configure a private container registry to all GKE clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Then perform the following commands on the root folder:
 | enable\_l4\_ilb\_subsetting | Enable L4 ILB Subsetting on the cluster | `bool` | `false` | no |
 | enable\_mesh\_certificates | Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity. | `bool` | `false` | no |
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
+| enable\_private\_registry\_access | (Optional) Enable private registry access for the cluster. | `bool` | `false` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
 | enable\_secret\_manager\_addon | Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | `bool` | `true` | no |
@@ -245,6 +246,8 @@ Then perform the following commands on the root folder:
 | notification\_config\_topic | The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}. | `string` | `""` | no |
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |
 | parallelstore\_csi\_driver | Whether the Parallelstore CSI driver Addon is enabled for this cluster. | `bool` | `null` | no |
+| private\_registry\_access\_certificate\_authority\_fqdns | (Optional) FQDNs of the certificate authority for private registry access. | `list(string)` | `[]` | no |
+| private\_registry\_access\_certificate\_secret\_uri | (Optional) The secret manager URI of the certificate secret for private registry access. | `string` | `""` | no |
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | ray\_operator\_config | The Ray Operator Addon configuration for this cluster. | <pre>object({<br>    enabled            = bool<br>    logging_enabled    = optional(bool, false)<br>    monitoring_enabled = optional(bool, false)<br>  })</pre> | <pre>{<br>  "enabled": false,<br>  "logging_enabled": false,<br>  "monitoring_enabled": false<br>}</pre> | no |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -257,20 +257,7 @@ resource "google_container_cluster" "primary" {
   
   in_transit_encryption_config = var.in_transit_encryption_config
 
-  containerd_config {
-  private_registry_access_config {
-    enabled = var.enable_private_registry_access
-    dynamic "certificate_authority_domain_config" {
-    for_each = var.enable_private_registry_access == true ? [1] : []
-    content {
-          fqdns = var.private_registry_access_certificate_authority_fqdns
-          gcp_secret_manager_certificate_config {
-           secret_uri = var.private_registry_access_certificate_secret_uri
-           }
-       }
-    }
-  }
-  }
+
 
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
@@ -690,6 +677,20 @@ resource "google_container_cluster" "primary" {
       }
 
       local_ssd_encryption_mode = lookup(var.node_pools[0], "local_ssd_encryption_mode", null)
+      containerd_config {
+        private_registry_access_config {
+          enabled = var.enable_private_registry_access
+          dynamic "certificate_authority_domain_config" {
+          for_each = var.enable_private_registry_access == true ? [1] : []
+          content {
+                fqdns = var.private_registry_access_certificate_authority_fqdns
+                gcp_secret_manager_certificate_config {
+                 secret_uri = var.private_registry_access_certificate_secret_uri
+                 }
+             }
+          }
+        }
+        }
     }
   }
   {% endif %}

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -257,6 +257,21 @@ resource "google_container_cluster" "primary" {
   
   in_transit_encryption_config = var.in_transit_encryption_config
 
+  containerd_config {
+  private_registry_access_config {
+    enabled = var.enable_private_registry_access
+    dynamic "certificate_authority_domain_config" {
+    for_each = var.enable_private_registry_access == true ? [1] : []
+    content {
+          fqdns = var.private_registry_access_certificate_authority_fqdns
+          gcp_secret_manager_certificate_config {
+           secret_uri = var.private_registry_access_certificate_secret_uri
+           }
+       }
+    }
+  }
+  }
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -1044,6 +1044,20 @@ resource "google_container_node_pool" "windows_pools" {
         enabled = fast_socket.value
       }
     }
+    containerd_config {
+            private_registry_access_config {
+              enabled = var.enable_private_registry_access
+              dynamic "certificate_authority_domain_config" {
+              for_each = var.enable_private_registry_access == true ? [1] : []
+              content {
+                    fqdns = var.private_registry_access_certificate_authority_fqdns
+                    gcp_secret_manager_certificate_config {
+                     secret_uri = var.private_registry_access_certificate_secret_uri
+                     }
+                 }
+              }
+            }
+            }
     dynamic "reservation_affinity" {
       for_each = lookup(each.value, "queued_provisioning", false) || lookup(each.value, "consume_reservation_type", "") != "" ? [each.value] : []
       content {

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -1123,3 +1123,21 @@ variable "dns_allow_external_traffic" {
   type        = bool
   default     = null
 }
+
+variable "enable_private_registry_access" {
+  description = "(Optional) Enable private registry access for the cluster."
+  type        = bool
+  default     = false
+}
+
+variable "private_registry_access_certificate_authority_fqdns" {
+  description = "(Optional) FQDNs of the certificate authority for private registry access."
+  type        = list(string)
+  default     = []
+}
+
+variable "private_registry_access_certificate_secret_uri" {
+  description = "(Optional) The secret manager URI of the certificate secret for private registry access."
+  type        = string
+  default     = ""
+}

--- a/cluster.tf
+++ b/cluster.tf
@@ -196,20 +196,7 @@ resource "google_container_cluster" "primary" {
 
   in_transit_encryption_config = var.in_transit_encryption_config
 
-  containerd_config {
-    private_registry_access_config {
-      enabled = var.enable_private_registry_access
-      dynamic "certificate_authority_domain_config" {
-        for_each = var.enable_private_registry_access == true ? [1] : []
-        content {
-          fqdns = var.private_registry_access_certificate_authority_fqdns
-          gcp_secret_manager_certificate_config {
-            secret_uri = var.private_registry_access_certificate_secret_uri
-          }
-        }
-      }
-    }
-  }
+
 
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
@@ -540,6 +527,20 @@ resource "google_container_cluster" "primary" {
       }
 
       local_ssd_encryption_mode = lookup(var.node_pools[0], "local_ssd_encryption_mode", null)
+      containerd_config {
+        private_registry_access_config {
+          enabled = var.enable_private_registry_access
+          dynamic "certificate_authority_domain_config" {
+            for_each = var.enable_private_registry_access == true ? [1] : []
+            content {
+              fqdns = var.private_registry_access_certificate_authority_fqdns
+              gcp_secret_manager_certificate_config {
+                secret_uri = var.private_registry_access_certificate_secret_uri
+              }
+            }
+          }
+        }
+      }
     }
   }
 

--- a/cluster.tf
+++ b/cluster.tf
@@ -196,6 +196,21 @@ resource "google_container_cluster" "primary" {
 
   in_transit_encryption_config = var.in_transit_encryption_config
 
+  containerd_config {
+    private_registry_access_config {
+      enabled = var.enable_private_registry_access
+      dynamic "certificate_authority_domain_config" {
+        for_each = var.enable_private_registry_access == true ? [1] : []
+        content {
+          fqdns = var.private_registry_access_certificate_authority_fqdns
+          gcp_secret_manager_certificate_config {
+            secret_uri = var.private_registry_access_certificate_secret_uri
+          }
+        }
+      }
+    }
+  }
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -144,6 +144,9 @@ spec:
         enable_network_egress_export:
           name: enable_network_egress_export
           title: Enable Network Egress Export
+        enable_private_registry_access:
+          name: enable_private_registry_access
+          title: Enable Private Registry Access
         enable_resource_consumption_export:
           name: enable_resource_consumption_export
           title: Enable Resource Consumption Export
@@ -342,6 +345,12 @@ spec:
         parallelstore_csi_driver:
           name: parallelstore_csi_driver
           title: Parallelstore Csi Driver
+        private_registry_access_certificate_authority_fqdns:
+          name: private_registry_access_certificate_authority_fqdns
+          title: Private Registry Access Certificate Authority Fqdns
+        private_registry_access_certificate_secret_uri:
+          name: private_registry_access_certificate_secret_uri
+          title: Private Registry Access Certificate Secret Uri
         project_id:
           name: project_id
           title: Project Id

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -732,6 +732,18 @@ spec:
       - name: dns_allow_external_traffic
         description: (Optional) Controls whether external traffic is allowed over the dns endpoint.
         varType: bool
+      - name: enable_private_registry_access
+        description: (Optional) Enable private registry access for the cluster.
+        varType: bool
+        defaultValue: false
+      - name: private_registry_access_certificate_authority_fqdns
+        description: (Optional) FQDNs of the certificate authority for private registry access.
+        varType: list(string)
+        defaultValue: []
+      - name: private_registry_access_certificate_secret_uri
+        description: (Optional) The secret manager URI of the certificate secret for private registry access.
+        varType: string
+        defaultValue: ""
     outputs:
       - name: ca_certificate
         description: Cluster ca certificate (base64 encoded)

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -100,6 +100,7 @@ Then perform the following commands on the root folder:
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_private\_endpoint | Whether the master's internal IP address is used as the cluster endpoint | `bool` | `false` | no |
 | enable\_private\_nodes | Whether nodes have internal IP addresses only | `bool` | `true` | no |
+| enable\_private\_registry\_access | (Optional) Enable private registry access for the cluster. | `bool` | `false` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
 | enable\_secret\_manager\_addon | Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
 | enable\_tpu | Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
@@ -142,6 +143,8 @@ Then perform the following commands on the root folder:
 | notification\_config\_topic | The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}. | `string` | `""` | no |
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |
 | private\_endpoint\_subnetwork | The subnetwork to use for the hosted master network. | `string` | `null` | no |
+| private\_registry\_access\_certificate\_authority\_fqdns | (Optional) FQDNs of the certificate authority for private registry access. | `list(string)` | `[]` | no |
+| private\_registry\_access\_certificate\_secret\_uri | (Optional) The secret manager URI of the certificate secret for private registry access. | `string` | `""` | no |
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | ray\_operator\_config | The Ray Operator Addon configuration for this cluster. | <pre>object({<br>    enabled            = bool<br>    logging_enabled    = optional(bool, false)<br>    monitoring_enabled = optional(bool, false)<br>  })</pre> | <pre>{<br>  "enabled": false,<br>  "logging_enabled": false,<br>  "monitoring_enabled": false<br>}</pre> | no |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -116,20 +116,7 @@ resource "google_container_cluster" "primary" {
 
   in_transit_encryption_config = var.in_transit_encryption_config
 
-  containerd_config {
-    private_registry_access_config {
-      enabled = var.enable_private_registry_access
-      dynamic "certificate_authority_domain_config" {
-        for_each = var.enable_private_registry_access == true ? [1] : []
-        content {
-          fqdns = var.private_registry_access_certificate_authority_fqdns
-          gcp_secret_manager_certificate_config {
-            secret_uri = var.private_registry_access_certificate_secret_uri
-          }
-        }
-      }
-    }
-  }
+
 
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -116,6 +116,21 @@ resource "google_container_cluster" "primary" {
 
   in_transit_encryption_config = var.in_transit_encryption_config
 
+  containerd_config {
+    private_registry_access_config {
+      enabled = var.enable_private_registry_access
+      dynamic "certificate_authority_domain_config" {
+        for_each = var.enable_private_registry_access == true ? [1] : []
+        content {
+          fqdns = var.private_registry_access_certificate_authority_fqdns
+          gcp_secret_manager_certificate_config {
+            secret_uri = var.private_registry_access_certificate_secret_uri
+          }
+        }
+      }
+    }
+  }
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/modules/beta-autopilot-private-cluster/metadata.display.yaml
+++ b/modules/beta-autopilot-private-cluster/metadata.display.yaml
@@ -112,6 +112,9 @@ spec:
         enable_private_nodes:
           name: enable_private_nodes
           title: Enable Private Nodes
+        enable_private_registry_access:
+          name: enable_private_registry_access
+          title: Enable Private Registry Access
         enable_resource_consumption_export:
           name: enable_resource_consumption_export
           title: Enable Resource Consumption Export
@@ -247,6 +250,12 @@ spec:
         private_endpoint_subnetwork:
           name: private_endpoint_subnetwork
           title: Private Endpoint Subnetwork
+        private_registry_access_certificate_authority_fqdns:
+          name: private_registry_access_certificate_authority_fqdns
+          title: Private Registry Access Certificate Authority Fqdns
+        private_registry_access_certificate_secret_uri:
+          name: private_registry_access_certificate_secret_uri
+          title: Private Registry Access Certificate Secret Uri
         project_id:
           name: project_id
           title: Project Id

--- a/modules/beta-autopilot-private-cluster/metadata.yaml
+++ b/modules/beta-autopilot-private-cluster/metadata.yaml
@@ -481,6 +481,18 @@ spec:
       - name: dns_allow_external_traffic
         description: (Optional) Controls whether external traffic is allowed over the dns endpoint.
         varType: bool
+      - name: enable_private_registry_access
+        description: (Optional) Enable private registry access for the cluster.
+        varType: bool
+        defaultValue: false
+      - name: private_registry_access_certificate_authority_fqdns
+        description: (Optional) FQDNs of the certificate authority for private registry access.
+        varType: list(string)
+        defaultValue: []
+      - name: private_registry_access_certificate_secret_uri
+        description: (Optional) The secret manager URI of the certificate secret for private registry access.
+        varType: string
+        defaultValue: ""
     outputs:
       - name: ca_certificate
         description: Cluster ca certificate (base64 encoded)

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -637,3 +637,21 @@ variable "dns_allow_external_traffic" {
   type        = bool
   default     = null
 }
+
+variable "enable_private_registry_access" {
+  description = "(Optional) Enable private registry access for the cluster."
+  type        = bool
+  default     = false
+}
+
+variable "private_registry_access_certificate_authority_fqdns" {
+  description = "(Optional) FQDNs of the certificate authority for private registry access."
+  type        = list(string)
+  default     = []
+}
+
+variable "private_registry_access_certificate_secret_uri" {
+  description = "(Optional) The secret manager URI of the certificate secret for private registry access."
+  type        = string
+  default     = ""
+}

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -91,6 +91,7 @@ Then perform the following commands on the root folder:
 | enable\_fqdn\_network\_policy | Enable FQDN Network Policies on the cluster | `bool` | `null` | no |
 | enable\_l4\_ilb\_subsetting | Enable L4 ILB Subsetting on the cluster | `bool` | `false` | no |
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
+| enable\_private\_registry\_access | (Optional) Enable private registry access for the cluster. | `bool` | `false` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
 | enable\_secret\_manager\_addon | Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
 | enable\_tpu | Enable Cloud TPU resources in the cluster. WARNING: changing this after cluster creation is destructive! | `bool` | `false` | no |
@@ -130,6 +131,8 @@ Then perform the following commands on the root folder:
 | node\_pools\_cgroup\_mode | Specifies the Linux cgroup mode for autopilot Kubernetes nodes in the cluster. Accepted values are `CGROUP_MODE_UNSPECIFIED`, `CGROUP_MODE_V1`, and `CGROUP_MODE_V2`, which determine the control group hierarchy used for resource management. | `string` | `null` | no |
 | notification\_config\_topic | The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}. | `string` | `""` | no |
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |
+| private\_registry\_access\_certificate\_authority\_fqdns | (Optional) FQDNs of the certificate authority for private registry access. | `list(string)` | `[]` | no |
+| private\_registry\_access\_certificate\_secret\_uri | (Optional) The secret manager URI of the certificate secret for private registry access. | `string` | `""` | no |
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | ray\_operator\_config | The Ray Operator Addon configuration for this cluster. | <pre>object({<br>    enabled            = bool<br>    logging_enabled    = optional(bool, false)<br>    monitoring_enabled = optional(bool, false)<br>  })</pre> | <pre>{<br>  "enabled": false,<br>  "logging_enabled": false,<br>  "monitoring_enabled": false<br>}</pre> | no |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -116,20 +116,7 @@ resource "google_container_cluster" "primary" {
 
   in_transit_encryption_config = var.in_transit_encryption_config
 
-  containerd_config {
-    private_registry_access_config {
-      enabled = var.enable_private_registry_access
-      dynamic "certificate_authority_domain_config" {
-        for_each = var.enable_private_registry_access == true ? [1] : []
-        content {
-          fqdns = var.private_registry_access_certificate_authority_fqdns
-          gcp_secret_manager_certificate_config {
-            secret_uri = var.private_registry_access_certificate_secret_uri
-          }
-        }
-      }
-    }
-  }
+
 
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -116,6 +116,21 @@ resource "google_container_cluster" "primary" {
 
   in_transit_encryption_config = var.in_transit_encryption_config
 
+  containerd_config {
+    private_registry_access_config {
+      enabled = var.enable_private_registry_access
+      dynamic "certificate_authority_domain_config" {
+        for_each = var.enable_private_registry_access == true ? [1] : []
+        content {
+          fqdns = var.private_registry_access_certificate_authority_fqdns
+          gcp_secret_manager_certificate_config {
+            secret_uri = var.private_registry_access_certificate_secret_uri
+          }
+        }
+      }
+    }
+  }
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/modules/beta-autopilot-public-cluster/metadata.display.yaml
+++ b/modules/beta-autopilot-public-cluster/metadata.display.yaml
@@ -103,6 +103,9 @@ spec:
         enable_network_egress_export:
           name: enable_network_egress_export
           title: Enable Network Egress Export
+        enable_private_registry_access:
+          name: enable_private_registry_access
+          title: Enable Private Registry Access
         enable_resource_consumption_export:
           name: enable_resource_consumption_export
           title: Enable Resource Consumption Export
@@ -229,6 +232,12 @@ spec:
         notification_filter_event_type:
           name: notification_filter_event_type
           title: Notification Filter Event Type
+        private_registry_access_certificate_authority_fqdns:
+          name: private_registry_access_certificate_authority_fqdns
+          title: Private Registry Access Certificate Authority Fqdns
+        private_registry_access_certificate_secret_uri:
+          name: private_registry_access_certificate_secret_uri
+          title: Private Registry Access Certificate Secret Uri
         project_id:
           name: project_id
           title: Project Id

--- a/modules/beta-autopilot-public-cluster/metadata.yaml
+++ b/modules/beta-autopilot-public-cluster/metadata.yaml
@@ -459,6 +459,18 @@ spec:
       - name: dns_allow_external_traffic
         description: (Optional) Controls whether external traffic is allowed over the dns endpoint.
         varType: bool
+      - name: enable_private_registry_access
+        description: (Optional) Enable private registry access for the cluster.
+        varType: bool
+        defaultValue: false
+      - name: private_registry_access_certificate_authority_fqdns
+        description: (Optional) FQDNs of the certificate authority for private registry access.
+        varType: list(string)
+        defaultValue: []
+      - name: private_registry_access_certificate_secret_uri
+        description: (Optional) The secret manager URI of the certificate secret for private registry access.
+        varType: string
+        defaultValue: ""
     outputs:
       - name: ca_certificate
         description: Cluster ca certificate (base64 encoded)

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -601,3 +601,21 @@ variable "dns_allow_external_traffic" {
   type        = bool
   default     = null
 }
+
+variable "enable_private_registry_access" {
+  description = "(Optional) Enable private registry access for the cluster."
+  type        = bool
+  default     = false
+}
+
+variable "private_registry_access_certificate_authority_fqdns" {
+  description = "(Optional) FQDNs of the certificate authority for private registry access."
+  type        = list(string)
+  default     = []
+}
+
+variable "private_registry_access_certificate_secret_uri" {
+  description = "(Optional) The secret manager URI of the certificate secret for private registry access."
+  type        = string
+  default     = ""
+}

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -217,6 +217,7 @@ Then perform the following commands on the root folder:
 | enable\_pod\_security\_policy | enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. Pod Security Policy was removed from GKE clusters with version >= 1.25.0. | `bool` | `false` | no |
 | enable\_private\_endpoint | Whether the master's internal IP address is used as the cluster endpoint | `bool` | `false` | no |
 | enable\_private\_nodes | Whether nodes have internal IP addresses only | `bool` | `true` | no |
+| enable\_private\_registry\_access | (Optional) Enable private registry access for the cluster. | `bool` | `false` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
 | enable\_secret\_manager\_addon | Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | `bool` | `true` | no |
@@ -290,6 +291,8 @@ Then perform the following commands on the root folder:
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |
 | parallelstore\_csi\_driver | Whether the Parallelstore CSI driver Addon is enabled for this cluster. | `bool` | `null` | no |
 | private\_endpoint\_subnetwork | The subnetwork to use for the hosted master network. | `string` | `null` | no |
+| private\_registry\_access\_certificate\_authority\_fqdns | (Optional) FQDNs of the certificate authority for private registry access. | `list(string)` | `[]` | no |
+| private\_registry\_access\_certificate\_secret\_uri | (Optional) The secret manager URI of the certificate secret for private registry access. | `string` | `""` | no |
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | ray\_operator\_config | The Ray Operator Addon configuration for this cluster. | <pre>object({<br>    enabled            = bool<br>    logging_enabled    = optional(bool, false)<br>    monitoring_enabled = optional(bool, false)<br>  })</pre> | <pre>{<br>  "enabled": false,<br>  "logging_enabled": false,<br>  "monitoring_enabled": false<br>}</pre> | no |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -209,20 +209,7 @@ resource "google_container_cluster" "primary" {
 
   in_transit_encryption_config = var.in_transit_encryption_config
 
-  containerd_config {
-    private_registry_access_config {
-      enabled = var.enable_private_registry_access
-      dynamic "certificate_authority_domain_config" {
-        for_each = var.enable_private_registry_access == true ? [1] : []
-        content {
-          fqdns = var.private_registry_access_certificate_authority_fqdns
-          gcp_secret_manager_certificate_config {
-            secret_uri = var.private_registry_access_certificate_secret_uri
-          }
-        }
-      }
-    }
-  }
+
 
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
@@ -585,6 +572,20 @@ resource "google_container_cluster" "primary" {
       }
 
       local_ssd_encryption_mode = lookup(var.node_pools[0], "local_ssd_encryption_mode", null)
+      containerd_config {
+        private_registry_access_config {
+          enabled = var.enable_private_registry_access
+          dynamic "certificate_authority_domain_config" {
+            for_each = var.enable_private_registry_access == true ? [1] : []
+            content {
+              fqdns = var.private_registry_access_certificate_authority_fqdns
+              gcp_secret_manager_certificate_config {
+                secret_uri = var.private_registry_access_certificate_secret_uri
+              }
+            }
+          }
+        }
+      }
     }
   }
 

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -209,6 +209,21 @@ resource "google_container_cluster" "primary" {
 
   in_transit_encryption_config = var.in_transit_encryption_config
 
+  containerd_config {
+    private_registry_access_config {
+      enabled = var.enable_private_registry_access
+      dynamic "certificate_authority_domain_config" {
+        for_each = var.enable_private_registry_access == true ? [1] : []
+        content {
+          fqdns = var.private_registry_access_certificate_authority_fqdns
+          gcp_secret_manager_certificate_config {
+            secret_uri = var.private_registry_access_certificate_secret_uri
+          }
+        }
+      }
+    }
+  }
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/modules/beta-private-cluster-update-variant/metadata.display.yaml
+++ b/modules/beta-private-cluster-update-variant/metadata.display.yaml
@@ -166,6 +166,9 @@ spec:
         enable_private_nodes:
           name: enable_private_nodes
           title: Enable Private Nodes
+        enable_private_registry_access:
+          name: enable_private_registry_access
+          title: Enable Private Registry Access
         enable_resource_consumption_export:
           name: enable_resource_consumption_export
           title: Enable Resource Consumption Export
@@ -385,6 +388,12 @@ spec:
         private_endpoint_subnetwork:
           name: private_endpoint_subnetwork
           title: Private Endpoint Subnetwork
+        private_registry_access_certificate_authority_fqdns:
+          name: private_registry_access_certificate_authority_fqdns
+          title: Private Registry Access Certificate Authority Fqdns
+        private_registry_access_certificate_secret_uri:
+          name: private_registry_access_certificate_secret_uri
+          title: Private Registry Access Certificate Secret Uri
         project_id:
           name: project_id
           title: Project Id

--- a/modules/beta-private-cluster-update-variant/metadata.yaml
+++ b/modules/beta-private-cluster-update-variant/metadata.yaml
@@ -763,6 +763,18 @@ spec:
       - name: dns_allow_external_traffic
         description: (Optional) Controls whether external traffic is allowed over the dns endpoint.
         varType: bool
+      - name: enable_private_registry_access
+        description: (Optional) Enable private registry access for the cluster.
+        varType: bool
+        defaultValue: false
+      - name: private_registry_access_certificate_authority_fqdns
+        description: (Optional) FQDNs of the certificate authority for private registry access.
+        varType: list(string)
+        defaultValue: []
+      - name: private_registry_access_certificate_secret_uri
+        description: (Optional) The secret manager URI of the certificate secret for private registry access.
+        varType: string
+        defaultValue: ""
     outputs:
       - name: ca_certificate
         description: Cluster ca certificate (base64 encoded)

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -1049,3 +1049,21 @@ variable "dns_allow_external_traffic" {
   type        = bool
   default     = null
 }
+
+variable "enable_private_registry_access" {
+  description = "(Optional) Enable private registry access for the cluster."
+  type        = bool
+  default     = false
+}
+
+variable "private_registry_access_certificate_authority_fqdns" {
+  description = "(Optional) FQDNs of the certificate authority for private registry access."
+  type        = list(string)
+  default     = []
+}
+
+variable "private_registry_access_certificate_secret_uri" {
+  description = "(Optional) The secret manager URI of the certificate secret for private registry access."
+  type        = string
+  default     = ""
+}

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -195,6 +195,7 @@ Then perform the following commands on the root folder:
 | enable\_pod\_security\_policy | enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. Pod Security Policy was removed from GKE clusters with version >= 1.25.0. | `bool` | `false` | no |
 | enable\_private\_endpoint | Whether the master's internal IP address is used as the cluster endpoint | `bool` | `false` | no |
 | enable\_private\_nodes | Whether nodes have internal IP addresses only | `bool` | `true` | no |
+| enable\_private\_registry\_access | (Optional) Enable private registry access for the cluster. | `bool` | `false` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
 | enable\_secret\_manager\_addon | Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | `bool` | `true` | no |
@@ -268,6 +269,8 @@ Then perform the following commands on the root folder:
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |
 | parallelstore\_csi\_driver | Whether the Parallelstore CSI driver Addon is enabled for this cluster. | `bool` | `null` | no |
 | private\_endpoint\_subnetwork | The subnetwork to use for the hosted master network. | `string` | `null` | no |
+| private\_registry\_access\_certificate\_authority\_fqdns | (Optional) FQDNs of the certificate authority for private registry access. | `list(string)` | `[]` | no |
+| private\_registry\_access\_certificate\_secret\_uri | (Optional) The secret manager URI of the certificate secret for private registry access. | `string` | `""` | no |
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | ray\_operator\_config | The Ray Operator Addon configuration for this cluster. | <pre>object({<br>    enabled            = bool<br>    logging_enabled    = optional(bool, false)<br>    monitoring_enabled = optional(bool, false)<br>  })</pre> | <pre>{<br>  "enabled": false,<br>  "logging_enabled": false,<br>  "monitoring_enabled": false<br>}</pre> | no |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -209,20 +209,7 @@ resource "google_container_cluster" "primary" {
 
   in_transit_encryption_config = var.in_transit_encryption_config
 
-  containerd_config {
-    private_registry_access_config {
-      enabled = var.enable_private_registry_access
-      dynamic "certificate_authority_domain_config" {
-        for_each = var.enable_private_registry_access == true ? [1] : []
-        content {
-          fqdns = var.private_registry_access_certificate_authority_fqdns
-          gcp_secret_manager_certificate_config {
-            secret_uri = var.private_registry_access_certificate_secret_uri
-          }
-        }
-      }
-    }
-  }
+
 
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
@@ -585,6 +572,20 @@ resource "google_container_cluster" "primary" {
       }
 
       local_ssd_encryption_mode = lookup(var.node_pools[0], "local_ssd_encryption_mode", null)
+      containerd_config {
+        private_registry_access_config {
+          enabled = var.enable_private_registry_access
+          dynamic "certificate_authority_domain_config" {
+            for_each = var.enable_private_registry_access == true ? [1] : []
+            content {
+              fqdns = var.private_registry_access_certificate_authority_fqdns
+              gcp_secret_manager_certificate_config {
+                secret_uri = var.private_registry_access_certificate_secret_uri
+              }
+            }
+          }
+        }
+      }
     }
   }
 

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -209,6 +209,21 @@ resource "google_container_cluster" "primary" {
 
   in_transit_encryption_config = var.in_transit_encryption_config
 
+  containerd_config {
+    private_registry_access_config {
+      enabled = var.enable_private_registry_access
+      dynamic "certificate_authority_domain_config" {
+        for_each = var.enable_private_registry_access == true ? [1] : []
+        content {
+          fqdns = var.private_registry_access_certificate_authority_fqdns
+          gcp_secret_manager_certificate_config {
+            secret_uri = var.private_registry_access_certificate_secret_uri
+          }
+        }
+      }
+    }
+  }
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/modules/beta-private-cluster/metadata.display.yaml
+++ b/modules/beta-private-cluster/metadata.display.yaml
@@ -166,6 +166,9 @@ spec:
         enable_private_nodes:
           name: enable_private_nodes
           title: Enable Private Nodes
+        enable_private_registry_access:
+          name: enable_private_registry_access
+          title: Enable Private Registry Access
         enable_resource_consumption_export:
           name: enable_resource_consumption_export
           title: Enable Resource Consumption Export
@@ -385,6 +388,12 @@ spec:
         private_endpoint_subnetwork:
           name: private_endpoint_subnetwork
           title: Private Endpoint Subnetwork
+        private_registry_access_certificate_authority_fqdns:
+          name: private_registry_access_certificate_authority_fqdns
+          title: Private Registry Access Certificate Authority Fqdns
+        private_registry_access_certificate_secret_uri:
+          name: private_registry_access_certificate_secret_uri
+          title: Private Registry Access Certificate Secret Uri
         project_id:
           name: project_id
           title: Project Id

--- a/modules/beta-private-cluster/metadata.yaml
+++ b/modules/beta-private-cluster/metadata.yaml
@@ -763,6 +763,18 @@ spec:
       - name: dns_allow_external_traffic
         description: (Optional) Controls whether external traffic is allowed over the dns endpoint.
         varType: bool
+      - name: enable_private_registry_access
+        description: (Optional) Enable private registry access for the cluster.
+        varType: bool
+        defaultValue: false
+      - name: private_registry_access_certificate_authority_fqdns
+        description: (Optional) FQDNs of the certificate authority for private registry access.
+        varType: list(string)
+        defaultValue: []
+      - name: private_registry_access_certificate_secret_uri
+        description: (Optional) The secret manager URI of the certificate secret for private registry access.
+        varType: string
+        defaultValue: ""
     outputs:
       - name: ca_certificate
         description: Cluster ca certificate (base64 encoded)

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -1049,3 +1049,21 @@ variable "dns_allow_external_traffic" {
   type        = bool
   default     = null
 }
+
+variable "enable_private_registry_access" {
+  description = "(Optional) Enable private registry access for the cluster."
+  type        = bool
+  default     = false
+}
+
+variable "private_registry_access_certificate_authority_fqdns" {
+  description = "(Optional) FQDNs of the certificate authority for private registry access."
+  type        = list(string)
+  default     = []
+}
+
+variable "private_registry_access_certificate_secret_uri" {
+  description = "(Optional) The secret manager URI of the certificate secret for private registry access."
+  type        = string
+  default     = ""
+}

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -208,6 +208,7 @@ Then perform the following commands on the root folder:
 | enable\_mesh\_certificates | Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity. | `bool` | `false` | no |
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_pod\_security\_policy | enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. Pod Security Policy was removed from GKE clusters with version >= 1.25.0. | `bool` | `false` | no |
+| enable\_private\_registry\_access | (Optional) Enable private registry access for the cluster. | `bool` | `false` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
 | enable\_secret\_manager\_addon | Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | `bool` | `true` | no |
@@ -278,6 +279,8 @@ Then perform the following commands on the root folder:
 | notification\_config\_topic | The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}. | `string` | `""` | no |
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |
 | parallelstore\_csi\_driver | Whether the Parallelstore CSI driver Addon is enabled for this cluster. | `bool` | `null` | no |
+| private\_registry\_access\_certificate\_authority\_fqdns | (Optional) FQDNs of the certificate authority for private registry access. | `list(string)` | `[]` | no |
+| private\_registry\_access\_certificate\_secret\_uri | (Optional) The secret manager URI of the certificate secret for private registry access. | `string` | `""` | no |
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | ray\_operator\_config | The Ray Operator Addon configuration for this cluster. | <pre>object({<br>    enabled            = bool<br>    logging_enabled    = optional(bool, false)<br>    monitoring_enabled = optional(bool, false)<br>  })</pre> | <pre>{<br>  "enabled": false,<br>  "logging_enabled": false,<br>  "monitoring_enabled": false<br>}</pre> | no |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -209,20 +209,7 @@ resource "google_container_cluster" "primary" {
 
   in_transit_encryption_config = var.in_transit_encryption_config
 
-  containerd_config {
-    private_registry_access_config {
-      enabled = var.enable_private_registry_access
-      dynamic "certificate_authority_domain_config" {
-        for_each = var.enable_private_registry_access == true ? [1] : []
-        content {
-          fqdns = var.private_registry_access_certificate_authority_fqdns
-          gcp_secret_manager_certificate_config {
-            secret_uri = var.private_registry_access_certificate_secret_uri
-          }
-        }
-      }
-    }
-  }
+
 
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
@@ -585,6 +572,20 @@ resource "google_container_cluster" "primary" {
       }
 
       local_ssd_encryption_mode = lookup(var.node_pools[0], "local_ssd_encryption_mode", null)
+      containerd_config {
+        private_registry_access_config {
+          enabled = var.enable_private_registry_access
+          dynamic "certificate_authority_domain_config" {
+            for_each = var.enable_private_registry_access == true ? [1] : []
+            content {
+              fqdns = var.private_registry_access_certificate_authority_fqdns
+              gcp_secret_manager_certificate_config {
+                secret_uri = var.private_registry_access_certificate_secret_uri
+              }
+            }
+          }
+        }
+      }
     }
   }
 

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -209,6 +209,21 @@ resource "google_container_cluster" "primary" {
 
   in_transit_encryption_config = var.in_transit_encryption_config
 
+  containerd_config {
+    private_registry_access_config {
+      enabled = var.enable_private_registry_access
+      dynamic "certificate_authority_domain_config" {
+        for_each = var.enable_private_registry_access == true ? [1] : []
+        content {
+          fqdns = var.private_registry_access_certificate_authority_fqdns
+          gcp_secret_manager_certificate_config {
+            secret_uri = var.private_registry_access_certificate_secret_uri
+          }
+        }
+      }
+    }
+  }
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/modules/beta-public-cluster-update-variant/metadata.display.yaml
+++ b/modules/beta-public-cluster-update-variant/metadata.display.yaml
@@ -157,6 +157,9 @@ spec:
         enable_pod_security_policy:
           name: enable_pod_security_policy
           title: Enable Pod Security Policy
+        enable_private_registry_access:
+          name: enable_private_registry_access
+          title: Enable Private Registry Access
         enable_resource_consumption_export:
           name: enable_resource_consumption_export
           title: Enable Resource Consumption Export
@@ -367,6 +370,12 @@ spec:
         parallelstore_csi_driver:
           name: parallelstore_csi_driver
           title: Parallelstore Csi Driver
+        private_registry_access_certificate_authority_fqdns:
+          name: private_registry_access_certificate_authority_fqdns
+          title: Private Registry Access Certificate Authority Fqdns
+        private_registry_access_certificate_secret_uri:
+          name: private_registry_access_certificate_secret_uri
+          title: Private Registry Access Certificate Secret Uri
         project_id:
           name: project_id
           title: Project Id

--- a/modules/beta-public-cluster-update-variant/metadata.yaml
+++ b/modules/beta-public-cluster-update-variant/metadata.yaml
@@ -741,6 +741,18 @@ spec:
       - name: dns_allow_external_traffic
         description: (Optional) Controls whether external traffic is allowed over the dns endpoint.
         varType: bool
+      - name: enable_private_registry_access
+        description: (Optional) Enable private registry access for the cluster.
+        varType: bool
+        defaultValue: false
+      - name: private_registry_access_certificate_authority_fqdns
+        description: (Optional) FQDNs of the certificate authority for private registry access.
+        varType: list(string)
+        defaultValue: []
+      - name: private_registry_access_certificate_secret_uri
+        description: (Optional) The secret manager URI of the certificate secret for private registry access.
+        varType: string
+        defaultValue: ""
     outputs:
       - name: ca_certificate
         description: Cluster ca certificate (base64 encoded)

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -1013,3 +1013,21 @@ variable "dns_allow_external_traffic" {
   type        = bool
   default     = null
 }
+
+variable "enable_private_registry_access" {
+  description = "(Optional) Enable private registry access for the cluster."
+  type        = bool
+  default     = false
+}
+
+variable "private_registry_access_certificate_authority_fqdns" {
+  description = "(Optional) FQDNs of the certificate authority for private registry access."
+  type        = list(string)
+  default     = []
+}
+
+variable "private_registry_access_certificate_secret_uri" {
+  description = "(Optional) The secret manager URI of the certificate secret for private registry access."
+  type        = string
+  default     = ""
+}

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -186,6 +186,7 @@ Then perform the following commands on the root folder:
 | enable\_mesh\_certificates | Controls the issuance of workload mTLS certificates. When enabled the GKE Workload Identity Certificates controller and node agent will be deployed in the cluster. Requires Workload Identity. | `bool` | `false` | no |
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_pod\_security\_policy | enabled - Enable the PodSecurityPolicy controller for this cluster. If enabled, pods must be valid under a PodSecurityPolicy to be created. Pod Security Policy was removed from GKE clusters with version >= 1.25.0. | `bool` | `false` | no |
+| enable\_private\_registry\_access | (Optional) Enable private registry access for the cluster. | `bool` | `false` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
 | enable\_secret\_manager\_addon | Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | `bool` | `true` | no |
@@ -256,6 +257,8 @@ Then perform the following commands on the root folder:
 | notification\_config\_topic | The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}. | `string` | `""` | no |
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |
 | parallelstore\_csi\_driver | Whether the Parallelstore CSI driver Addon is enabled for this cluster. | `bool` | `null` | no |
+| private\_registry\_access\_certificate\_authority\_fqdns | (Optional) FQDNs of the certificate authority for private registry access. | `list(string)` | `[]` | no |
+| private\_registry\_access\_certificate\_secret\_uri | (Optional) The secret manager URI of the certificate secret for private registry access. | `string` | `""` | no |
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | ray\_operator\_config | The Ray Operator Addon configuration for this cluster. | <pre>object({<br>    enabled            = bool<br>    logging_enabled    = optional(bool, false)<br>    monitoring_enabled = optional(bool, false)<br>  })</pre> | <pre>{<br>  "enabled": false,<br>  "logging_enabled": false,<br>  "monitoring_enabled": false<br>}</pre> | no |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -209,20 +209,7 @@ resource "google_container_cluster" "primary" {
 
   in_transit_encryption_config = var.in_transit_encryption_config
 
-  containerd_config {
-    private_registry_access_config {
-      enabled = var.enable_private_registry_access
-      dynamic "certificate_authority_domain_config" {
-        for_each = var.enable_private_registry_access == true ? [1] : []
-        content {
-          fqdns = var.private_registry_access_certificate_authority_fqdns
-          gcp_secret_manager_certificate_config {
-            secret_uri = var.private_registry_access_certificate_secret_uri
-          }
-        }
-      }
-    }
-  }
+
 
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
@@ -585,6 +572,20 @@ resource "google_container_cluster" "primary" {
       }
 
       local_ssd_encryption_mode = lookup(var.node_pools[0], "local_ssd_encryption_mode", null)
+      containerd_config {
+        private_registry_access_config {
+          enabled = var.enable_private_registry_access
+          dynamic "certificate_authority_domain_config" {
+            for_each = var.enable_private_registry_access == true ? [1] : []
+            content {
+              fqdns = var.private_registry_access_certificate_authority_fqdns
+              gcp_secret_manager_certificate_config {
+                secret_uri = var.private_registry_access_certificate_secret_uri
+              }
+            }
+          }
+        }
+      }
     }
   }
 

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -209,6 +209,21 @@ resource "google_container_cluster" "primary" {
 
   in_transit_encryption_config = var.in_transit_encryption_config
 
+  containerd_config {
+    private_registry_access_config {
+      enabled = var.enable_private_registry_access
+      dynamic "certificate_authority_domain_config" {
+        for_each = var.enable_private_registry_access == true ? [1] : []
+        content {
+          fqdns = var.private_registry_access_certificate_authority_fqdns
+          gcp_secret_manager_certificate_config {
+            secret_uri = var.private_registry_access_certificate_secret_uri
+          }
+        }
+      }
+    }
+  }
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/modules/beta-public-cluster/metadata.display.yaml
+++ b/modules/beta-public-cluster/metadata.display.yaml
@@ -157,6 +157,9 @@ spec:
         enable_pod_security_policy:
           name: enable_pod_security_policy
           title: Enable Pod Security Policy
+        enable_private_registry_access:
+          name: enable_private_registry_access
+          title: Enable Private Registry Access
         enable_resource_consumption_export:
           name: enable_resource_consumption_export
           title: Enable Resource Consumption Export
@@ -367,6 +370,12 @@ spec:
         parallelstore_csi_driver:
           name: parallelstore_csi_driver
           title: Parallelstore Csi Driver
+        private_registry_access_certificate_authority_fqdns:
+          name: private_registry_access_certificate_authority_fqdns
+          title: Private Registry Access Certificate Authority Fqdns
+        private_registry_access_certificate_secret_uri:
+          name: private_registry_access_certificate_secret_uri
+          title: Private Registry Access Certificate Secret Uri
         project_id:
           name: project_id
           title: Project Id

--- a/modules/beta-public-cluster/metadata.yaml
+++ b/modules/beta-public-cluster/metadata.yaml
@@ -741,6 +741,18 @@ spec:
       - name: dns_allow_external_traffic
         description: (Optional) Controls whether external traffic is allowed over the dns endpoint.
         varType: bool
+      - name: enable_private_registry_access
+        description: (Optional) Enable private registry access for the cluster.
+        varType: bool
+        defaultValue: false
+      - name: private_registry_access_certificate_authority_fqdns
+        description: (Optional) FQDNs of the certificate authority for private registry access.
+        varType: list(string)
+        defaultValue: []
+      - name: private_registry_access_certificate_secret_uri
+        description: (Optional) The secret manager URI of the certificate secret for private registry access.
+        varType: string
+        defaultValue: ""
     outputs:
       - name: ca_certificate
         description: Cluster ca certificate (base64 encoded)

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -1013,3 +1013,21 @@ variable "dns_allow_external_traffic" {
   type        = bool
   default     = null
 }
+
+variable "enable_private_registry_access" {
+  description = "(Optional) Enable private registry access for the cluster."
+  type        = bool
+  default     = false
+}
+
+variable "private_registry_access_certificate_authority_fqdns" {
+  description = "(Optional) FQDNs of the certificate authority for private registry access."
+  type        = list(string)
+  default     = []
+}
+
+variable "private_registry_access_certificate_secret_uri" {
+  description = "(Optional) The secret manager URI of the certificate secret for private registry access."
+  type        = string
+  default     = ""
+}

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -210,6 +210,7 @@ Then perform the following commands on the root folder:
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_private\_endpoint | Whether the master's internal IP address is used as the cluster endpoint | `bool` | `false` | no |
 | enable\_private\_nodes | Whether nodes have internal IP addresses only | `bool` | `true` | no |
+| enable\_private\_registry\_access | (Optional) Enable private registry access for the cluster. | `bool` | `false` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
 | enable\_secret\_manager\_addon | Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | `bool` | `true` | no |
@@ -279,6 +280,8 @@ Then perform the following commands on the root folder:
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |
 | parallelstore\_csi\_driver | Whether the Parallelstore CSI driver Addon is enabled for this cluster. | `bool` | `null` | no |
 | private\_endpoint\_subnetwork | The subnetwork to use for the hosted master network. | `string` | `null` | no |
+| private\_registry\_access\_certificate\_authority\_fqdns | (Optional) FQDNs of the certificate authority for private registry access. | `list(string)` | `[]` | no |
+| private\_registry\_access\_certificate\_secret\_uri | (Optional) The secret manager URI of the certificate secret for private registry access. | `string` | `""` | no |
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | ray\_operator\_config | The Ray Operator Addon configuration for this cluster. | <pre>object({<br>    enabled            = bool<br>    logging_enabled    = optional(bool, false)<br>    monitoring_enabled = optional(bool, false)<br>  })</pre> | <pre>{<br>  "enabled": false,<br>  "logging_enabled": false,<br>  "monitoring_enabled": false<br>}</pre> | no |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -196,20 +196,7 @@ resource "google_container_cluster" "primary" {
 
   in_transit_encryption_config = var.in_transit_encryption_config
 
-  containerd_config {
-    private_registry_access_config {
-      enabled = var.enable_private_registry_access
-      dynamic "certificate_authority_domain_config" {
-        for_each = var.enable_private_registry_access == true ? [1] : []
-        content {
-          fqdns = var.private_registry_access_certificate_authority_fqdns
-          gcp_secret_manager_certificate_config {
-            secret_uri = var.private_registry_access_certificate_secret_uri
-          }
-        }
-      }
-    }
-  }
+
 
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
@@ -540,6 +527,20 @@ resource "google_container_cluster" "primary" {
       }
 
       local_ssd_encryption_mode = lookup(var.node_pools[0], "local_ssd_encryption_mode", null)
+      containerd_config {
+        private_registry_access_config {
+          enabled = var.enable_private_registry_access
+          dynamic "certificate_authority_domain_config" {
+            for_each = var.enable_private_registry_access == true ? [1] : []
+            content {
+              fqdns = var.private_registry_access_certificate_authority_fqdns
+              gcp_secret_manager_certificate_config {
+                secret_uri = var.private_registry_access_certificate_secret_uri
+              }
+            }
+          }
+        }
+      }
     }
   }
 

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -196,6 +196,21 @@ resource "google_container_cluster" "primary" {
 
   in_transit_encryption_config = var.in_transit_encryption_config
 
+  containerd_config {
+    private_registry_access_config {
+      enabled = var.enable_private_registry_access
+      dynamic "certificate_authority_domain_config" {
+        for_each = var.enable_private_registry_access == true ? [1] : []
+        content {
+          fqdns = var.private_registry_access_certificate_authority_fqdns
+          gcp_secret_manager_certificate_config {
+            secret_uri = var.private_registry_access_certificate_secret_uri
+          }
+        }
+      }
+    }
+  }
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/modules/private-cluster-update-variant/metadata.display.yaml
+++ b/modules/private-cluster-update-variant/metadata.display.yaml
@@ -154,6 +154,9 @@ spec:
         enable_private_nodes:
           name: enable_private_nodes
           title: Enable Private Nodes
+        enable_private_registry_access:
+          name: enable_private_registry_access
+          title: Enable Private Registry Access
         enable_resource_consumption_export:
           name: enable_resource_consumption_export
           title: Enable Resource Consumption Export
@@ -361,6 +364,12 @@ spec:
         private_endpoint_subnetwork:
           name: private_endpoint_subnetwork
           title: Private Endpoint Subnetwork
+        private_registry_access_certificate_authority_fqdns:
+          name: private_registry_access_certificate_authority_fqdns
+          title: Private Registry Access Certificate Authority Fqdns
+        private_registry_access_certificate_secret_uri:
+          name: private_registry_access_certificate_secret_uri
+          title: Private Registry Access Certificate Secret Uri
         project_id:
           name: project_id
           title: Project Id

--- a/modules/private-cluster-update-variant/metadata.yaml
+++ b/modules/private-cluster-update-variant/metadata.yaml
@@ -720,6 +720,18 @@ spec:
       - name: dns_allow_external_traffic
         description: (Optional) Controls whether external traffic is allowed over the dns endpoint.
         varType: bool
+      - name: enable_private_registry_access
+        description: (Optional) Enable private registry access for the cluster.
+        varType: bool
+        defaultValue: false
+      - name: private_registry_access_certificate_authority_fqdns
+        description: (Optional) FQDNs of the certificate authority for private registry access.
+        varType: list(string)
+        defaultValue: []
+      - name: private_registry_access_certificate_secret_uri
+        description: (Optional) The secret manager URI of the certificate secret for private registry access.
+        varType: string
+        defaultValue: ""
     outputs:
       - name: ca_certificate
         description: Cluster ca certificate (base64 encoded)

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -983,3 +983,21 @@ variable "dns_allow_external_traffic" {
   type        = bool
   default     = null
 }
+
+variable "enable_private_registry_access" {
+  description = "(Optional) Enable private registry access for the cluster."
+  type        = bool
+  default     = false
+}
+
+variable "private_registry_access_certificate_authority_fqdns" {
+  description = "(Optional) FQDNs of the certificate authority for private registry access."
+  type        = list(string)
+  default     = []
+}
+
+variable "private_registry_access_certificate_secret_uri" {
+  description = "(Optional) The secret manager URI of the certificate secret for private registry access."
+  type        = string
+  default     = ""
+}

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -188,6 +188,7 @@ Then perform the following commands on the root folder:
 | enable\_network\_egress\_export | Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created in the cluster to meter network egress traffic. | `bool` | `false` | no |
 | enable\_private\_endpoint | Whether the master's internal IP address is used as the cluster endpoint | `bool` | `false` | no |
 | enable\_private\_nodes | Whether nodes have internal IP addresses only | `bool` | `true` | no |
+| enable\_private\_registry\_access | (Optional) Enable private registry access for the cluster. | `bool` | `false` | no |
 | enable\_resource\_consumption\_export | Whether to enable resource consumption metering on this cluster. When enabled, a table will be created in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export. | `bool` | `true` | no |
 | enable\_secret\_manager\_addon | Enable the Secret Manager add-on for this cluster | `bool` | `false` | no |
 | enable\_shielded\_nodes | Enable Shielded Nodes features on all nodes in this cluster | `bool` | `true` | no |
@@ -257,6 +258,8 @@ Then perform the following commands on the root folder:
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |
 | parallelstore\_csi\_driver | Whether the Parallelstore CSI driver Addon is enabled for this cluster. | `bool` | `null` | no |
 | private\_endpoint\_subnetwork | The subnetwork to use for the hosted master network. | `string` | `null` | no |
+| private\_registry\_access\_certificate\_authority\_fqdns | (Optional) FQDNs of the certificate authority for private registry access. | `list(string)` | `[]` | no |
+| private\_registry\_access\_certificate\_secret\_uri | (Optional) The secret manager URI of the certificate secret for private registry access. | `string` | `""` | no |
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |
 | ray\_operator\_config | The Ray Operator Addon configuration for this cluster. | <pre>object({<br>    enabled            = bool<br>    logging_enabled    = optional(bool, false)<br>    monitoring_enabled = optional(bool, false)<br>  })</pre> | <pre>{<br>  "enabled": false,<br>  "logging_enabled": false,<br>  "monitoring_enabled": false<br>}</pre> | no |
 | region | The region to host the cluster in (optional if zonal cluster / required if regional) | `string` | `null` | no |

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -196,20 +196,7 @@ resource "google_container_cluster" "primary" {
 
   in_transit_encryption_config = var.in_transit_encryption_config
 
-  containerd_config {
-    private_registry_access_config {
-      enabled = var.enable_private_registry_access
-      dynamic "certificate_authority_domain_config" {
-        for_each = var.enable_private_registry_access == true ? [1] : []
-        content {
-          fqdns = var.private_registry_access_certificate_authority_fqdns
-          gcp_secret_manager_certificate_config {
-            secret_uri = var.private_registry_access_certificate_secret_uri
-          }
-        }
-      }
-    }
-  }
+
 
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
@@ -540,6 +527,20 @@ resource "google_container_cluster" "primary" {
       }
 
       local_ssd_encryption_mode = lookup(var.node_pools[0], "local_ssd_encryption_mode", null)
+      containerd_config {
+        private_registry_access_config {
+          enabled = var.enable_private_registry_access
+          dynamic "certificate_authority_domain_config" {
+            for_each = var.enable_private_registry_access == true ? [1] : []
+            content {
+              fqdns = var.private_registry_access_certificate_authority_fqdns
+              gcp_secret_manager_certificate_config {
+                secret_uri = var.private_registry_access_certificate_secret_uri
+              }
+            }
+          }
+        }
+      }
     }
   }
 

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -196,6 +196,21 @@ resource "google_container_cluster" "primary" {
 
   in_transit_encryption_config = var.in_transit_encryption_config
 
+  containerd_config {
+    private_registry_access_config {
+      enabled = var.enable_private_registry_access
+      dynamic "certificate_authority_domain_config" {
+        for_each = var.enable_private_registry_access == true ? [1] : []
+        content {
+          fqdns = var.private_registry_access_certificate_authority_fqdns
+          gcp_secret_manager_certificate_config {
+            secret_uri = var.private_registry_access_certificate_secret_uri
+          }
+        }
+      }
+    }
+  }
+
   dynamic "secret_manager_config" {
     for_each = var.enable_secret_manager_addon ? [var.enable_secret_manager_addon] : []
     content {

--- a/modules/private-cluster/metadata.display.yaml
+++ b/modules/private-cluster/metadata.display.yaml
@@ -154,6 +154,9 @@ spec:
         enable_private_nodes:
           name: enable_private_nodes
           title: Enable Private Nodes
+        enable_private_registry_access:
+          name: enable_private_registry_access
+          title: Enable Private Registry Access
         enable_resource_consumption_export:
           name: enable_resource_consumption_export
           title: Enable Resource Consumption Export
@@ -361,6 +364,12 @@ spec:
         private_endpoint_subnetwork:
           name: private_endpoint_subnetwork
           title: Private Endpoint Subnetwork
+        private_registry_access_certificate_authority_fqdns:
+          name: private_registry_access_certificate_authority_fqdns
+          title: Private Registry Access Certificate Authority Fqdns
+        private_registry_access_certificate_secret_uri:
+          name: private_registry_access_certificate_secret_uri
+          title: Private Registry Access Certificate Secret Uri
         project_id:
           name: project_id
           title: Project Id

--- a/modules/private-cluster/metadata.yaml
+++ b/modules/private-cluster/metadata.yaml
@@ -720,6 +720,18 @@ spec:
       - name: dns_allow_external_traffic
         description: (Optional) Controls whether external traffic is allowed over the dns endpoint.
         varType: bool
+      - name: enable_private_registry_access
+        description: (Optional) Enable private registry access for the cluster.
+        varType: bool
+        defaultValue: false
+      - name: private_registry_access_certificate_authority_fqdns
+        description: (Optional) FQDNs of the certificate authority for private registry access.
+        varType: list(string)
+        defaultValue: []
+      - name: private_registry_access_certificate_secret_uri
+        description: (Optional) The secret manager URI of the certificate secret for private registry access.
+        varType: string
+        defaultValue: ""
     outputs:
       - name: ca_certificate
         description: Cluster ca certificate (base64 encoded)

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -983,3 +983,21 @@ variable "dns_allow_external_traffic" {
   type        = bool
   default     = null
 }
+
+variable "enable_private_registry_access" {
+  description = "(Optional) Enable private registry access for the cluster."
+  type        = bool
+  default     = false
+}
+
+variable "private_registry_access_certificate_authority_fqdns" {
+  description = "(Optional) FQDNs of the certificate authority for private registry access."
+  type        = list(string)
+  default     = []
+}
+
+variable "private_registry_access_certificate_secret_uri" {
+  description = "(Optional) The secret manager URI of the certificate secret for private registry access."
+  type        = string
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -947,3 +947,21 @@ variable "dns_allow_external_traffic" {
   type        = bool
   default     = null
 }
+
+variable "enable_private_registry_access" {
+  description = "(Optional) Enable private registry access for the cluster."
+  type        = bool
+  default     = false
+}
+
+variable "private_registry_access_certificate_authority_fqdns" {
+  description = "(Optional) FQDNs of the certificate authority for private registry access."
+  type        = list(string)
+  default     = []
+}
+
+variable "private_registry_access_certificate_secret_uri" {
+  description = "(Optional) The secret manager URI of the certificate secret for private registry access."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Feature:
Enable use of private container registries for GKE clsuters:

Guide: https://cloud.google.com/kubernetes-engine/docs/how-to/access-private-registries-private-certificates#how-it-works