### PR TITLE
feat: Fleet app operator permissions custom roles

### DIFF
--- a/examples/simple_fleet_app_operator_permissions/main.tf
+++ b/examples/simple_fleet_app_operator_permissions/main.tf
@@ -18,7 +18,8 @@ locals {
   app_operator_id   = "app-operator-id"
   app_operator_team = "app-operator-team"
   app_operator_role = "VIEW"
-  app_operator_custom_role = "my-custom-role"
+  custom_app_operator_id = "custom-app-operator-id"
+  custom_app_operator_role = "my-custom-role"
 }
 
 # Create a Service Account, which can be used as an app operator.
@@ -40,7 +41,7 @@ resource "google_gke_hub_feature" "rbacrolebindingactuation" {
   location = "global"
   spec {
     rbacrolebindingactuation {
-      allowed_custom_roles = [local.app_operator_custom_role]
+      allowed_custom_roles = [local.custom_app_operator_role]
     }
   }
 }
@@ -67,8 +68,8 @@ module "custom_permissions" {
 
   fleet_project_id = var.fleet_project_id
   scope_id         = google_gke_hub_scope.scope.scope_id
-  users            = ["${local.app_operator_id}@${var.fleet_project_id}.iam.gserviceaccount.com"]
-  custom_role      = local.app_operator_custom_role
+  users            = ["${local.custom_app_operator_id}@${var.fleet_project_id}.iam.gserviceaccount.com"]
+  custom_role      = local.custom_app_operator_role
 
   depends_on = [
     google_service_account.service_account,

--- a/examples/simple_fleet_app_operator_permissions/main.tf
+++ b/examples/simple_fleet_app_operator_permissions/main.tf
@@ -61,7 +61,7 @@ module "permissions" {
 }
 
 # Grant custom role permissions to the app operator to work with the Fleet Scope.
-module "permissions" {
+module "custom_permissions" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/fleet-app-operator-permissions"
   version = "~> 37.0"
 

--- a/examples/simple_fleet_app_operator_permissions/main.tf
+++ b/examples/simple_fleet_app_operator_permissions/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/fleet-app-operator-permissions/main.tf
+++ b/modules/fleet-app-operator-permissions/main.tf
@@ -56,14 +56,22 @@ resource "google_project_iam_member" "log_view_permissions" {
 resource "google_project_iam_member" "project_level_scope_permissions" {
   project  = var.fleet_project_id
   for_each = toset(concat(local.user_principals, local.group_principals))
-  role     = local.project_level_scope_role[var.role]
+  {% if var.custom_role != "" %}
+    role  = local.resource_level_scope_role["CUSTOM"]
+  {% else %}
+    role  = local.resource_level_scope_role[var.role]
+  {% endif %}
   member   = each.value
 }
 
 resource "google_gke_hub_scope_iam_binding" "resource_level_scope_permissions" {
   project  = var.fleet_project_id
   scope_id = var.scope_id
-  role     = local.resource_level_scope_role[var.role]
+  {% if var.custom_role != "" %}
+    role  = local.resource_level_scope_role["CUSTOM"]
+  {% else %}
+    role  = local.resource_level_scope_role[var.role]
+  {% endif %}
   members  = concat(local.user_principals, local.group_principals)
 }
 

--- a/modules/fleet-app-operator-permissions/main.tf
+++ b/modules/fleet-app-operator-permissions/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,12 +30,14 @@ locals {
     "VIEW"  = "roles/gkehub.scopeViewerProjectLevel"
     "EDIT"  = "roles/gkehub.scopeEditorProjectLevel"
     "ADMIN" = "roles/gkehub.scopeEditorProjectLevel" # Same as EDIT
+    "CUSTOM" = "roles/gkehub.scopeEditorProjectLevel" # Same as EDIT
   }
 
   resource_level_scope_role = {
     "VIEW"  = "roles/gkehub.scopeViewer"
     "EDIT"  = "roles/gkehub.scopeEditor"
     "ADMIN" = "roles/gkehub.scopeAdmin"
+    "CUSTOM" = "roles/gkehub.scopeViewer" # Same as VIEW
   }
 }
 

--- a/modules/fleet-app-operator-permissions/main.tf
+++ b/modules/fleet-app-operator-permissions/main.tf
@@ -79,7 +79,11 @@ resource "google_gke_hub_scope_rbac_role_binding" "scope_rbac_user_role_bindings
   scope_id                   = var.scope_id
   user                       = each.key
   role {
+  {% if var.custom_role != "" %}
+    custom_role = var.custom_role
+  {% else %}
     predefined_role = var.role
+  {% endif %}
   }
 }
 
@@ -95,7 +99,11 @@ resource "google_gke_hub_scope_rbac_role_binding" "scope_rbac_group_role_binding
   scope_id                   = var.scope_id
   group                      = each.key
   role {
+  {% if var.custom_role != "" %}
+    custom_role = var.custom_role
+  {% else %}
     predefined_role = var.role
+  {% endif %}
   }
 }
 

--- a/modules/fleet-app-operator-permissions/variables.tf
+++ b/modules/fleet-app-operator-permissions/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ variable "groups" {
 }
 
 variable "role" {
-  description = "The principal's role for the Fleet Scope (`VIEW`/`EDIT`/`ADMIN`)."
+  description = "The principal's predefined role for the Fleet Scope (`VIEW`/`EDIT`/`ADMIN`). Either a predefined role or a custom role should be set"
   type        = string
   validation {
     condition     = contains(["VIEW", "EDIT", "ADMIN"], var.role)
@@ -47,7 +47,7 @@ variable "role" {
 }
 
 variable "custom_role" {
-  description = "The principal's role for the Fleet Scope which is a custom Kubernetes ClusterRole."
+  description = "The principal's role for the Fleet Scope which is a custom Kubernetes ClusterRole. Either a predefined role or a custom role should be set"
   type        = string
   default     = ""
 }

--- a/modules/fleet-app-operator-permissions/variables.tf
+++ b/modules/fleet-app-operator-permissions/variables.tf
@@ -43,10 +43,12 @@ variable "role" {
     condition     = contains(["VIEW", "EDIT", "ADMIN"], var.role)
     error_message = "Allowed values for role are VIEW, EDIT, or ADMIN."
   }
+  default     = ""
 }
 
 variable "custom_role" {
   description = "The principal's role for the Fleet Scope which is a custom Kubernetes ClusterRole."
   type        = string
+  default     = ""
 }
 

--- a/modules/fleet-app-operator-permissions/variables.tf
+++ b/modules/fleet-app-operator-permissions/variables.tf
@@ -37,11 +37,16 @@ variable "groups" {
 }
 
 variable "role" {
-  description = "The principals role for the Fleet Scope (`VIEW`/`EDIT`/`ADMIN`)."
+  description = "The principal's role for the Fleet Scope (`VIEW`/`EDIT`/`ADMIN`)."
   type        = string
   validation {
     condition     = contains(["VIEW", "EDIT", "ADMIN"], var.role)
     error_message = "Allowed values for role are VIEW, EDIT, or ADMIN."
   }
+}
+
+variable "custom_role" {
+  description = "The principal's role for the Fleet Scope which is a custom Kubernetes ClusterRole."
+  type        = string
 }
 

--- a/test/integration/simple_fleet_app_operator_permissions/simple_fleet_app_operator_permissions_test.go
+++ b/test/integration/simple_fleet_app_operator_permissions/simple_fleet_app_operator_permissions_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,6 +39,41 @@ func TestSimpleFleetAppOperatorPermissions(t *testing.T) {
 		appOperatorPrincipal := fmt.Sprintf("serviceAccount:%s", appOperatorEmail)
 		scopeLevelRole := "roles/gkehub.scopeViewer"
 		projectLevelRole := "roles/gkehub.scopeViewerProjectLevel"
+		logViewRole := "roles/logging.viewAccessor"
+		logViewContainerBucket := fmt.Sprintf("projects/%s/locations/global/buckets/fleet-o11y-scope-%s/views/fleet-o11y-scope-%s-k8s_container", projectId, scopeId, scopeId)
+		logViewPodBucket := fmt.Sprintf("projects/%s/locations/global/buckets/fleet-o11y-scope-%s/views/fleet-o11y-scope-%s-k8s_pod", projectId, scopeId, scopeId)
+
+		scopeRrbList := gcloud.Runf(t, "container fleet scopes rbacrolebindings list --scope %s --project %s", scopeId, projectId).String()
+		assert.Equal(strings.Contains(scopeRrbList, appOperatorEmail), true, "app operator email should be in the list of Scope RBAC Role Bindings")
+
+		scopeIam := gcloud.Runf(t, "container fleet scopes get-iam-policy %s --project %s", scopeId, projectId).String()
+		assert.Equal(strings.Contains(scopeIam, appOperatorPrincipal), true, "app operator principal should be in the Scope IAM policy")
+		assert.Equal(strings.Contains(scopeIam, scopeLevelRole), true, "app operator Scope role should be in the Scope IAM policy")
+
+		projectIam := gcloud.Runf(t, "projects get-iam-policy %s", projectId).String()
+		assert.Equal(strings.Contains(projectIam, appOperatorPrincipal), true, "app operator principal should be in the project IAM policy")
+		assert.Equal(strings.Contains(projectIam, projectLevelRole), true, "app operator Scope role should be in the project IAM policy")
+		assert.Equal(strings.Contains(projectIam, logViewRole), true, "app operator log view role should be in the project IAM policy")
+		assert.Equal(strings.Contains(projectIam, logViewContainerBucket), true, "app operator log view container bucket should be in the project IAM policy")
+		assert.Equal(strings.Contains(projectIam, logViewPodBucket), true, "app operator log view pod bucket should be in the project IAM policy")
+	})
+
+	appOppT.Test()
+}
+
+func TestCustomFleetAppOperatorPermissions(t *testing.T) {
+	appOppT := tft.NewTFBlueprintTest(t,
+		tft.WithRetryableTerraformErrors(testutils.RetryableTransientErrors, 3, 2*time.Minute),
+	)
+	appOppT.DefineVerify(func(assert *assert.Assertions) {
+		appOppT.DefaultVerify(assert)
+
+		projectId := appOppT.GetStringOutput("project_id")
+		scopeId := "app-operator-team"
+		appOperatorEmail := fmt.Sprintf("custom-app-operator-id@%s.iam.gserviceaccount.com", projectId)
+		appOperatorPrincipal := fmt.Sprintf("serviceAccount:%s", appOperatorEmail)
+		scopeLevelRole := "roles/gkehub.scopeViewer"
+		projectLevelRole := "roles/gkehub.scopeEditorProjectLevel"
 		logViewRole := "roles/logging.viewAccessor"
 		logViewContainerBucket := fmt.Sprintf("projects/%s/locations/global/buckets/fleet-o11y-scope-%s/views/fleet-o11y-scope-%s-k8s_container", projectId, scopeId, scopeId)
 		logViewPodBucket := fmt.Sprintf("projects/%s/locations/global/buckets/fleet-o11y-scope-%s/views/fleet-o11y-scope-%s-k8s_pod", projectId, scopeId, scopeId)


### PR DESCRIPTION
This PR introduces custom roles to the Terraform module that bundles different permissions (IAM and RBAC Role Bindings) required for [Fleet team management](https://cloud.google.com/kubernetes-engine/fleet-management/docs/team-management).