### PR TITLE
fix: remove default-pool beta gate for boot_disk_kms_key

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -254,7 +254,7 @@ resource "google_container_cluster" "primary" {
   disable_l4_lb_firewall_reconciliation = var.disable_l4_lb_firewall_reconciliation
 
   enable_cilium_clusterwide_network_policy = var.enable_cilium_clusterwide_network_policy
-  
+
   in_transit_encryption_config = var.in_transit_encryption_config
 
   dynamic "secret_manager_config" {
@@ -664,8 +664,8 @@ resource "google_container_cluster" "primary" {
         }
       }
 
-      boot_disk_kms_key = lookup(var.node_pools[0], "boot_disk_kms_key", var.boot_disk_kms_key)
       {% endif %}
+      boot_disk_kms_key = lookup(var.node_pools[0], "boot_disk_kms_key", var.boot_disk_kms_key)
 
       storage_pools = lookup(var.node_pools[0], "storage_pools", null) != null ? [var.node_pools[0].storage_pools] : []
 
@@ -1253,7 +1253,7 @@ resource "google_container_node_pool" "windows_pools" {
           content {
             hugepage_size_2m = try(coalesce(local.node_pools_hugepage_size_2m[each.value["name"]], local.node_pools_hugepage_size_2m["all"]), null)
             hugepage_size_1g = try(coalesce(local.node_pools_hugepage_size_1g[each.value["name"]], local.node_pools_hugepage_size_1g["all"]), null)
-          }  
+          }
         }
       }
     }

--- a/cluster.tf
+++ b/cluster.tf
@@ -516,6 +516,7 @@ resource "google_container_cluster" "primary" {
 
       metadata = local.node_pools_metadata["all"]
 
+      boot_disk_kms_key = lookup(var.node_pools[0], "boot_disk_kms_key", var.boot_disk_kms_key)
 
       storage_pools = lookup(var.node_pools[0], "storage_pools", null) != null ? [var.node_pools[0].storage_pools] : []
 

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -516,6 +516,7 @@ resource "google_container_cluster" "primary" {
 
       metadata = local.node_pools_metadata["all"]
 
+      boot_disk_kms_key = lookup(var.node_pools[0], "boot_disk_kms_key", var.boot_disk_kms_key)
 
       storage_pools = lookup(var.node_pools[0], "storage_pools", null) != null ? [var.node_pools[0].storage_pools] : []
 

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -516,6 +516,7 @@ resource "google_container_cluster" "primary" {
 
       metadata = local.node_pools_metadata["all"]
 
+      boot_disk_kms_key = lookup(var.node_pools[0], "boot_disk_kms_key", var.boot_disk_kms_key)
 
       storage_pools = lookup(var.node_pools[0], "storage_pools", null) != null ? [var.node_pools[0].storage_pools] : []
 


### PR DESCRIPTION
The `boot_disk_kms_key` field was (accidentally?) **beta cluster** gated in the `default-pool`.

Fixes: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/2344