### PR TITLE
feat(safer-cluster): add support for gcs fuse csi driver

### DIFF
--- a/autogen/safer-cluster/main.tf.tmpl
+++ b/autogen/safer-cluster/main.tf.tmpl
@@ -208,6 +208,7 @@ module "gke" {
 
   gce_pd_csi_driver    = var.gce_pd_csi_driver
   filestore_csi_driver = var.filestore_csi_driver
+  gcs_fuse_csi_driver  = var.gcs_fuse_csi_driver
 
   notification_config_topic = var.notification_config_topic
 

--- a/autogen/safer-cluster/variables.tf.tmpl
+++ b/autogen/safer-cluster/variables.tf.tmpl
@@ -464,6 +464,12 @@ variable "filestore_csi_driver" {
   default     = false
 }
 
+variable "gcs_fuse_csi_driver" {
+  type        = bool
+  description = "Whether GCE FUSE CSI driver is enabled for this cluster."
+  default     = false
+}
+
 variable "add_cluster_firewall_rules" {
   type        = bool
   description = "Create additional firewall rules"

--- a/modules/safer-cluster-update-variant/README.md
+++ b/modules/safer-cluster-update-variant/README.md
@@ -234,6 +234,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | gateway\_api\_channel | The gateway api channel of this cluster. Accepted values are `CHANNEL_STANDARD` and `CHANNEL_DISABLED`. | `string` | `null` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | `bool` | `true` | no |
+| gcs\_fuse\_csi\_driver | Whether GCE FUSE CSI driver is enabled for this cluster. | `bool` | `false` | no |
 | gke\_backup\_agent\_config | (Beta) Whether Backup for GKE agent is enabled for this cluster. | `bool` | `false` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | `bool` | `true` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |

--- a/modules/safer-cluster-update-variant/main.tf
+++ b/modules/safer-cluster-update-variant/main.tf
@@ -204,6 +204,7 @@ module "gke" {
 
   gce_pd_csi_driver    = var.gce_pd_csi_driver
   filestore_csi_driver = var.filestore_csi_driver
+  gcs_fuse_csi_driver  = var.gcs_fuse_csi_driver
 
   notification_config_topic = var.notification_config_topic
 

--- a/modules/safer-cluster-update-variant/metadata.display.yaml
+++ b/modules/safer-cluster-update-variant/metadata.display.yaml
@@ -127,6 +127,9 @@ spec:
         gce_pd_csi_driver:
           name: gce_pd_csi_driver
           title: Gce Pd Csi Driver
+        gcs_fuse_csi_driver:
+          name: gcs_fuse_csi_driver
+          title: Gcs Fuse Csi Driver
         gke_backup_agent_config:
           name: gke_backup_agent_config
           title: Gke Backup Agent Config

--- a/modules/safer-cluster-update-variant/metadata.yaml
+++ b/modules/safer-cluster-update-variant/metadata.yaml
@@ -422,6 +422,10 @@ spec:
         description: The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes
         varType: bool
         defaultValue: false
+      - name: gcs_fuse_csi_driver
+        description: Whether GCE FUSE CSI driver is enabled for this cluster.
+        varType: bool
+        defaultValue: false
       - name: add_cluster_firewall_rules
         description: Create additional firewall rules
         varType: bool

--- a/modules/safer-cluster-update-variant/variables.tf
+++ b/modules/safer-cluster-update-variant/variables.tf
@@ -464,6 +464,12 @@ variable "filestore_csi_driver" {
   default     = false
 }
 
+variable "gcs_fuse_csi_driver" {
+  type        = bool
+  description = "Whether GCE FUSE CSI driver is enabled for this cluster."
+  default     = false
+}
+
 variable "add_cluster_firewall_rules" {
   type        = bool
   description = "Create additional firewall rules"

--- a/modules/safer-cluster/README.md
+++ b/modules/safer-cluster/README.md
@@ -234,6 +234,7 @@ For simplicity, we suggest using `roles/container.admin` and
 | firewall\_priority | Priority rule for firewall rules | `number` | `1000` | no |
 | gateway\_api\_channel | The gateway api channel of this cluster. Accepted values are `CHANNEL_STANDARD` and `CHANNEL_DISABLED`. | `string` | `null` | no |
 | gce\_pd\_csi\_driver | (Beta) Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. | `bool` | `true` | no |
+| gcs\_fuse\_csi\_driver | Whether GCE FUSE CSI driver is enabled for this cluster. | `bool` | `false` | no |
 | gke\_backup\_agent\_config | (Beta) Whether Backup for GKE agent is enabled for this cluster. | `bool` | `false` | no |
 | grant\_registry\_access | Grants created cluster-specific service account storage.objectViewer role. | `bool` | `true` | no |
 | horizontal\_pod\_autoscaling | Enable horizontal pod autoscaling addon | `bool` | `true` | no |

--- a/modules/safer-cluster/main.tf
+++ b/modules/safer-cluster/main.tf
@@ -204,6 +204,7 @@ module "gke" {
 
   gce_pd_csi_driver    = var.gce_pd_csi_driver
   filestore_csi_driver = var.filestore_csi_driver
+  gcs_fuse_csi_driver  = var.gcs_fuse_csi_driver
 
   notification_config_topic = var.notification_config_topic
 

--- a/modules/safer-cluster/metadata.display.yaml
+++ b/modules/safer-cluster/metadata.display.yaml
@@ -127,6 +127,9 @@ spec:
         gce_pd_csi_driver:
           name: gce_pd_csi_driver
           title: Gce Pd Csi Driver
+        gcs_fuse_csi_driver:
+          name: gcs_fuse_csi_driver
+          title: Gcs Fuse Csi Driver
         gke_backup_agent_config:
           name: gke_backup_agent_config
           title: Gke Backup Agent Config

--- a/modules/safer-cluster/metadata.yaml
+++ b/modules/safer-cluster/metadata.yaml
@@ -422,6 +422,10 @@ spec:
         description: The status of the Filestore CSI driver addon, which allows the usage of filestore instance as volumes
         varType: bool
         defaultValue: false
+      - name: gcs_fuse_csi_driver
+        description: Whether GCE FUSE CSI driver is enabled for this cluster.
+        varType: bool
+        defaultValue: false
       - name: add_cluster_firewall_rules
         description: Create additional firewall rules
         varType: bool

--- a/modules/safer-cluster/variables.tf
+++ b/modules/safer-cluster/variables.tf
@@ -464,6 +464,12 @@ variable "filestore_csi_driver" {
   default     = false
 }
 
+variable "gcs_fuse_csi_driver" {
+  type        = bool
+  description = "Whether GCE FUSE CSI driver is enabled for this cluster."
+  default     = false
+}
+
 variable "add_cluster_firewall_rules" {
   type        = bool
   description = "Create additional firewall rules"


### PR DESCRIPTION
This feature is currently only available for other clusters, adjusted the template so safer-cluster variants can use it as well.