### PR TITLE
fix: include zero value local_ssd_ephemeral_storage_count for GKE nodepool disktype=hyperdisk-balanced…

### DIFF
--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -1315,7 +1315,7 @@ resource "google_container_node_pool" "windows_pools" {
     disk_type       = lookup(each.value, "disk_type", "pd-standard")
 
     dynamic "ephemeral_storage_local_ssd_config" {
-      for_each = lookup(each.value, "local_ssd_ephemeral_storage_count", 0) >= 0 || lookup(each.value, "ephemeral_storage_local_ssd_data_cache_count", 0) > 0 ? [1] : []
+      for_each = lookup(each.value, "local_ssd_ephemeral_storage_count", 0) > 0 || lookup(each.value, "ephemeral_storage_local_ssd_data_cache_count", 0) > 0 || lookup(each.value, "disk_type", "pd-ssd") == "hyperdisk-balanced" ? [1] : []
       content {
         local_ssd_count  = lookup(each.value, "local_ssd_ephemeral_storage_count", 0)
         data_cache_count = lookup(each.value, "ephemeral_storage_local_ssd_data_cache_count", 0)


### PR DESCRIPTION

### Preview

I recently tried to create a new nodepool with machine_type=c4-highcpu-4 using a disk_type=**hyperdisk-balanced**
My GCP managed cluster controlplane version=**1.32.8-gke.1134000**
I am using terraform to add the new GKE nodepool.

Since my nodepool uses disk_type=**hyperdisk-balanced** (**and not disk_type=pd-ssd**),
the GKE API always assumes that the node pool might want ephemeral storage (since this is typically chosen for high-performance workloads), so it always exposes ephemeralStorageLocalSsdConfig: {} even if local_ssd_count = 0.

### Problem
Following the preview above, the API wants to add ephemeralStorageLocalSsdConfig: {} when creating a new nodepool with disk_type=**hyperdisk-balanced** but then the GKE code checks whether local_ssd_count exists.
Since local_ssd_count doesn't exist in my nodepool configuration then terraform wants to omit ephemeralStorageLocalSsdConfig: {}

### Relevant Code in cluster.tf
https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/main/modules/beta-private-cluster/cluster.tf
`dynamic "ephemeral_storage_local_ssd_config" {
      for_each = **lookup(each.value, "local_ssd_ephemeral_storage_count", 0) > 0** || lookup(each.value, "ephemeral_storage_local_ssd_data_cache_count", 0) > 0 ? [1] : []
      content {
        local_ssd_count  = lookup(each.value, "local_ssd_ephemeral_storage_count", 0)
        data_cache_count = lookup(each.value, "ephemeral_storage_local_ssd_data_cache_count", 0)
      }
    }`

### FInal Result
Finally the terraform codes shows: **Plan: 1 to add, 0 to change, 1 to destroy.**

`# module.gke.google_container_cluster.primary has changed ~ resource "google_container_cluster" "primary" {
...
...
+ ephemeral_storage_local_ssd_config { + local_ssd_count = 0 }
...
...
Terraform will perform the following actions: # module.gke.google_container_node_pool.pools["event-proc"] must be replaced -/+ resource "google_container_node_pool" "pools" {
...
...
- ephemeral_storage_local_ssd_config { # forces replacement - local_ssd_count = 0 -> null }
- ...
- ...
- Plan: 1 to add, 0 to change, 1 to destroy.`

### Suggested Solution
If add the option in the code not to remove **dynamic "ephemeral_storage_local_ssd_config"**
In case local_ssd_count=0 this will align with the API exposes ephemeralStorageLocalSsdConfig: {} even if local_ssd_count=0 

