### PR TITLE
fix: move deprecated to versioned resources

### DIFF
--- a/autogen/main/masq.tf.tmpl
+++ b/autogen/main/masq.tf.tmpl
@@ -20,7 +20,7 @@
 /******************************************
   Create ip-masq-agent confimap
  *****************************************/
-resource "kubernetes_config_map" "ip_masq_agent" {
+resource "kubernetes_config_map_v1" "ip_masq_agent" {
   count = var.configure_ip_masq ? 1 : 0
 
   metadata {

--- a/autogen/main/moved.tf.tmpl
+++ b/autogen/main/moved.tf.tmpl
@@ -35,7 +35,12 @@ moved {
 
 moved {
   from = kubernetes_config_map.ip-masq-agent
-  to   = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
+}
+
+moved {
+  from = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
 }
 
 moved {

--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -63,7 +63,7 @@ resource "kubernetes_pod" "nginx-example" {
   depends_on = [module.gke]
 }
 
-resource "kubernetes_service" "nginx-example" {
+resource "kubernetes_service_v1" "nginx-example" {
   metadata {
     name = "terraform-example"
   }

--- a/examples/deploy_service/main.tf
+++ b/examples/deploy_service/main.tf
@@ -43,7 +43,7 @@ module "gke" {
   deletion_protection    = false
 }
 
-resource "kubernetes_pod" "nginx-example" {
+resource "kubernetes_pod_v1" "nginx-example" {
   metadata {
     name = "nginx-example"
 
@@ -70,7 +70,7 @@ resource "kubernetes_service_v1" "nginx-example" {
 
   spec {
     selector = {
-      app = kubernetes_pod.nginx-example.metadata[0].labels.app
+      app = kubernetes_pod_v1.nginx-example.metadata[0].labels.app
     }
 
     session_affinity = "ClientIP"

--- a/examples/workload_identity/main.tf
+++ b/examples/workload_identity/main.tf
@@ -60,10 +60,11 @@ module "workload_identity" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
   version = "~> 43.0"
 
-  project_id          = var.project_id
-  name                = "iden-${module.gke.name}"
-  namespace           = "default"
-  use_existing_k8s_sa = false
+  project_id    = var.project_id
+  name          = "iden-${module.gke.name}"
+  network       = var.network
+  subnetwork    = var.subnetwork
+  ip_range_pods = var.ip_range_pods
 }
 
 # example with existing KSA
@@ -80,13 +81,11 @@ module "workload_identity_existing_ksa" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
   version = "~> 43.0"
 
-  project_id          = var.project_id
-  name                = "existing-${module.gke.name}"
-  cluster_name        = module.gke.name
-  location            = module.gke.location
-  namespace           = "default"
-  use_existing_k8s_sa = true
-  k8s_sa_name         = kubernetes_service_account_v1.test.metadata[0].name
+  project_id    = var.project_id
+  name          = "existing-${module.gke.name}"
+  network       = var.network
+  subnetwork    = var.subnetwork
+  ip_range_pods = var.ip_range_pods
 }
 
 # example with existing GSA
@@ -99,9 +98,11 @@ module "workload_identity_existing_gsa" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
   version = "~> 43.0"
 
-  project_id          = var.project_id
-  name                = google_service_account.custom.account_id
-  use_existing_gcp_sa = true
+  project_id    = var.project_id
+  name          = google_service_account.custom.account_id
+  network       = var.network
+  subnetwork    = var.subnetwork
+  ip_range_pods = var.ip_range_pods
   # wait till custom GSA is created to force module data source read during apply
   # https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1059
   depends_on = [google_service_account.custom]

--- a/examples/workload_identity/main.tf
+++ b/examples/workload_identity/main.tf
@@ -67,7 +67,7 @@ module "workload_identity" {
 }
 
 # example with existing KSA
-resource "kubernetes_service_account" "test" {
+resource "kubernetes_service_account_v1" "test" {
   metadata {
     name = "foo-ksa"
   }
@@ -86,7 +86,7 @@ module "workload_identity_existing_ksa" {
   location            = module.gke.location
   namespace           = "default"
   use_existing_k8s_sa = true
-  k8s_sa_name         = kubernetes_service_account.test.metadata[0].name
+  k8s_sa_name         = kubernetes_service_account_v1.test.metadata[0].name
 }
 
 # example with existing GSA

--- a/masq.tf
+++ b/masq.tf
@@ -19,7 +19,7 @@
 /******************************************
   Create ip-masq-agent confimap
  *****************************************/
-resource "kubernetes_config_map" "ip_masq_agent" {
+resource "kubernetes_config_map_v1" "ip_masq_agent" {
   count = var.configure_ip_masq ? 1 : 0
 
   metadata {

--- a/modules/beta-autopilot-private-cluster/moved.tf
+++ b/modules/beta-autopilot-private-cluster/moved.tf
@@ -17,7 +17,12 @@
 
 moved {
   from = kubernetes_config_map.ip-masq-agent
-  to   = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
+}
+
+moved {
+  from = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
 }
 
 moved {

--- a/modules/beta-autopilot-public-cluster/moved.tf
+++ b/modules/beta-autopilot-public-cluster/moved.tf
@@ -17,7 +17,12 @@
 
 moved {
   from = kubernetes_config_map.ip-masq-agent
-  to   = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
+}
+
+moved {
+  from = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
 }
 
 moved {

--- a/modules/beta-private-cluster-update-variant/masq.tf
+++ b/modules/beta-private-cluster-update-variant/masq.tf
@@ -19,7 +19,7 @@
 /******************************************
   Create ip-masq-agent confimap
  *****************************************/
-resource "kubernetes_config_map" "ip_masq_agent" {
+resource "kubernetes_config_map_v1" "ip_masq_agent" {
   count = var.configure_ip_masq ? 1 : 0
 
   metadata {

--- a/modules/beta-private-cluster-update-variant/moved.tf
+++ b/modules/beta-private-cluster-update-variant/moved.tf
@@ -33,7 +33,12 @@ moved {
 
 moved {
   from = kubernetes_config_map.ip-masq-agent
-  to   = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
+}
+
+moved {
+  from = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
 }
 
 moved {

--- a/modules/beta-private-cluster/masq.tf
+++ b/modules/beta-private-cluster/masq.tf
@@ -19,7 +19,7 @@
 /******************************************
   Create ip-masq-agent confimap
  *****************************************/
-resource "kubernetes_config_map" "ip_masq_agent" {
+resource "kubernetes_config_map_v1" "ip_masq_agent" {
   count = var.configure_ip_masq ? 1 : 0
 
   metadata {

--- a/modules/beta-private-cluster/moved.tf
+++ b/modules/beta-private-cluster/moved.tf
@@ -33,7 +33,12 @@ moved {
 
 moved {
   from = kubernetes_config_map.ip-masq-agent
-  to   = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
+}
+
+moved {
+  from = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
 }
 
 moved {

--- a/modules/beta-public-cluster-update-variant/masq.tf
+++ b/modules/beta-public-cluster-update-variant/masq.tf
@@ -19,7 +19,7 @@
 /******************************************
   Create ip-masq-agent confimap
  *****************************************/
-resource "kubernetes_config_map" "ip_masq_agent" {
+resource "kubernetes_config_map_v1" "ip_masq_agent" {
   count = var.configure_ip_masq ? 1 : 0
 
   metadata {

--- a/modules/beta-public-cluster-update-variant/moved.tf
+++ b/modules/beta-public-cluster-update-variant/moved.tf
@@ -33,7 +33,12 @@ moved {
 
 moved {
   from = kubernetes_config_map.ip-masq-agent
-  to   = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
+}
+
+moved {
+  from = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
 }
 
 moved {

--- a/modules/beta-public-cluster/masq.tf
+++ b/modules/beta-public-cluster/masq.tf
@@ -19,7 +19,7 @@
 /******************************************
   Create ip-masq-agent confimap
  *****************************************/
-resource "kubernetes_config_map" "ip_masq_agent" {
+resource "kubernetes_config_map_v1" "ip_masq_agent" {
   count = var.configure_ip_masq ? 1 : 0
 
   metadata {

--- a/modules/beta-public-cluster/moved.tf
+++ b/modules/beta-public-cluster/moved.tf
@@ -33,7 +33,12 @@ moved {
 
 moved {
   from = kubernetes_config_map.ip-masq-agent
-  to   = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
+}
+
+moved {
+  from = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
 }
 
 moved {

--- a/modules/gke-autopilot-cluster/metadata.yaml
+++ b/modules/gke-autopilot-cluster/metadata.yaml
@@ -575,9 +575,9 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/iam.serviceAccountUser
           - roles/compute.admin
           - roles/container.admin
-          - roles/iam.serviceAccountUser
     services:
       - compute.googleapis.com
       - container.googleapis.com

--- a/modules/private-cluster-update-variant/masq.tf
+++ b/modules/private-cluster-update-variant/masq.tf
@@ -19,7 +19,7 @@
 /******************************************
   Create ip-masq-agent confimap
  *****************************************/
-resource "kubernetes_config_map" "ip_masq_agent" {
+resource "kubernetes_config_map_v1" "ip_masq_agent" {
   count = var.configure_ip_masq ? 1 : 0
 
   metadata {

--- a/modules/private-cluster-update-variant/moved.tf
+++ b/modules/private-cluster-update-variant/moved.tf
@@ -33,7 +33,12 @@ moved {
 
 moved {
   from = kubernetes_config_map.ip-masq-agent
-  to   = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
+}
+
+moved {
+  from = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
 }
 
 moved {

--- a/modules/private-cluster/masq.tf
+++ b/modules/private-cluster/masq.tf
@@ -19,7 +19,7 @@
 /******************************************
   Create ip-masq-agent confimap
  *****************************************/
-resource "kubernetes_config_map" "ip_masq_agent" {
+resource "kubernetes_config_map_v1" "ip_masq_agent" {
   count = var.configure_ip_masq ? 1 : 0
 
   metadata {

--- a/modules/private-cluster/moved.tf
+++ b/modules/private-cluster/moved.tf
@@ -33,7 +33,12 @@ moved {
 
 moved {
   from = kubernetes_config_map.ip-masq-agent
-  to   = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
+}
+
+moved {
+  from = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
 }
 
 moved {

--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -73,7 +73,7 @@ module "my-app-workload-identity" {
 An existing Kubernetes service account can optionally be used.
 
 ```hcl
-resource "kubernetes_service_account" "preexisting" {
+resource "kubernetes_service_account_v1" "preexisting" {
   metadata {
     name      = "preexisting-sa"
     namespace = "prod"
@@ -85,8 +85,8 @@ module "my-app-workload-identity" {
   use_existing_k8s_sa = true
   cluster_name        = "my-k8s-cluster-name"
   location            = "my-k8s-cluster-location"
-  name                = kubernetes_service_account.preexisting.metadata[0].name
-  namespace           = kubernetes_service_account.preexisting.metadata[0].namespace
+  name                = kubernetes_service_account_v1.preexisting.metadata[0].name
+  namespace           = kubernetes_service_account_v1.preexisting.metadata[0].namespace
   project_id          = var.project_id
 }
 ```
@@ -134,9 +134,9 @@ This approach is required when managing multiple clusters. Omitting this step ca
 ```shell
 Error: Get "http://localhost/api/v1/namespaces/default/serviceaccounts/your-service-account": dial tcp [::1]:80: connect: connection refused
 │
-│   with module.your_workload_identity.kubernetes_service_account.main[0],
-│   on .terraform/modules/your_workload_identity/modules/workload-identity/main.tf line 50, in resource "kubernetes_service_account" "main":
-│   50: resource "kubernetes_service_account" "main" {
+│   with module.your_workload_identity.kubernetes_service_account_v1.main[0],
+│   on .terraform/modules/your_workload_identity/modules/workload-identity/main.tf line 50, in resource "kubernetes_service_account_v1" "main":
+│   50: resource "kubernetes_service_account_v1" "main" {
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/workload-identity/main.tf
+++ b/modules/workload-identity/main.tf
@@ -23,8 +23,8 @@ locals {
 
   # This will cause Terraform to block returning outputs until the service account is created
   k8s_given_name       = var.k8s_sa_name != null ? var.k8s_sa_name : var.name
-  output_k8s_name      = var.use_existing_k8s_sa ? local.k8s_given_name : kubernetes_service_account.main[0].metadata[0].name
-  output_k8s_namespace = var.use_existing_k8s_sa ? var.namespace : kubernetes_service_account.main[0].metadata[0].namespace
+  output_k8s_name      = var.use_existing_k8s_sa ? local.k8s_given_name : kubernetes_service_account_v1.main[0].metadata[0].name
+  output_k8s_namespace = var.use_existing_k8s_sa ? var.namespace : kubernetes_service_account_v1.main[0].metadata[0].namespace
 
   k8s_sa_project_id       = var.k8s_sa_project_id != null ? var.k8s_sa_project_id : var.project_id
   k8s_sa_gcp_derived_name = "serviceAccount:${local.k8s_sa_project_id}.svc.id.goog[${var.namespace}/${local.output_k8s_name}]"
@@ -49,7 +49,7 @@ resource "google_service_account" "cluster_service_account" {
   create_ignore_already_exists = var.gcp_sa_create_ignore_already_exists
 }
 
-resource "kubernetes_service_account" "main" {
+resource "kubernetes_service_account_v1" "main" {
   count = var.use_existing_k8s_sa ? 0 : 1
 
   automount_service_account_token = var.automount_service_account_token

--- a/modules/workload-identity/moved.tf
+++ b/modules/workload-identity/moved.tf
@@ -1,4 +1,20 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 moved {
   from = kubernetes_service_account.main
-  to = kubernetes_service_account_v1.main
+  to   = kubernetes_service_account_v1.main
 }

--- a/modules/workload-identity/moved.tf
+++ b/modules/workload-identity/moved.tf
@@ -1,0 +1,4 @@
+moved {
+  from = kubernetes_service_account.main
+  to = kubernetes_service_account_v1.main
+}

--- a/moved.tf
+++ b/moved.tf
@@ -33,7 +33,12 @@ moved {
 
 moved {
   from = kubernetes_config_map.ip-masq-agent
-  to   = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
+}
+
+moved {
+  from = kubernetes_config_map.ip_masq_agent
+  to   = kubernetes_config_map_v1.ip_masq_agent
 }
 
 moved {


### PR DESCRIPTION
- Terraform's Kubernetes provider's v3 update has deprecated several unversioned resource names
- This PR updates all affected resources
  - kubernetes_service
  - kubernetes_service_account
  - kubernetes_config_map
  - kubernetes_pod
- If a resource is part of regular code, then there is always a corresponding moved block to move the old resource to the new one
- If a resource is part of directory `examples/`, then its resource type is only renamed, but there is no corresponding moved block as that is only exemplary code
- Additionally, the file `examples/workload_identity/main.tf` has been updated to be valid and syntactically correct