### PR TITLE
fix(TPG>=7.10)!: bump min google provider to 7.10 for network_tier_config support

### DIFF
--- a/autogen/main/versions.tf.tmpl
+++ b/autogen/main/versions.tf.tmpl
@@ -24,33 +24,33 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
 {% elif beta_cluster and autopilot_cluster %}
   required_providers {
     google = {
       source = "hashicorp/google"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
     google-beta = {
       source = "hashicorp/google-beta"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
 {% elif autopilot_cluster  %}
   required_providers {
     google = {
       source = "hashicorp/google"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
 {% else %}
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
 {% endif %}
     kubernetes = {

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -883,7 +883,7 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.0.0, < 8"
+        version: ">= 7.10.0, < 8"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/beta-autopilot-private-cluster/metadata.yaml
+++ b/modules/beta-autopilot-private-cluster/metadata.yaml
@@ -609,9 +609,9 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.0.0, < 8"
+        version: ">= 7.10.0, < 8"
       - source: hashicorp/google-beta
-        version: ">= 7.0.0, < 8"
+        version: ">= 7.10.0, < 8"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/beta-autopilot-private-cluster/versions.tf
+++ b/modules/beta-autopilot-private-cluster/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-autopilot-public-cluster/metadata.yaml
+++ b/modules/beta-autopilot-public-cluster/metadata.yaml
@@ -583,9 +583,9 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.0.0, < 8"
+        version: ">= 7.10.0, < 8"
       - source: hashicorp/google-beta
-        version: ">= 7.0.0, < 8"
+        version: ">= 7.10.0, < 8"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/beta-autopilot-public-cluster/versions.tf
+++ b/modules/beta-autopilot-public-cluster/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-private-cluster-update-variant/metadata.yaml
+++ b/modules/beta-private-cluster-update-variant/metadata.yaml
@@ -904,9 +904,9 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.0.0, < 8"
+        version: ">= 7.10.0, < 8"
       - source: hashicorp/google-beta
-        version: ">= 7.0.0, < 8"
+        version: ">= 7.10.0, < 8"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/beta-private-cluster-update-variant/versions.tf
+++ b/modules/beta-private-cluster-update-variant/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-private-cluster/metadata.yaml
+++ b/modules/beta-private-cluster/metadata.yaml
@@ -904,9 +904,9 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.0.0, < 8"
+        version: ">= 7.10.0, < 8"
       - source: hashicorp/google-beta
-        version: ">= 7.0.0, < 8"
+        version: ">= 7.10.0, < 8"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/beta-private-cluster/versions.tf
+++ b/modules/beta-private-cluster/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-public-cluster-update-variant/metadata.yaml
+++ b/modules/beta-public-cluster-update-variant/metadata.yaml
@@ -878,9 +878,9 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.0.0, < 8"
+        version: ">= 7.10.0, < 8"
       - source: hashicorp/google-beta
-        version: ">= 7.0.0, < 8"
+        version: ">= 7.10.0, < 8"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/beta-public-cluster-update-variant/versions.tf
+++ b/modules/beta-public-cluster-update-variant/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-public-cluster/metadata.yaml
+++ b/modules/beta-public-cluster/metadata.yaml
@@ -878,9 +878,9 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.0.0, < 8"
+        version: ">= 7.10.0, < 8"
       - source: hashicorp/google-beta
-        version: ">= 7.0.0, < 8"
+        version: ">= 7.10.0, < 8"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/beta-public-cluster/versions.tf
+++ b/modules/beta-public-cluster/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/gke-node-pool/metadata.yaml
+++ b/modules/gke-node-pool/metadata.yaml
@@ -415,9 +415,9 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/compute.admin
           - roles/container.admin
           - roles/iam.serviceAccountUser
+          - roles/compute.admin
     services:
       - compute.googleapis.com
       - container.googleapis.com

--- a/modules/private-cluster-update-variant/metadata.yaml
+++ b/modules/private-cluster-update-variant/metadata.yaml
@@ -869,7 +869,7 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.0.0, < 8"
+        version: ">= 7.10.0, < 8"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/private-cluster-update-variant/versions.tf
+++ b/modules/private-cluster-update-variant/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/private-cluster/metadata.yaml
+++ b/modules/private-cluster/metadata.yaml
@@ -869,7 +869,7 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.0.0, < 8"
+        version: ">= 7.10.0, < 8"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/private-cluster/versions.tf
+++ b/modules/private-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/versions.tf
+++ b/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.0.0, < 8"
+      version = ">= 7.10.0, < 8"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
# Description
This PR bumps the minimum required version of the hashicorp/google and hashicorp/google-beta providers to 7.10.0.

Fixes #2523 

# Reason
The network_tier_config block was added to the google_container_cluster resource in the Google provider version 7.10.0 ([reference](https://github.com/hashicorp/terraform-provider-google/blob/main/CHANGELOG.md#7100-november-4-2025)).
The current module code (v43.0.0+) utilizes this block in cluster.tf. However, the provider version constraint was previously set to >= 7.0.0. Users running provider versions between 7.0.0 and 7.9.0 encounter the following error:
```text
Error: Unsupported block type

  on .terraform/modules/gke/modules/private-cluster-update-variant/cluster.tf line 437, in resource "google_container_cluster" "primary":
 437:     dynamic "network_tier_config" {

Blocks of type "network_tier_config" are not expected here.
```

# Changes
Updated `autogen/versions.tf.tmpl` to require `google` and `google-beta >= 7.10.0`.
Ran `make build` to regenerate all module `versions.tf` files.
