### PR TITLE
fix: add variable to exclude ai zones from available zones

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,10 @@ data "google_compute_zones" "available" {
 resource "random_shuffle" "available_zones" {
   count = local.zone_count == 0 ? 1 : 0
 
-  input        = data.google_compute_zones.available[0].names
+  input = var.exclude_ai_zones ? [
+    for zone in data.google_compute_zones.available[0].names : zone
+    if !can(regex("-ai\\d+[a-z]$", zone))
+  ] : data.google_compute_zones.available[0].names
   result_count = 3
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1072,3 +1072,9 @@ variable "network_tier_config" {
     error_message = "Network tier allowed values are only NETWORK_TIER_DEFAULT, NETWORK_TIER_STANDARD or NETWORK_TIER_PREMIUM"
   }
 }
+
+variable "exclude_ai_zones" {
+  description = "(Optional) Controls whether to exclude AI zones from the dynamically fetched google_compute_zones"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
As noted in: https://github.com/hashicorp/terraform-provider-google/issues/25914

It seems the GCP API for returning compute zones began returning ai zones, as a result of the recent introduction of AI zones on 16th Jan in `us-central1`

This PR adds a variable to allow users to exclude AI zones when using the GKE module