### PR TITLE
Adding labels to the google_gke_hub_membership resource

### DIFF
--- a/modules/fleet-membership/membership.tf
+++ b/modules/fleet-membership/membership.tf
@@ -22,6 +22,7 @@ resource "google_gke_hub_membership" "primary" {
   project       = local.hub_project_id
   membership_id = local.gke_hub_membership_name
   location      = var.membership_location
+  labels        = var.resource_labels
 
   endpoint {
     gke_cluster {

--- a/modules/fleet-membership/variables.tf
+++ b/modules/fleet-membership/variables.tf
@@ -53,3 +53,9 @@ variable "membership_location" {
   type        = string
   default     = "global"
 }
+
+variable "resource_labels" {
+  description = "The resource labels (a map of key/value pairs) to be applied to the fleet membership. This field is non-authoritative, and will only manage the labels present in your configuration. Please refer to the field 'effective_labels' for all of the labels present on the resource."
+  type        = map(string)
+  default     = null
+}


### PR DESCRIPTION
This resource supports the use of labels but does not respect the provider default labels. To ensure users of the module can label their resources I have exposed that argument and created a corresponding variable. 