### PR TITLE
feat: Add missing vpc connection for GKE Standard Cluster

### DIFF
--- a/modules/gke-node-pool/metadata.yaml
+++ b/modules/gke-node-pool/metadata.yaml
@@ -350,10 +350,11 @@ spec:
               }))
             })
         connections:
-        - source: https://github.com/terraform-google-modules/terraform-google-network
-          version: ">= 16.0.1"
-          spec:
-            outputExpr: '{"additional_node_network_configs": [{"network": network_name, "subnetwork": subnets_names}]}'
+          - source:
+              source: https://github.com/terraform-google-modules/terraform-google-network
+              version: ">= 16.0.1"
+            spec:
+              outputExpr: '{"additional_node_network_configs": [{"network": network_name, "subnetwork": subnets_names}]}'
       - name: node_count
         description: The number of nodes per instance group. This field can be used to update the number of nodes per instance group but should not be used alongside autoscaling.
         varType: number

--- a/modules/gke-node-pool/metadata.yaml
+++ b/modules/gke-node-pool/metadata.yaml
@@ -349,6 +349,11 @@ spec:
                 total_egress_bandwidth_tier = string
               }))
             })
+        connections:
+        - source: https://github.com/terraform-google-modules/terraform-google-network
+          version: ">= 16.0.1"
+          spec:
+            outputExpr: '{"additional_node_network_configs": [{"network": network_name, "subnetwork": subnets_names}]}'
       - name: node_count
         description: The number of nodes per instance group. This field can be used to update the number of nodes per instance group but should not be used alongside autoscaling.
         varType: number

--- a/modules/gke-node-pool/metadata.yaml
+++ b/modules/gke-node-pool/metadata.yaml
@@ -354,7 +354,7 @@ spec:
               source: https://github.com/terraform-google-modules/terraform-google-network
               version: ">= 16.0.1"
             spec:
-              outputExpr: '{"additional_node_network_configs": [{"network": network_name, "subnetwork": subnets_names[0]}]}'
+              outputExpr: "{\"additional_node_network_configs\": [{\"network\": network_name, \"subnetwork\": subnets_names[0]}]}"
       - name: node_count
         description: The number of nodes per instance group. This field can be used to update the number of nodes per instance group but should not be used alongside autoscaling.
         varType: number

--- a/modules/gke-node-pool/metadata.yaml
+++ b/modules/gke-node-pool/metadata.yaml
@@ -354,7 +354,7 @@ spec:
               source: https://github.com/terraform-google-modules/terraform-google-network
               version: ">= 16.0.1"
             spec:
-              outputExpr: '{"additional_node_network_configs": [{"network": network_name, "subnetwork": subnets_names}]}'
+              outputExpr: "{"additional_node_network_configs": [{"network": network_name, "subnetwork": subnets_names}]}"
       - name: node_count
         description: The number of nodes per instance group. This field can be used to update the number of nodes per instance group but should not be used alongside autoscaling.
         varType: number

--- a/modules/gke-node-pool/metadata.yaml
+++ b/modules/gke-node-pool/metadata.yaml
@@ -349,12 +349,6 @@ spec:
                 total_egress_bandwidth_tier = string
               }))
             })
-        connections:
-          - source:
-              source: https://github.com/terraform-google-modules/terraform-google-network
-              version: ">= 16.0.1"
-            spec:
-              outputExpr: "{\"additional_node_network_configs\": [{\"network\": network_name, \"subnetwork\": subnets_names[0]}]}"
       - name: node_count
         description: The number of nodes per instance group. This field can be used to update the number of nodes per instance group but should not be used alongside autoscaling.
         varType: number

--- a/modules/gke-node-pool/metadata.yaml
+++ b/modules/gke-node-pool/metadata.yaml
@@ -354,7 +354,7 @@ spec:
               source: https://github.com/terraform-google-modules/terraform-google-network
               version: ">= 16.0.1"
             spec:
-              outputExpr: "{"additional_node_network_configs": [{"network": network_name, "subnetwork": subnets_names}]}"
+              outputExpr: '{"additional_node_network_configs": [{"network": network_name, "subnetwork": subnets_names[0]}]}'
       - name: node_count
         description: The number of nodes per instance group. This field can be used to update the number of nodes per instance group but should not be used alongside autoscaling.
         varType: number

--- a/modules/gke-standard-cluster/metadata.yaml
+++ b/modules/gke-standard-cluster/metadata.yaml
@@ -149,10 +149,20 @@ spec:
         description: The name or self_link of the Google Compute Engine network to which the cluster is connected. For Shared VPC, this network must be in the host project.
         varType: string
         required: true
+        connections:
+        - source: https://github.com/terraform-google-modules/terraform-google-network
+          version: ">= 16.0.1"
+          spec:
+            outputExpr: network_name
       - name: subnetwork
         description: The name or self_link of the Google Compute Engine subnetwork in which the cluster's instances are launched.
         varType: string
         required: true
+        connections:
+        - source: https://github.com/terraform-google-modules/terraform-google-network
+          version: ">= 16.0.1"
+          spec:
+            outputExpr: subnets_names
       - name: node_locations
         description: The list of zones in which the cluster's nodes are located. Nodes are created in the region's zones by default. This list must be a subset of the compute/zones in the region to which the cluster belongs. This field is optional for Zonal clusters and required for Regional clusters.
         varType: list(string)

--- a/modules/gke-standard-cluster/metadata.yaml
+++ b/modules/gke-standard-cluster/metadata.yaml
@@ -150,19 +150,21 @@ spec:
         varType: string
         required: true
         connections:
-        - source: https://github.com/terraform-google-modules/terraform-google-network
-          version: ">= 16.0.1"
-          spec:
-            outputExpr: network_name
+          - source:
+              source: https://github.com/terraform-google-modules/terraform-google-network
+              version: ">= 16.0.1"
+            spec:
+              outputExpr: network_name
       - name: subnetwork
         description: The name or self_link of the Google Compute Engine subnetwork in which the cluster's instances are launched.
         varType: string
         required: true
         connections:
-        - source: https://github.com/terraform-google-modules/terraform-google-network
-          version: ">= 16.0.1"
-          spec:
-            outputExpr: subnets_names
+          - source:
+              source: https://github.com/terraform-google-modules/terraform-google-network
+              version: ">= 16.0.1"
+            spec:
+              outputExpr: subnets_names
       - name: node_locations
         description: The list of zones in which the cluster's nodes are located. Nodes are created in the region's zones by default. This list must be a subset of the compute/zones in the region to which the cluster belongs. This field is optional for Zonal clusters and required for Regional clusters.
         varType: list(string)

--- a/modules/gke-standard-cluster/metadata.yaml
+++ b/modules/gke-standard-cluster/metadata.yaml
@@ -164,7 +164,7 @@ spec:
               source: https://github.com/terraform-google-modules/terraform-google-network
               version: ">= 16.0.1"
             spec:
-              outputExpr: subnets_names
+              outputExpr: subnets_names[0]
       - name: node_locations
         description: The list of zones in which the cluster's nodes are located. Nodes are created in the region's zones by default. This list must be a subset of the compute/zones in the region to which the cluster belongs. This field is optional for Zonal clusters and required for Regional clusters.
         varType: list(string)


### PR DESCRIPTION
Adding missing VPC connection for GKE Standard Cluster.

Testing Steps for VPC Connection:

1. Ingest Component Revision (BYOC):
- Set the gcloud configuration to point to the Staging environment.
- Create the template metadata for the GKE Standard Cluster component.

2. Create a template revision to pull our specific code tag (e.g., v44.0.0) into the private catalog.

3. Manual UI Verification (ADC Canvas):
- Navigate to the [Pantheon Staging environment]. Ensure that Coliseum environment is set to STAGING and config is set to PROD in Backend Overrides.
- In the ADC canvas, drag and drop the custom GKE Standard cluster and VPC components.
- Verify the connection: Drag a connection line between the two. The connection should automatically snap to the network and subnetwork variables, and the connections parameters must be populated.

4. Deployment Verification:
- Create a new application with the connected components, inputting all necessary configurations (e.g., region us-central1).
- Click Preview and confirm that the Terraform Plan generates without errors.
- Click Deploy and ensure the application deployment completes successfully.