### PR TITLE
fix: update Cgroup V2 transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Then perform the following commands on the root folder:
 | network\_tier\_config | Network tier configuration for the cluster | `string` | `null` | no |
 | node\_metadata | Specifies how node metadata is exposed to the workload running on the node | `string` | `"GKE_METADATA"` | no |
 | node\_pools | List of maps containing node pools | `list(map(any))` | <pre>[<br>  {<br>    "name": "default-node-pool"<br>  }<br>]</pre> | no |
-| node\_pools\_cgroup\_mode | Map of strings containing cgroup node config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
+| node\_pools\_cgroup\_mode | Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35. | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_hugepage\_size\_1g | Map of strings containing hugepage size 1g config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_hugepage\_size\_2m | Map of strings containing hugepage size 2m node config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_labels | Map of maps containing node labels by node-pool name | `map(map(string))` | <pre>{<br>  "all": {},<br>  "default-node-pool": {}<br>}</pre> | no |

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -117,7 +117,7 @@ variable "insecure_kubelet_readonly_port_enabled" {
 {% if autopilot_cluster %}
 variable "node_pools_cgroup_mode" {
   type = string
-  description = "Specifies the Linux cgroup mode for autopilot Kubernetes nodes in the cluster. Accepted values are `CGROUP_MODE_UNSPECIFIED`, `CGROUP_MODE_V1`, and `CGROUP_MODE_V2`, which determine the control group hierarchy used for resource management."
+  description = "Specifies the Linux cgroup mode for autopilot Kubernetes nodes in the cluster. Accepted values are `CGROUP_MODE_UNSPECIFIED`, `CGROUP_MODE_V1`, and `CGROUP_MODE_V2`, which determine the control group hierarchy used for resource management. Note: GKE is removing cgroup v1 support in 1.35."
   validation {
     condition = var.node_pools_cgroup_mode == null || contains([
       "",
@@ -265,7 +265,7 @@ variable "node_pools_linux_node_configs_sysctls" {
 
 variable "node_pools_cgroup_mode" {
   type        = map(string)
-  description = "Map of strings containing cgroup node config by node-pool name"
+  description = "Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35."
 
   # Default is being set in variables_defaults.tf
   default = {

--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -181,8 +181,7 @@ module "gke" {
   }
 
   node_pools_cgroup_mode = {
-    all     = "CGROUP_MODE_V2"
-    pool-01 = "CGROUP_MODE_V1"
+    all = "CGROUP_MODE_V2"
   }
 
   node_pools_hugepage_size_2m = {

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -314,7 +314,7 @@ spec:
           all: {}
           default-node-pool: {}
       - name: node_pools_cgroup_mode
-        description: Map of strings containing cgroup node config by node-pool name
+        description: "Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35."
         varType: map(string)
         defaultValue:
           all: ""

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -148,7 +148,7 @@ Then perform the following commands on the root folder:
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
 | network\_tags | (Optional) - List of network tags applied to autopilot and auto-provisioned node pools. | `list(string)` | `[]` | no |
 | network\_tier\_config | Network tier configuration for the cluster | `string` | `null` | no |
-| node\_pools\_cgroup\_mode | Specifies the Linux cgroup mode for autopilot Kubernetes nodes in the cluster. Accepted values are `CGROUP_MODE_UNSPECIFIED`, `CGROUP_MODE_V1`, and `CGROUP_MODE_V2`, which determine the control group hierarchy used for resource management. | `string` | `null` | no |
+| node\_pools\_cgroup\_mode | Specifies the Linux cgroup mode for autopilot Kubernetes nodes in the cluster. Accepted values are `CGROUP_MODE_UNSPECIFIED`, `CGROUP_MODE_V1`, and `CGROUP_MODE_V2`, which determine the control group hierarchy used for resource management. Note: GKE is removing cgroup v1 support in 1.35. | `string` | `null` | no |
 | notification\_config\_topic | The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}. | `string` | `""` | no |
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |
 | private\_endpoint\_subnetwork | The subnetwork to use for the hosted master network. | `string` | `null` | no |

--- a/modules/beta-autopilot-private-cluster/metadata.yaml
+++ b/modules/beta-autopilot-private-cluster/metadata.yaml
@@ -196,7 +196,7 @@ spec:
         description: Whether or not to set `insecure_kubelet_readonly_port_enabled` for node pool defaults and autopilot clusters.
         varType: bool
       - name: node_pools_cgroup_mode
-        description: Specifies the Linux cgroup mode for autopilot Kubernetes nodes in the cluster. Accepted values are `CGROUP_MODE_UNSPECIFIED`, `CGROUP_MODE_V1`, and `CGROUP_MODE_V2`, which determine the control group hierarchy used for resource management.
+        description: "Specifies the Linux cgroup mode for autopilot Kubernetes nodes in the cluster. Accepted values are `CGROUP_MODE_UNSPECIFIED`, `CGROUP_MODE_V1`, and `CGROUP_MODE_V2`, which determine the control group hierarchy used for resource management. Note: GKE is removing cgroup v1 support in 1.35."
         varType: string
       - name: maintenance_start_time
         description: Time window specified for daily or recurring maintenance operations in RFC3339 format

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -116,7 +116,7 @@ variable "insecure_kubelet_readonly_port_enabled" {
 
 variable "node_pools_cgroup_mode" {
   type        = string
-  description = "Specifies the Linux cgroup mode for autopilot Kubernetes nodes in the cluster. Accepted values are `CGROUP_MODE_UNSPECIFIED`, `CGROUP_MODE_V1`, and `CGROUP_MODE_V2`, which determine the control group hierarchy used for resource management."
+  description = "Specifies the Linux cgroup mode for autopilot Kubernetes nodes in the cluster. Accepted values are `CGROUP_MODE_UNSPECIFIED`, `CGROUP_MODE_V1`, and `CGROUP_MODE_V2`, which determine the control group hierarchy used for resource management. Note: GKE is removing cgroup v1 support in 1.35."
   validation {
     condition = var.node_pools_cgroup_mode == null || contains([
       "",

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -137,7 +137,7 @@ Then perform the following commands on the root folder:
 | network\_project\_id | The project ID of the shared VPC's host (for shared vpc support) | `string` | `""` | no |
 | network\_tags | (Optional) - List of network tags applied to autopilot and auto-provisioned node pools. | `list(string)` | `[]` | no |
 | network\_tier\_config | Network tier configuration for the cluster | `string` | `null` | no |
-| node\_pools\_cgroup\_mode | Specifies the Linux cgroup mode for autopilot Kubernetes nodes in the cluster. Accepted values are `CGROUP_MODE_UNSPECIFIED`, `CGROUP_MODE_V1`, and `CGROUP_MODE_V2`, which determine the control group hierarchy used for resource management. | `string` | `null` | no |
+| node\_pools\_cgroup\_mode | Specifies the Linux cgroup mode for autopilot Kubernetes nodes in the cluster. Accepted values are `CGROUP_MODE_UNSPECIFIED`, `CGROUP_MODE_V1`, and `CGROUP_MODE_V2`, which determine the control group hierarchy used for resource management. Note: GKE is removing cgroup v1 support in 1.35. | `string` | `null` | no |
 | notification\_config\_topic | The desired Pub/Sub topic to which notifications will be sent by GKE. Format is projects/{project}/topics/{topic}. | `string` | `""` | no |
 | notification\_filter\_event\_type | Choose what type of notifications you want to receive. If no filters are applied, you'll receive all notification types. Can be used to filter what notifications are sent. Accepted values are UPGRADE\_AVAILABLE\_EVENT, UPGRADE\_EVENT, and SECURITY\_BULLETIN\_EVENT. | `list(string)` | `[]` | no |
 | project\_id | The project ID to host the cluster in (required) | `string` | n/a | yes |

--- a/modules/beta-autopilot-public-cluster/metadata.yaml
+++ b/modules/beta-autopilot-public-cluster/metadata.yaml
@@ -196,7 +196,7 @@ spec:
         description: Whether or not to set `insecure_kubelet_readonly_port_enabled` for node pool defaults and autopilot clusters.
         varType: bool
       - name: node_pools_cgroup_mode
-        description: Specifies the Linux cgroup mode for autopilot Kubernetes nodes in the cluster. Accepted values are `CGROUP_MODE_UNSPECIFIED`, `CGROUP_MODE_V1`, and `CGROUP_MODE_V2`, which determine the control group hierarchy used for resource management.
+        description: "Specifies the Linux cgroup mode for autopilot Kubernetes nodes in the cluster. Accepted values are `CGROUP_MODE_UNSPECIFIED`, `CGROUP_MODE_V1`, and `CGROUP_MODE_V2`, which determine the control group hierarchy used for resource management. Note: GKE is removing cgroup v1 support in 1.35."
         varType: string
       - name: maintenance_start_time
         description: Time window specified for daily or recurring maintenance operations in RFC3339 format

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -116,7 +116,7 @@ variable "insecure_kubelet_readonly_port_enabled" {
 
 variable "node_pools_cgroup_mode" {
   type        = string
-  description = "Specifies the Linux cgroup mode for autopilot Kubernetes nodes in the cluster. Accepted values are `CGROUP_MODE_UNSPECIFIED`, `CGROUP_MODE_V1`, and `CGROUP_MODE_V2`, which determine the control group hierarchy used for resource management."
+  description = "Specifies the Linux cgroup mode for autopilot Kubernetes nodes in the cluster. Accepted values are `CGROUP_MODE_UNSPECIFIED`, `CGROUP_MODE_V1`, and `CGROUP_MODE_V2`, which determine the control group hierarchy used for resource management. Note: GKE is removing cgroup v1 support in 1.35."
   validation {
     condition = var.node_pools_cgroup_mode == null || contains([
       "",

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -280,7 +280,7 @@ Then perform the following commands on the root folder:
 | network\_tier\_config | Network tier configuration for the cluster | `string` | `null` | no |
 | node\_metadata | Specifies how node metadata is exposed to the workload running on the node | `string` | `"GKE_METADATA"` | no |
 | node\_pools | List of maps containing node pools | `list(map(any))` | <pre>[<br>  {<br>    "name": "default-node-pool"<br>  }<br>]</pre> | no |
-| node\_pools\_cgroup\_mode | Map of strings containing cgroup node config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
+| node\_pools\_cgroup\_mode | Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35. | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_hugepage\_size\_1g | Map of strings containing hugepage size 1g config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_hugepage\_size\_2m | Map of strings containing hugepage size 2m node config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_labels | Map of maps containing node labels by node-pool name | `map(map(string))` | <pre>{<br>  "all": {},<br>  "default-node-pool": {}<br>}</pre> | no |

--- a/modules/beta-private-cluster-update-variant/metadata.yaml
+++ b/modules/beta-private-cluster-update-variant/metadata.yaml
@@ -274,7 +274,7 @@ spec:
           all: {}
           default-node-pool: {}
       - name: node_pools_cgroup_mode
-        description: Map of strings containing cgroup node config by node-pool name
+        description: "Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35."
         varType: map(string)
         defaultValue:
           all: ""

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -245,7 +245,7 @@ variable "node_pools_linux_node_configs_sysctls" {
 
 variable "node_pools_cgroup_mode" {
   type        = map(string)
-  description = "Map of strings containing cgroup node config by node-pool name"
+  description = "Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35."
 
   # Default is being set in variables_defaults.tf
   default = {

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -258,7 +258,7 @@ Then perform the following commands on the root folder:
 | network\_tier\_config | Network tier configuration for the cluster | `string` | `null` | no |
 | node\_metadata | Specifies how node metadata is exposed to the workload running on the node | `string` | `"GKE_METADATA"` | no |
 | node\_pools | List of maps containing node pools | `list(map(any))` | <pre>[<br>  {<br>    "name": "default-node-pool"<br>  }<br>]</pre> | no |
-| node\_pools\_cgroup\_mode | Map of strings containing cgroup node config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
+| node\_pools\_cgroup\_mode | Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35. | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_hugepage\_size\_1g | Map of strings containing hugepage size 1g config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_hugepage\_size\_2m | Map of strings containing hugepage size 2m node config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_labels | Map of maps containing node labels by node-pool name | `map(map(string))` | <pre>{<br>  "all": {},<br>  "default-node-pool": {}<br>}</pre> | no |

--- a/modules/beta-private-cluster/metadata.yaml
+++ b/modules/beta-private-cluster/metadata.yaml
@@ -274,7 +274,7 @@ spec:
           all: {}
           default-node-pool: {}
       - name: node_pools_cgroup_mode
-        description: Map of strings containing cgroup node config by node-pool name
+        description: "Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35."
         varType: map(string)
         defaultValue:
           all: ""

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -245,7 +245,7 @@ variable "node_pools_linux_node_configs_sysctls" {
 
 variable "node_pools_cgroup_mode" {
   type        = map(string)
-  description = "Map of strings containing cgroup node config by node-pool name"
+  description = "Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35."
 
   # Default is being set in variables_defaults.tf
   default = {

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -269,7 +269,7 @@ Then perform the following commands on the root folder:
 | network\_tier\_config | Network tier configuration for the cluster | `string` | `null` | no |
 | node\_metadata | Specifies how node metadata is exposed to the workload running on the node | `string` | `"GKE_METADATA"` | no |
 | node\_pools | List of maps containing node pools | `list(map(any))` | <pre>[<br>  {<br>    "name": "default-node-pool"<br>  }<br>]</pre> | no |
-| node\_pools\_cgroup\_mode | Map of strings containing cgroup node config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
+| node\_pools\_cgroup\_mode | Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35. | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_hugepage\_size\_1g | Map of strings containing hugepage size 1g config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_hugepage\_size\_2m | Map of strings containing hugepage size 2m node config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_labels | Map of maps containing node labels by node-pool name | `map(map(string))` | <pre>{<br>  "all": {},<br>  "default-node-pool": {}<br>}</pre> | no |

--- a/modules/beta-public-cluster-update-variant/metadata.yaml
+++ b/modules/beta-public-cluster-update-variant/metadata.yaml
@@ -274,7 +274,7 @@ spec:
           all: {}
           default-node-pool: {}
       - name: node_pools_cgroup_mode
-        description: Map of strings containing cgroup node config by node-pool name
+        description: "Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35."
         varType: map(string)
         defaultValue:
           all: ""

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -245,7 +245,7 @@ variable "node_pools_linux_node_configs_sysctls" {
 
 variable "node_pools_cgroup_mode" {
   type        = map(string)
-  description = "Map of strings containing cgroup node config by node-pool name"
+  description = "Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35."
 
   # Default is being set in variables_defaults.tf
   default = {

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -247,7 +247,7 @@ Then perform the following commands on the root folder:
 | network\_tier\_config | Network tier configuration for the cluster | `string` | `null` | no |
 | node\_metadata | Specifies how node metadata is exposed to the workload running on the node | `string` | `"GKE_METADATA"` | no |
 | node\_pools | List of maps containing node pools | `list(map(any))` | <pre>[<br>  {<br>    "name": "default-node-pool"<br>  }<br>]</pre> | no |
-| node\_pools\_cgroup\_mode | Map of strings containing cgroup node config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
+| node\_pools\_cgroup\_mode | Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35. | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_hugepage\_size\_1g | Map of strings containing hugepage size 1g config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_hugepage\_size\_2m | Map of strings containing hugepage size 2m node config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_labels | Map of maps containing node labels by node-pool name | `map(map(string))` | <pre>{<br>  "all": {},<br>  "default-node-pool": {}<br>}</pre> | no |

--- a/modules/beta-public-cluster/metadata.yaml
+++ b/modules/beta-public-cluster/metadata.yaml
@@ -274,7 +274,7 @@ spec:
           all: {}
           default-node-pool: {}
       - name: node_pools_cgroup_mode
-        description: Map of strings containing cgroup node config by node-pool name
+        description: "Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35."
         varType: map(string)
         defaultValue:
           all: ""

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -245,7 +245,7 @@ variable "node_pools_linux_node_configs_sysctls" {
 
 variable "node_pools_cgroup_mode" {
   type        = map(string)
-  description = "Map of strings containing cgroup node config by node-pool name"
+  description = "Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35."
 
   # Default is being set in variables_defaults.tf
   default = {

--- a/modules/gke-autopilot-cluster/metadata.yaml
+++ b/modules/gke-autopilot-cluster/metadata.yaml
@@ -575,9 +575,9 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/iam.serviceAccountUser
           - roles/compute.admin
           - roles/container.admin
+          - roles/iam.serviceAccountUser
     services:
       - compute.googleapis.com
       - container.googleapis.com

--- a/modules/gke-node-pool/metadata.yaml
+++ b/modules/gke-node-pool/metadata.yaml
@@ -415,9 +415,9 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/iam.serviceAccountUser
           - roles/compute.admin
           - roles/container.admin
-          - roles/iam.serviceAccountUser
     services:
       - compute.googleapis.com
       - container.googleapis.com

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -273,7 +273,7 @@ Then perform the following commands on the root folder:
 | network\_tier\_config | Network tier configuration for the cluster | `string` | `null` | no |
 | node\_metadata | Specifies how node metadata is exposed to the workload running on the node | `string` | `"GKE_METADATA"` | no |
 | node\_pools | List of maps containing node pools | `list(map(any))` | <pre>[<br>  {<br>    "name": "default-node-pool"<br>  }<br>]</pre> | no |
-| node\_pools\_cgroup\_mode | Map of strings containing cgroup node config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
+| node\_pools\_cgroup\_mode | Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35. | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_hugepage\_size\_1g | Map of strings containing hugepage size 1g config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_hugepage\_size\_2m | Map of strings containing hugepage size 2m node config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_labels | Map of maps containing node labels by node-pool name | `map(map(string))` | <pre>{<br>  "all": {},<br>  "default-node-pool": {}<br>}</pre> | no |

--- a/modules/private-cluster-update-variant/metadata.yaml
+++ b/modules/private-cluster-update-variant/metadata.yaml
@@ -274,7 +274,7 @@ spec:
           all: {}
           default-node-pool: {}
       - name: node_pools_cgroup_mode
-        description: Map of strings containing cgroup node config by node-pool name
+        description: "Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35."
         varType: map(string)
         defaultValue:
           all: ""

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -245,7 +245,7 @@ variable "node_pools_linux_node_configs_sysctls" {
 
 variable "node_pools_cgroup_mode" {
   type        = map(string)
-  description = "Map of strings containing cgroup node config by node-pool name"
+  description = "Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35."
 
   # Default is being set in variables_defaults.tf
   default = {

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -251,7 +251,7 @@ Then perform the following commands on the root folder:
 | network\_tier\_config | Network tier configuration for the cluster | `string` | `null` | no |
 | node\_metadata | Specifies how node metadata is exposed to the workload running on the node | `string` | `"GKE_METADATA"` | no |
 | node\_pools | List of maps containing node pools | `list(map(any))` | <pre>[<br>  {<br>    "name": "default-node-pool"<br>  }<br>]</pre> | no |
-| node\_pools\_cgroup\_mode | Map of strings containing cgroup node config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
+| node\_pools\_cgroup\_mode | Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35. | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_hugepage\_size\_1g | Map of strings containing hugepage size 1g config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_hugepage\_size\_2m | Map of strings containing hugepage size 2m node config by node-pool name | `map(string)` | <pre>{<br>  "all": "",<br>  "default-node-pool": ""<br>}</pre> | no |
 | node\_pools\_labels | Map of maps containing node labels by node-pool name | `map(map(string))` | <pre>{<br>  "all": {},<br>  "default-node-pool": {}<br>}</pre> | no |

--- a/modules/private-cluster/metadata.yaml
+++ b/modules/private-cluster/metadata.yaml
@@ -274,7 +274,7 @@ spec:
           all: {}
           default-node-pool: {}
       - name: node_pools_cgroup_mode
-        description: Map of strings containing cgroup node config by node-pool name
+        description: "Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35."
         varType: map(string)
         defaultValue:
           all: ""

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -245,7 +245,7 @@ variable "node_pools_linux_node_configs_sysctls" {
 
 variable "node_pools_cgroup_mode" {
   type        = map(string)
-  description = "Map of strings containing cgroup node config by node-pool name"
+  description = "Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35."
 
   # Default is being set in variables_defaults.tf
   default = {

--- a/test/integration/autopilot_private_firewalls/testdata/TestAutopilotPrivateFirewalls.json
+++ b/test/integration/autopilot_private_firewalls/testdata/TestAutopilotPrivateFirewalls.json
@@ -16,7 +16,8 @@
     },
     "networkPolicyConfig": {
       "disabled": true
-    }
+    },
+    "nodeReadinessConfig": {}
   },
   "autopilot": {
     "enabled": true

--- a/test/integration/beta_cluster/beta_cluster_test.go
+++ b/test/integration/beta_cluster/beta_cluster_test.go
@@ -58,7 +58,7 @@ func TestBetaCluster(t *testing.T) {
 			"addonsConfig",
 			"networkConfig.datapathProvider",
 			"binaryAuthorization",
-			"databaseEncryption.state",
+			// "databaseEncryption.state",
 			"loggingConfig",
 			"monitoringConfig",
 		}

--- a/test/integration/beta_cluster/beta_cluster_test.go
+++ b/test/integration/beta_cluster/beta_cluster_test.go
@@ -55,16 +55,20 @@ func TestBetaCluster(t *testing.T) {
 			"networkConfig.datapathProvider",
 			"databaseEncryption.state",
 			// "identityServiceConfig.enabled", TODO: b/378974729
-			"addonsConfig",
 			"networkConfig.datapathProvider",
 			"binaryAuthorization",
 			// "databaseEncryption.state",
 			"loggingConfig",
 			"monitoringConfig",
+			"addonsConfig.dnsCacheConfig.enabled",
+			"addonsConfig.gcePersistentDiskCsiDriverConfig.enabled",
+			"addonsConfig.kubernetesDashboard.disabled",
+			"addonsConfig.networkPolicyConfig.disabled",
 		}
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)
 		}
+
 		for _, np := range op.Get("nodePools").Array() {
 			npName := np.Get("name").String()
 			// sanitze current nodepool data

--- a/test/integration/beta_cluster/testdata/TestBetaCluster.json
+++ b/test/integration/beta_cluster/testdata/TestBetaCluster.json
@@ -35,7 +35,7 @@
   "currentNodeVersion": "1.26.5-gke.1200",
   "databaseEncryption": {
     "keyName": "projects/PROJECT_ID/locations/us-central1/keyRings/beta-cluster-qwc4-db/cryptoKeys/beta-cluster-qwc4",
-    "state": "ENCRYPTED"
+    "state": "ALL_OBJECTS_ENCRYPTION_ENABLED"
   },
   "defaultMaxPodsConstraint": {
     "maxPodsPerNode": "110"

--- a/test/integration/beta_cluster/testdata/TestBetaCluster.json
+++ b/test/integration/beta_cluster/testdata/TestBetaCluster.json
@@ -314,4 +314,3 @@
   "verticalPodAutoscaling": {},
   "zone": "us-central1"
 }
-

--- a/test/integration/confidential_autopilot_private/confidential_autopilot_private_test.go
+++ b/test/integration/confidential_autopilot_private/confidential_autopilot_private_test.go
@@ -42,7 +42,7 @@ func TestConfidentialAutopilotPrivate(t *testing.T) {
 		assert.True(op.Get("autopilot.enabled").Bool(), "should be autopilot")
 		assert.Equal(op.Get("autoscaling.autoprovisioningNodePoolDefaults.bootDiskKmsKey").String(), key, "should have CMEK configured in boot disk")
 		assert.True(op.Get("confidentialNodes.enabled").Bool(), "should have confidential nodes enabled")
-		assert.Equal(op.Get("databaseEncryption.state").String(), "ENCRYPTED", "should have database encryption")
+		assert.Equal(op.Get("databaseEncryption.state").String(), "ALL_OBJECTS_ENCRYPTION_ENABLED", "should have database encryption")
 		assert.Equal(op.Get("databaseEncryption.keyName").String(), key, "should have CMEK configured in database")
 	})
 	bpt.Test()

--- a/test/integration/confidential_safer_cluster/confidential_safer_cluster_test.go
+++ b/test/integration/confidential_safer_cluster/confidential_safer_cluster_test.go
@@ -55,9 +55,6 @@ func TestConfidentialSaferCluster(t *testing.T) {
 			// "databaseEncryption.state",
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
-			"addonsConfig.horizontalPodAutoscaling",
-			"addonsConfig.kubernetesDashboard",
-			"addonsConfig.networkPolicyConfig",
 			"networkPolicy",
 			"networkConfig.datapathProvider",
 			"binaryAuthorization.evaluationMode",
@@ -78,6 +75,9 @@ func TestConfidentialSaferCluster(t *testing.T) {
 			"nodePools.config.tags",
 			"nodePools.management.autoRepair",
 			"nodePools.shieldedInstanceConfig",
+			"addonsConfig.gcePersistentDiskCsiDriverConfig.enabled",
+			"addonsConfig.kubernetesDashboard.disabled",
+			"addonsConfig.networkPolicyConfig.disabled",
 		}
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)

--- a/test/integration/confidential_safer_cluster/confidential_safer_cluster_test.go
+++ b/test/integration/confidential_safer_cluster/confidential_safer_cluster_test.go
@@ -52,7 +52,7 @@ func TestConfidentialSaferCluster(t *testing.T) {
 			"location",
 			"confidentialNodes.enabled",
 			"databaseEncryption.keyName",
-			"databaseEncryption.state",
+			// "databaseEncryption.state",
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
 			"addonsConfig.horizontalPodAutoscaling",

--- a/test/integration/confidential_safer_cluster/testdata/TestConfidentialSaferCluster.json
+++ b/test/integration/confidential_safer_cluster/testdata/TestConfidentialSaferCluster.json
@@ -57,7 +57,7 @@
   "databaseEncryption": {
     "currentState": "CURRENT_STATE_ENCRYPTED",
     "keyName": "KEY_NAME",
-    "state": "ENCRYPTED"
+    "state": "ALL_OBJECTS_ENCRYPTION_ENABLED"
   },
   "defaultMaxPodsConstraint": {
     "maxPodsPerNode": "110"

--- a/test/integration/gke_autopilot_cluster/gke_autopilot_cluster_test.go
+++ b/test/integration/gke_autopilot_cluster/gke_autopilot_cluster_test.go
@@ -46,10 +46,15 @@ func TestGKEAutopilotCluster(t *testing.T) {
 			"location",
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
-			"addonsConfig.kubernetesDashboard.disabled",
-			"addonsConfig.networkPolicyConfig.disabled",
 			"confidentialNodes.enabled",
 			"masterAuthorizedNetworksConfig.enabled",
+			"addonsConfig.dnsCacheConfig.enabled",
+			"addonsConfig.gcePersistentDiskCsiDriverConfig.enabled",
+			"addonsConfig.gcsFuseCsiDriverConfig.enabled",
+			"addonsConfig.kubernetesDashboard.disabled",
+			"addonsConfig.networkPolicyConfig.disabled",
+			"addonsConfig.parallelstoreCsiDriverConfig.enabled",
+			"addonsConfig.statefulHaConfig.enabled",
 		}
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)

--- a/test/integration/gke_standard_cluster/gke_standard_cluster_test.go
+++ b/test/integration/gke_standard_cluster/gke_standard_cluster_test.go
@@ -49,8 +49,6 @@ func TestGKEStandardCluster(t *testing.T) {
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
 			"defaultMaxPodsConstraint.maxPodsPerNode",
-			"addonsConfig.kubernetesDashboard.disabled",
-			"addonsConfig.networkPolicyConfig.disabled",
 			"nodePools.autoscaling.enabled",
 			"nodePools.autoscaling.minNodeCount",
 			"nodePools.autoscaling.maxNodeCount",
@@ -61,6 +59,8 @@ func TestGKEStandardCluster(t *testing.T) {
 			"nodePools.maxPodsConstraint.maxPodsPerNode",
 			"networkConfig.datapathProvider",
 			"networkConfig.enableMultiNetworking",
+			"addonsConfig.kubernetesDashboard.disabled",
+			"addonsConfig.networkPolicyConfig.disabled",
 		}
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)

--- a/test/integration/node_pool/node_pool_test.go
+++ b/test/integration/node_pool/node_pool_test.go
@@ -18,9 +18,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/cai"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/golden"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/utils"
+	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/stretchr/testify/assert"
 	"github.com/terraform-google-modules/terraform-google-kubernetes-engine/test/integration/testutils"
 )
@@ -42,14 +44,8 @@ func TestNodePool(t *testing.T) {
 		kubernetesEndpoint := bpt.GetStringOutput("kubernetes_endpoint")
 		nodeServiceAccount := bpt.GetStringOutput("compute_engine_service_account")
 
-		// Retrieve Project CAI
-		projectCAI := cai.GetProjectResources(t, projectId, cai.WithAssetTypes([]string{"container.googleapis.com/Cluster", "k8s.io/Node"}))
-
-		// Retrieve Cluster from CAI
-		// Equivalent gcloud describe command (classic)
-		// cluster := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
-		clusterResourceName := fmt.Sprintf("//container.googleapis.com/projects/%s/locations/%s/clusters/%s", projectId, location, clusterName)
-		cluster := projectCAI.Get("#(name=\"" + clusterResourceName + "\").resource.data")
+		// Retrieve Cluster
+		cluster := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
 
 		// Setup golden image with sanitizers
 		g := golden.NewOrUpdate(t, cluster.String(),
@@ -69,6 +65,13 @@ func TestNodePool(t *testing.T) {
 		assert.Equal("value-"+randomString, cluster.Get(tagKeyPath).String())
 
 		// K8s Assertions
+		gcloud.Runf(t, "container clusters get-credentials %s --region %s --project %s", clusterName, location, projectId)
+		k8sOpts := k8s.NewKubectlOptions(fmt.Sprintf("gke_%s_%s_%s", projectId, location, clusterName), "", "")
+
+		nodesOutput, err := k8s.RunKubectlAndGetOutputE(t, k8sOpts, "get", "nodes", "-o", "json")
+		assert.NoError(err)
+		nodes := utils.ParseKubectlJSONResult(t, nodesOutput)
+
 		assert.JSONEq(`[
 				{
 					"effect": "PreferNoSchedule",
@@ -81,7 +84,7 @@ func TestNodePool(t *testing.T) {
 					"value": "true"
 				}
 			]`,
-			projectCAI.Get("#(resource.data.metadata.labels.node_pool==\"pool-01\").resource.data.spec.taints").String(), "has the expected taints")
+			nodes.Get("items.#(metadata.labels.node_pool==\"pool-01\").spec.taints").String(), "has the expected taints")
 		assert.JSONEq(`[
 				{
 					"effect": "PreferNoSchedule",
@@ -94,7 +97,7 @@ func TestNodePool(t *testing.T) {
 					"value": "present"
 				}
 			]`,
-			projectCAI.Get("#(resource.data.metadata.labels.node_pool==\"pool-02\").resource.data.spec.taints").String(), "has the expected all-pools-example taint")
+			nodes.Get("items.#(metadata.labels.node_pool==\"pool-02\").spec.taints").String(), "has the expected all-pools-example taint")
 		assert.JSONEq(`[
 				{
 					"effect": "PreferNoSchedule",
@@ -107,7 +110,7 @@ func TestNodePool(t *testing.T) {
 					"value": "gvisor"
 				}
 			]`,
-			projectCAI.Get("#(resource.data.metadata.labels.node_pool==\"pool-03\").resource.data.spec.taints").String(), "has the expected all-pools-example taint")
+			nodes.Get("items.#(metadata.labels.node_pool==\"pool-03\").spec.taints").String(), "has the expected all-pools-example taint")
 	})
 
 	bpt.Test()

--- a/test/integration/node_pool/testdata/TestNodePool.json
+++ b/test/integration/node_pool/testdata/TestNodePool.json
@@ -202,7 +202,7 @@
       "config": {
         "diskSizeGb": 100,
         "diskType": "pd-balanced",
-        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V1",
+        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
         "gcfsConfig": {},
         "imageType": "COS_CONTAINERD",
         "loggingConfig": {
@@ -319,7 +319,7 @@
       "config": {
         "diskSizeGb": 100,
         "diskType": "pd-standard",
-        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V1",
+        "effectiveCgroupMode": "EFFECTIVE_CGROUP_MODE_V2",
         "gcfsConfig": {},
         "imageType": "COS_CONTAINERD",
         "labels": {

--- a/test/integration/private_zonal_with_networking/private_zonal_with_networking_test.go
+++ b/test/integration/private_zonal_with_networking/private_zonal_with_networking_test.go
@@ -62,7 +62,9 @@ func TestPrivateZonalWithNetworking(t *testing.T) {
 			"locations",
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
-			"addonsConfig",
+			"addonsConfig.gcePersistentDiskCsiDriverConfig.enabled",
+			"addonsConfig.kubernetesDashboard.disabled",
+			"addonsConfig.networkPolicyConfig.disabled",
 		}
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)

--- a/test/integration/private_zonal_with_networking/testdata/TestPrivateZonalWithNetworking.json
+++ b/test/integration/private_zonal_with_networking/testdata/TestPrivateZonalWithNetworking.json
@@ -14,7 +14,8 @@
     },
     "networkPolicyConfig": {
       "disabled": true
-    }
+    },
+    "nodeReadinessConfig": {}
   },
   "autopilot": {},
   "autoscaling": {
@@ -253,7 +254,7 @@
           "gke-CLUSTER_NAME",
           "gke-CLUSTER_NAME-default-node-pool"
         ],
-        "windowsNodeConfig" : {},
+        "windowsNodeConfig": {},
         "workloadMetadataConfig": {
           "mode": "GKE_METADATA"
         }

--- a/test/integration/safer_cluster/safer_cluster_test.go
+++ b/test/integration/safer_cluster/safer_cluster_test.go
@@ -50,8 +50,6 @@ func TestSaferCluster(t *testing.T) {
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
 			"addonsConfig.horizontalPodAutoscaling",
-			"addonsConfig.kubernetesDashboard",
-			"addonsConfig.networkPolicyConfig",
 			"networkPolicy",
 			"networkConfig.datapathProvider",
 			"binaryAuthorization.evaluationMode",
@@ -64,6 +62,9 @@ func TestSaferCluster(t *testing.T) {
 			"nodePools.config.tags",
 			"nodePools.management.autoRepair",
 			"nodePools.shieldedInstanceConfig",
+			"addonsConfig.gcePersistentDiskCsiDriverConfig.enabled",
+			"addonsConfig.kubernetesDashboard.disabled",
+			"addonsConfig.networkPolicyConfig.disabled",
 		}
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)

--- a/test/integration/sandbox_enabled/sandbox_enabled_test.go
+++ b/test/integration/sandbox_enabled/sandbox_enabled_test.go
@@ -50,10 +50,11 @@ func TestSandboxEnabled(t *testing.T) {
 			"location",
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
-			"addonsConfig",
 			"nodePools.config.labels",
 			"nodePools.config.taints",
 			"nodePools.config.tags",
+			"addonsConfig.kubernetesDashboard.disabled",
+			"addonsConfig.networkPolicyConfig.disabled",
 		}
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)

--- a/test/integration/simple_autopilot_private/simple_autopilot_private_test.go
+++ b/test/integration/simple_autopilot_private/simple_autopilot_private_test.go
@@ -50,9 +50,11 @@ func TestSimpleAutopilotPrivate(t *testing.T) {
 			"privateClusterConfig.enablePrivateNodes",
 			"addonsConfig.horizontalPodAutoscaling",
 			"addonsConfig.httpLoadBalancing",
+			"masterAuthorizedNetworksConfig.enabled",
+			"addonsConfig.dnsCacheConfig.enabled",
+			"addonsConfig.gcePersistentDiskCsiDriverConfig.enabled",
 			"addonsConfig.kubernetesDashboard.disabled",
 			"addonsConfig.networkPolicyConfig.disabled",
-			"masterAuthorizedNetworksConfig.enabled",
 		}
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)

--- a/test/integration/simple_autopilot_public/simple_autopiliot_public_test.go
+++ b/test/integration/simple_autopilot_public/simple_autopiliot_public_test.go
@@ -48,14 +48,14 @@ func TestSimpleAutopilotPublic(t *testing.T) {
 			"location",
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
-			"addonsConfig.horizontalPodAutoscaling",
-			"addonsConfig.httpLoadBalancing",
-			"addonsConfig.kubernetesDashboard.disabled",
-			"addonsConfig.networkPolicyConfig.disabled",
+			"nodePoolDefaults.nodeConfigDefaults.gcfsConfig.enabled",
+			"addonsConfig.dnsCacheConfig.enabled",
+			"addonsConfig.gcePersistentDiskCsiDriverConfig.enabled",
 			"addonsConfig.rayOperatorConfig.enabled",
 			"addonsConfig.rayOperatorConfig.rayClusterLoggingConfig.enabled",
 			"addonsConfig.rayOperatorConfig.rayClusterMonitoringConfig.enabled",
-			"nodePoolDefaults.nodeConfigDefaults.gcfsConfig.enabled",
+			"addonsConfig.kubernetesDashboard.disabled",
+			"addonsConfig.networkPolicyConfig.disabled",
 		}
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)

--- a/test/integration/simple_regional/simple_regional_test.go
+++ b/test/integration/simple_regional/simple_regional_test.go
@@ -49,18 +49,21 @@ func TestSimpleRegional(t *testing.T) {
 			"location",
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
-			"addonsConfig",
 			"databaseEncryption",
 			"shieldedNodes",
 			"binaryAuthorization",
 			"nodePools.autoscaling",
 			"nodePools.config",
 			"nodePools.management",
+			"addonsConfig.gcePersistentDiskCsiDriverConfig.enabled",
+			"addonsConfig.gcsFuseCsiDriverConfig.enabled",
+			"addonsConfig.statefulHaConfig.enabled",
+			"addonsConfig.kubernetesDashboard.disabled",
+			"addonsConfig.networkPolicyConfig.disabled",
 		}
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)
 		}
-
 	})
 
 	bpt.Test()

--- a/test/integration/simple_regional/testdata/TestSimpleRegional.json
+++ b/test/integration/simple_regional/testdata/TestSimpleRegional.json
@@ -18,6 +18,7 @@
     "networkPolicyConfig": {
       "disabled": true
     },
+    "nodeReadinessConfig": {},
     "statefulHaConfig": {
       "enabled": true
     }

--- a/test/integration/simple_regional_additional_ip_ranges/simple_regional_additional_ip_ranges_test.go
+++ b/test/integration/simple_regional_additional_ip_ranges/simple_regional_additional_ip_ranges_test.go
@@ -49,13 +49,15 @@ func TestSimpleRegionalAdditionalIPRanges(t *testing.T) {
 			"location",
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
-			"addonsConfig",
 			"databaseEncryption",
 			"shieldedNodes",
 			"binaryAuthorization",
 			"nodePools.autoscaling",
 			"nodePools.config",
 			"nodePools.management",
+			"addonsConfig.gcePersistentDiskCsiDriverConfig.enabled",
+			"addonsConfig.kubernetesDashboard.disabled",
+			"addonsConfig.networkPolicyConfig.disabled",
 		}
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)

--- a/test/integration/simple_regional_additional_ip_ranges/testdata/TestSimpleRegionalAdditionalIPRanges.json
+++ b/test/integration/simple_regional_additional_ip_ranges/testdata/TestSimpleRegionalAdditionalIPRanges.json
@@ -61,7 +61,9 @@
     "additionalIpRangesConfigs": [
       {
         "subnetwork": "projects/PROJECT_ID/regions/us-west1/subnetworks/cft-gke-test-2-RANDOM_STRING",
-        "podIpv4RangeNames": ["test2"]
+        "podIpv4RangeNames": [
+          "test2"
+        ]
       }
     ]
   },

--- a/test/integration/simple_regional_cluster_autoscaling/simple_regional_cluster_autoscaling_test.go
+++ b/test/integration/simple_regional_cluster_autoscaling/simple_regional_cluster_autoscaling_test.go
@@ -45,7 +45,6 @@ func TestSimpleRegionalClusterAutoscaling(t *testing.T) {
 			"location",
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
-			"addonsConfig",
 			"databaseEncryption",
 			"shieldedNodes",
 			"binaryAuthorization",
@@ -53,6 +52,9 @@ func TestSimpleRegionalClusterAutoscaling(t *testing.T) {
 			"nodePools.config",
 			"nodePools.config.tags",
 			"nodePools.management",
+			"addonsConfig.gcePersistentDiskCsiDriverConfig.enabled",
+			"addonsConfig.kubernetesDashboard.disabled",
+			"addonsConfig.networkPolicyConfig.disabled",
 		}
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)

--- a/test/integration/simple_regional_cluster_autoscaling/testdata/TestSimpleRegionalClusterAutoscaling.json
+++ b/test/integration/simple_regional_cluster_autoscaling/testdata/TestSimpleRegionalClusterAutoscaling.json
@@ -14,7 +14,8 @@
     },
     "networkPolicyConfig": {
       "disabled": true
-    }
+    },
+    "nodeReadinessConfig": {}
   },
   "autopilot": {},
   "autoscaling": {

--- a/test/integration/simple_regional_private/simple_regional_private_test.go
+++ b/test/integration/simple_regional_private/simple_regional_private_test.go
@@ -51,10 +51,6 @@ func TestSimpleRegionalPrivate(t *testing.T) {
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
 			"defaultMaxPodsConstraint.maxPodsPerNode",
-			"addonsConfig.horizontalPodAutoscaling",
-			"addonsConfig.httpLoadBalancing",
-			"addonsConfig.kubernetesDashboard.disabled",
-			"addonsConfig.networkPolicyConfig.disabled",
 			"nodePools.autoscaling.enabled",
 			"nodePools.autoscaling.minNodeCount",
 			"nodePools.autoscaling.maxNodeCount",
@@ -65,6 +61,9 @@ func TestSimpleRegionalPrivate(t *testing.T) {
 			"nodePools.config.tags",
 			"nodePools.management.autoRepair",
 			"node_pools.maxPodsConstraint.maxPodsPerNode",
+			"addonsConfig.gcePersistentDiskCsiDriverConfig.enabled",
+			"addonsConfig.kubernetesDashboard.disabled",
+			"addonsConfig.networkPolicyConfig.disabled",
 		}
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)

--- a/test/integration/simple_regional_private_no_pool/simple_regional_private_no_pool_test.go
+++ b/test/integration/simple_regional_private_no_pool/simple_regional_private_no_pool_test.go
@@ -52,17 +52,17 @@ func TestSimpleRegionalPrivateNoPool(t *testing.T) {
 			"defaultMaxPodsConstraint.maxPodsPerNode",
 			"addonsConfig.horizontalPodAutoscaling",
 			"addonsConfig.httpLoadBalancing",
-			"addonsConfig.kubernetesDashboard.disabled",
-			"addonsConfig.networkPolicyConfig.disabled",
 			"autoscaling.defaultComputeClassConfig.enabled",
 			"autoscaling.enableNodeAutoprovisioning",
+			"addonsConfig.gcePersistentDiskCsiDriverConfig.enabled",
+			"addonsConfig.kubernetesDashboard.disabled",
+			"addonsConfig.networkPolicyConfig.disabled",
 		}
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)
 		}
 
 		assert.Contains([]string{"RUNNING", "RECONCILING"}, op.Get("status").String()) // comes up healthy
-
 	})
 
 	bpt.Test()

--- a/test/integration/simple_regional_with_gateway_api/simple_regional_with_gateway_api_test.go
+++ b/test/integration/simple_regional_with_gateway_api/simple_regional_with_gateway_api_test.go
@@ -14,11 +14,10 @@
 package node_pool
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/cai"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/golden"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
 	"github.com/stretchr/testify/assert"
@@ -42,14 +41,8 @@ func TestSimpleRegionalWithGatewayAPI(t *testing.T) {
 		kubernetesEndpoint := bpt.GetStringOutput("kubernetes_endpoint")
 		nodeServiceAccount := bpt.GetStringOutput("compute_engine_service_account")
 
-		// Retrieve Project CAI
-		projectCAI := cai.GetProjectResources(t, projectId, cai.WithAssetTypes([]string{"container.googleapis.com/Cluster"}))
-
-		// Retrieve Cluster from CAI
-		// Equivalent gcloud describe command (classic)
-		// cluster := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
-		clusterResourceName := fmt.Sprintf("//container.googleapis.com/projects/%s/locations/%s/clusters/%s", projectId, location, clusterName)
-		cluster := projectCAI.Get("#(name=\"" + clusterResourceName + "\").resource.data")
+		// Retrieve Cluster
+		cluster := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
 
 		// Setup golden image with sanitizers
 		g := golden.NewOrUpdate(t, cluster.String(),

--- a/test/integration/simple_regional_with_ipv6/simple_regional_with_ipv6_test.go
+++ b/test/integration/simple_regional_with_ipv6/simple_regional_with_ipv6_test.go
@@ -14,11 +14,10 @@
 package node_pool
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
-	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/cai"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/golden"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
 	"github.com/stretchr/testify/assert"
@@ -42,14 +41,8 @@ func TestSimpleRegionalWithGatewayAPI(t *testing.T) {
 		kubernetesEndpoint := bpt.GetStringOutput("kubernetes_endpoint")
 		nodeServiceAccount := bpt.GetStringOutput("compute_engine_service_account")
 
-		// Retrieve Project CAI
-		projectCAI := cai.GetProjectResources(t, projectId, cai.WithAssetTypes([]string{"container.googleapis.com/Cluster"}))
-
-		// Retrieve Cluster from CAI
-		// Equivalent gcloud describe command (classic)
-		// cluster := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
-		clusterResourceName := fmt.Sprintf("//container.googleapis.com/projects/%s/locations/%s/clusters/%s", projectId, location, clusterName)
-		cluster := projectCAI.Get("#(name=\"" + clusterResourceName + "\").resource.data")
+		// Retrieve Cluster
+		cluster := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
 
 		// Setup golden image with sanitizers
 		g := golden.NewOrUpdate(t, cluster.String(),

--- a/test/integration/simple_regional_with_kubeconfig/simple_regional_with_kubeconfig_test.go
+++ b/test/integration/simple_regional_with_kubeconfig/simple_regional_with_kubeconfig_test.go
@@ -49,10 +49,6 @@ func TestSimpleRegionalWithKubeConfig(t *testing.T) {
 			"location",
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
-			"addonsConfig.horizontalPodAutoscaling",
-			"addonsConfig.httpLoadBalancing",
-			"addonsConfig.kubernetesDashboard.disabled",
-			"addonsConfig.networkPolicyConfig.disabled",
 			"nodePools.autoscaling.enabled",
 			"nodePools.autoscaling.minNodeCount",
 			"nodePools.autoscaling.maxNodeCount",
@@ -63,6 +59,9 @@ func TestSimpleRegionalWithKubeConfig(t *testing.T) {
 			"nodePools.config.tags",
 			"nodePools.management.autoRepair",
 			"nodePools.management.autoUpgrade",
+			"addonsConfig.gcePersistentDiskCsiDriverConfig.enabled",
+			"addonsConfig.kubernetesDashboard.disabled",
+			"addonsConfig.networkPolicyConfig.disabled",
 		}
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)

--- a/test/integration/simple_regional_with_networking/simple_regional_with_networking_test.go
+++ b/test/integration/simple_regional_with_networking/simple_regional_with_networking_test.go
@@ -55,8 +55,6 @@ func TestSimpleRegionalWithNetworking(t *testing.T) {
 			"privateClusterConfig.enablePrivateNodes",
 			"addonsConfig.horizontalPodAutoscaling",
 			"addonsConfig.httpLoadBalancing",
-			"addonsConfig.kubernetesDashboard.disabled",
-			"addonsConfig.networkPolicyConfig.disabled",
 			"nodePools.autoscaling.enabled",
 			"nodePools.autoscaling.minNodeCount",
 			"nodePools.autoscaling.maxNodeCount",
@@ -67,6 +65,9 @@ func TestSimpleRegionalWithNetworking(t *testing.T) {
 			"nodePools.config.tags",
 			"nodePools.management.autoRepair",
 			"nodePools.management.autoUpgrade",
+			"addonsConfig.gcePersistentDiskCsiDriverConfig.enabled",
+			"addonsConfig.kubernetesDashboard.disabled",
+			"addonsConfig.networkPolicyConfig.disabled",
 		}
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)

--- a/test/integration/simple_windows_node_pool/testdata/TestSimpleWindowsNodePool.json
+++ b/test/integration/simple_windows_node_pool/testdata/TestSimpleWindowsNodePool.json
@@ -323,4 +323,3 @@
   },
   "zone": "us-central1-a"
 }
-

--- a/test/integration/simple_zonal_private/simple_zonal_private_test.go
+++ b/test/integration/simple_zonal_private/simple_zonal_private_test.go
@@ -53,6 +53,7 @@ func TestSimpleZonalPrivate(t *testing.T) {
 			"privateClusterConfig.enablePrivateNodes",
 			"addonsConfig.horizontalPodAutoscaling",
 			"addonsConfig.httpLoadBalancing",
+			"addonsConfig.gcePersistentDiskCsiDriverConfig.enabled",
 			"addonsConfig.kubernetesDashboard.disabled",
 			"addonsConfig.networkPolicyConfig.disabled",
 			"nodePools.name",

--- a/test/integration/stub_domains/stub_domains_test.go
+++ b/test/integration/stub_domains/stub_domains_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/cai"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/golden"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
@@ -45,14 +44,8 @@ func TestStubDomains(t *testing.T) {
 		kubernetesEndpoint := bpt.GetStringOutput("kubernetes_endpoint")
 		nodeServiceAccount := bpt.GetStringOutput("compute_engine_service_account")
 
-		// Retrieve Project CAI
-		projectCAI := cai.GetProjectResources(t, projectId, cai.WithAssetTypes([]string{"container.googleapis.com/Cluster"}))
-
-		// Retrieve Cluster from CAI
-		// Equivalent gcloud describe command (classic)
-		// cluster := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
-		clusterResourceName := fmt.Sprintf("//container.googleapis.com/projects/%s/locations/%s/clusters/%s", projectId, location, clusterName)
-		cluster := projectCAI.Get("#(name=\"" + clusterResourceName + "\").resource.data")
+		// Retrieve Cluster
+		cluster := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
 
 		// Setup golden image with sanitizers
 		g := golden.NewOrUpdate(t, cluster.String(),

--- a/test/integration/stub_domains_private/stub_domains_private_test.go
+++ b/test/integration/stub_domains_private/stub_domains_private_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/cai"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/golden"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
@@ -45,14 +44,8 @@ func TestStubDomainsPrivate(t *testing.T) {
 		kubernetesEndpoint := bpt.GetStringOutput("kubernetes_endpoint")
 		nodeServiceAccount := bpt.GetStringOutput("compute_engine_service_account")
 
-		// Retrieve Project CAI
-		projectCAI := cai.GetProjectResources(t, projectId, cai.WithAssetTypes([]string{"container.googleapis.com/Cluster"}))
-
-		// Retrieve Cluster from CAI
-		// Equivalent gcloud describe command (classic)
-		// cluster := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
-		clusterResourceName := fmt.Sprintf("//container.googleapis.com/projects/%s/locations/%s/clusters/%s", projectId, location, clusterName)
-		cluster := projectCAI.Get("#(name=\"" + clusterResourceName + "\").resource.data")
+		// Retrieve Cluster
+		cluster := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
 
 		// Setup golden image with sanitizers
 		g := golden.NewOrUpdate(t, cluster.String(),

--- a/test/integration/stub_domains_upstream_nameservers/stub_domains_upstream_nameservers_test.go
+++ b/test/integration/stub_domains_upstream_nameservers/stub_domains_upstream_nameservers_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/cai"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/golden"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
@@ -45,14 +44,8 @@ func TestStubDomainsUpstreamNameservers(t *testing.T) {
 		kubernetesEndpoint := bpt.GetStringOutput("kubernetes_endpoint")
 		nodeServiceAccount := bpt.GetStringOutput("compute_engine_service_account")
 
-		// Retrieve Project CAI
-		projectCAI := cai.GetProjectResources(t, projectId, cai.WithAssetTypes([]string{"container.googleapis.com/Cluster"}))
-
-		// Retrieve Cluster from CAI
-		// Equivalent gcloud describe command (classic)
-		// cluster := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
-		clusterResourceName := fmt.Sprintf("//container.googleapis.com/projects/%s/locations/%s/clusters/%s", projectId, location, clusterName)
-		cluster := projectCAI.Get("#(name=\"" + clusterResourceName + "\").resource.data")
+		// Retrieve Cluster
+		cluster := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
 
 		// Setup golden image with sanitizers
 		g := golden.NewOrUpdate(t, cluster.String(),

--- a/test/integration/upstream_nameservers/upstream_nameservers_test.go
+++ b/test/integration/upstream_nameservers/upstream_nameservers_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/cai"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/golden"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
@@ -45,14 +44,8 @@ func TestUpstreamNameservers(t *testing.T) {
 		kubernetesEndpoint := bpt.GetStringOutput("kubernetes_endpoint")
 		nodeServiceAccount := bpt.GetStringOutput("compute_engine_service_account")
 
-		// Retrieve Project CAI
-		projectCAI := cai.GetProjectResources(t, projectId, cai.WithAssetTypes([]string{"container.googleapis.com/Cluster"}))
-
-		// Retrieve Cluster from CAI
-		// Equivalent gcloud describe command (classic)
-		// cluster := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
-		clusterResourceName := fmt.Sprintf("//container.googleapis.com/projects/%s/locations/%s/clusters/%s", projectId, location, clusterName)
-		cluster := projectCAI.Get("#(name=\"" + clusterResourceName + "\").resource.data")
+		// Retrieve Cluster
+		cluster := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
 
 		// Setup golden image with sanitizers
 		g := golden.NewOrUpdate(t, cluster.String(),

--- a/test/integration/workload_metadata_config/workload_metadata_config_test.go
+++ b/test/integration/workload_metadata_config/workload_metadata_config_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/cai"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/golden"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
@@ -43,14 +42,8 @@ func TestWorkloadMetadataConfig(t *testing.T) {
 		kubernetesEndpoint := bpt.GetStringOutput("kubernetes_endpoint")
 		nodeServiceAccount := bpt.GetStringOutput("service_account")
 
-		// Retrieve Project CAI
-		projectCAI := cai.GetProjectResources(t, projectId, cai.WithAssetTypes([]string{"container.googleapis.com/Cluster"}))
-
-		// Retrieve Cluster from CAI
-		// Equivalent gcloud describe command (classic)
-		// cluster := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
-		clusterResourceName := fmt.Sprintf("//container.googleapis.com/projects/%s/zones/%s/clusters/%s", projectId, location, clusterName)
-		cluster := projectCAI.Get("#(name=\"" + clusterResourceName + "\").resource.data")
+		// Retrieve Cluster
+		cluster := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
 
 		// Setup golden image with sanitizers
 		g := golden.NewOrUpdate(t, cluster.String(),

--- a/variables.tf
+++ b/variables.tf
@@ -245,7 +245,7 @@ variable "node_pools_linux_node_configs_sysctls" {
 
 variable "node_pools_cgroup_mode" {
   type        = map(string)
-  description = "Map of strings containing cgroup node config by node-pool name"
+  description = "Map of strings containing cgroup node config by node-pool name. Note: GKE is removing cgroup v1 support in 1.35."
 
   # Default is being set in variables_defaults.tf
   default = {


### PR DESCRIPTION
* Annotated template and Beta modules variables listing deprecation on `CGROUP_MODE_V1` in GKE 1.35
* Cleared explicit override falling to defaults on tests cluster environments assumes Mode V2
* Updated golden expectations in TestNodePool.json mapping effective Mode V2
* Refactored GKE integration tests to resolve CAI latency and GKE default addon upgrades