### PR TITLE
fix: add ENABLE_BPMETADATA=1 to docker_generate_modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ docker_generate_docs:
 .PHONY: docker_generate_modules
 docker_generate_modules:
 	$(DOCKER_BIN) run --rm -it \
+                -e ENABLE_BPMETADATA=1 \
                 -v "$(CURDIR)":/workspace \
                 $(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
                 /bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_modules'


### PR DESCRIPTION
## Summary

`docker_generate_modules` (used by `make build` and `make generate`) was missing `-e ENABLE_BPMETADATA=1`, while `docker_test_lint` — and therefore the CI `check_generate_modules` check — runs with that flag set.

The result: adding a new variable to any module causes `make build` to silently skip updating the corresponding `metadata.yaml` files, but CI then flags them as stale and fails.

One-line fix: pass `-e ENABLE_BPMETADATA=1` to the `docker_generate_modules` container, matching what CI does.

## Context

Discovered while working on #2573 (`feat: Add secret_sync_config support to all beta cluster modules`), where `make build` was run but `metadata.yaml` files were not updated, causing `check_generate_modules` to fail in CI.

## Test plan

- [x] `make generate` / `make build` will now regenerate `metadata.yaml` files alongside the `.tf` files, keeping them in sync with CI