### PR TITLE
fix(workload-identity): resolve inconsistent conditional result types in output

### DIFF
--- a/modules/workload-identity/output.tf
+++ b/modules/workload-identity/output.tf
@@ -41,5 +41,8 @@ output "gcp_service_account_name" {
 
 output "gcp_service_account" {
   description = "GCP service account."
-  value       = var.use_existing_gcp_sa ? data.google_service_account.cluster_service_account[0] : google_service_account.cluster_service_account[0]
+  value = one(concat(
+    data.google_service_account.cluster_service_account,
+    google_service_account.cluster_service_account
+  ))
 }


### PR DESCRIPTION
## Description

Fixes #1112

When `use_existing_gcp_sa` is unknown at plan time (e.g., comes from another resource's output), Terraform fails with:

```
Error: Inconsistent conditional result types

  on .../modules/workload-identity/output.tf line 44, in output "gcp_service_account":
    value = var.use_existing_gcp_sa ? data.google_service_account.cluster_service_account[0] : google_service_account.cluster_service_account[0]

The true and false result expressions must have consistent types.
```

## Root Cause

The `data.google_service_account` data source and `google_service_account` resource return objects with slightly different attribute schemas. When Terraform can't determine which branch to evaluate at plan time, it requires both branches to have identical types.

## Solution

Replace the conditional expression with `one(concat(...))`:

```hcl
# Before
value = var.use_existing_gcp_sa ? data.google_service_account.cluster_service_account[0] : google_service_account.cluster_service_account[0]

# After
value = one(concat(
  data.google_service_account.cluster_service_account,
  google_service_account.cluster_service_account
))
```

This works because:
- Only one list will ever have elements (based on the mutually exclusive count conditions)
- `concat()` doesn't require type comparison between the list elements
- `one()` extracts the single element from the concatenated list

## Backward Compatibility

The output value is identical - it still returns the full GCP service account object. Only the implementation changes to avoid the type mismatch error.