### PR TITLE
feat: expose dns_enable_k8s_tokens_via_dns for GKE DNS endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Then perform the following commands on the root folder:
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | `bool` | `true` | no |
 | dns\_allow\_external\_traffic | (Optional) Controls whether external traffic is allowed over the dns endpoint. | `bool` | `null` | no |
 | dns\_cache | The status of the NodeLocal DNSCache addon. | `bool` | `false` | no |
+| dns\_enable\_k8s\_tokens\_via\_dns | (Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint. | `bool` | `null` | no |
 | enable\_binary\_authorization | Enable BinAuthZ Admission controller | `bool` | `false` | no |
 | enable\_cilium\_clusterwide\_network\_policy | Enable Cilium Cluster Wide Network Policies on the cluster | `bool` | `false` | no |
 | enable\_confidential\_nodes | An optional flag to enable confidential node config. | `bool` | `false` | no |

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -813,12 +813,13 @@ resource "google_container_cluster" "primary" {
 
 {% endif %}
   dynamic "control_plane_endpoints_config" {
-    for_each = var.dns_allow_external_traffic != null || var.ip_endpoints_enabled != null ? [1] : []
+    for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null || var.ip_endpoints_enabled != null ? [1] : []
     content {
       dynamic "dns_endpoint_config" {
-        for_each = var.dns_allow_external_traffic != null ? [1] : []
+        for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null ? [1] : []
         content {
-          allow_external_traffic = var.dns_allow_external_traffic
+          allow_external_traffic    = var.dns_allow_external_traffic
+          enable_k8s_tokens_via_dns = var.dns_enable_k8s_tokens_via_dns
         }
       }
       dynamic "ip_endpoints_config" {

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -1217,6 +1217,12 @@ variable "dns_allow_external_traffic" {
   default     = null
 }
 
+variable "dns_enable_k8s_tokens_via_dns" {
+  description = "(Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint."
+  type        = bool
+  default     = null
+}
+
 variable "ip_endpoints_enabled" {
   description = "(Optional) Controls whether to allow direct IP access. Defaults to `true`."
   type        = bool

--- a/cluster.tf
+++ b/cluster.tf
@@ -636,12 +636,13 @@ resource "google_container_cluster" "primary" {
   }
 
   dynamic "control_plane_endpoints_config" {
-    for_each = var.dns_allow_external_traffic != null || var.ip_endpoints_enabled != null ? [1] : []
+    for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null || var.ip_endpoints_enabled != null ? [1] : []
     content {
       dynamic "dns_endpoint_config" {
-        for_each = var.dns_allow_external_traffic != null ? [1] : []
+        for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null ? [1] : []
         content {
-          allow_external_traffic = var.dns_allow_external_traffic
+          allow_external_traffic    = var.dns_allow_external_traffic
+          enable_k8s_tokens_via_dns = var.dns_enable_k8s_tokens_via_dns
         }
       }
       dynamic "ip_endpoints_config" {

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -117,6 +117,9 @@ spec:
         dns_cache:
           name: dns_cache
           title: Dns Cache
+        dns_enable_k8s_tokens_via_dns:
+          name: dns_enable_k8s_tokens_via_dns
+          title: Dns Enable K8s Tokens Via Dns
         enable_binary_authorization:
           name: enable_binary_authorization
           title: Enable Binary Authorization

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -795,6 +795,9 @@ spec:
       - name: dns_allow_external_traffic
         description: (Optional) Controls whether external traffic is allowed over the dns endpoint.
         varType: bool
+      - name: dns_enable_k8s_tokens_via_dns
+        description: (Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint.
+        varType: bool
       - name: ip_endpoints_enabled
         description: (Optional) Controls whether to allow direct IP access. Defaults to `true`.
         varType: bool

--- a/modules/beta-autopilot-private-cluster/README.md
+++ b/modules/beta-autopilot-private-cluster/README.md
@@ -94,6 +94,7 @@ Then perform the following commands on the root folder:
 | disable\_l4\_lb\_firewall\_reconciliation | Disable L4 Load Balancer firewall reconciliation | `bool` | `null` | no |
 | dns\_allow\_external\_traffic | (Optional) Controls whether external traffic is allowed over the dns endpoint. | `bool` | `null` | no |
 | dns\_cache | The status of the NodeLocal DNSCache addon. | `bool` | `true` | no |
+| dns\_enable\_k8s\_tokens\_via\_dns | (Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint. | `bool` | `null` | no |
 | enable\_binary\_authorization | Enable BinAuthZ Admission controller | `bool` | `false` | no |
 | enable\_cilium\_clusterwide\_network\_policy | Enable Cilium Cluster Wide Network Policies on the cluster | `bool` | `false` | no |
 | enable\_confidential\_nodes | An optional flag to enable confidential node config. | `bool` | `false` | no |

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -432,12 +432,13 @@ resource "google_container_cluster" "primary" {
   }
 
   dynamic "control_plane_endpoints_config" {
-    for_each = var.dns_allow_external_traffic != null || var.ip_endpoints_enabled != null ? [1] : []
+    for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null || var.ip_endpoints_enabled != null ? [1] : []
     content {
       dynamic "dns_endpoint_config" {
-        for_each = var.dns_allow_external_traffic != null ? [1] : []
+        for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null ? [1] : []
         content {
-          allow_external_traffic = var.dns_allow_external_traffic
+          allow_external_traffic    = var.dns_allow_external_traffic
+          enable_k8s_tokens_via_dns = var.dns_enable_k8s_tokens_via_dns
         }
       }
       dynamic "ip_endpoints_config" {

--- a/modules/beta-autopilot-private-cluster/metadata.display.yaml
+++ b/modules/beta-autopilot-private-cluster/metadata.display.yaml
@@ -97,6 +97,9 @@ spec:
         dns_cache:
           name: dns_cache
           title: Dns Cache
+        dns_enable_k8s_tokens_via_dns:
+          name: dns_enable_k8s_tokens_via_dns
+          title: Dns Enable K8s Tokens Via Dns
         enable_binary_authorization:
           name: enable_binary_authorization
           title: Enable Binary Authorization

--- a/modules/beta-autopilot-private-cluster/metadata.yaml
+++ b/modules/beta-autopilot-private-cluster/metadata.yaml
@@ -527,6 +527,9 @@ spec:
       - name: dns_allow_external_traffic
         description: (Optional) Controls whether external traffic is allowed over the dns endpoint.
         varType: bool
+      - name: dns_enable_k8s_tokens_via_dns
+        description: (Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint.
+        varType: bool
       - name: ip_endpoints_enabled
         description: (Optional) Controls whether to allow direct IP access. Defaults to `true`.
         varType: bool

--- a/modules/beta-autopilot-private-cluster/variables.tf
+++ b/modules/beta-autopilot-private-cluster/variables.tf
@@ -705,6 +705,12 @@ variable "dns_allow_external_traffic" {
   default     = null
 }
 
+variable "dns_enable_k8s_tokens_via_dns" {
+  description = "(Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint."
+  type        = bool
+  default     = null
+}
+
 variable "ip_endpoints_enabled" {
   description = "(Optional) Controls whether to allow direct IP access. Defaults to `true`."
   type        = bool

--- a/modules/beta-autopilot-public-cluster/README.md
+++ b/modules/beta-autopilot-public-cluster/README.md
@@ -87,6 +87,7 @@ Then perform the following commands on the root folder:
 | disable\_l4\_lb\_firewall\_reconciliation | Disable L4 Load Balancer firewall reconciliation | `bool` | `null` | no |
 | dns\_allow\_external\_traffic | (Optional) Controls whether external traffic is allowed over the dns endpoint. | `bool` | `null` | no |
 | dns\_cache | The status of the NodeLocal DNSCache addon. | `bool` | `true` | no |
+| dns\_enable\_k8s\_tokens\_via\_dns | (Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint. | `bool` | `null` | no |
 | enable\_binary\_authorization | Enable BinAuthZ Admission controller | `bool` | `false` | no |
 | enable\_cilium\_clusterwide\_network\_policy | Enable Cilium Cluster Wide Network Policies on the cluster | `bool` | `false` | no |
 | enable\_confidential\_nodes | An optional flag to enable confidential node config. | `bool` | `false` | no |

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -410,12 +410,13 @@ resource "google_container_cluster" "primary" {
   }
 
   dynamic "control_plane_endpoints_config" {
-    for_each = var.dns_allow_external_traffic != null || var.ip_endpoints_enabled != null ? [1] : []
+    for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null || var.ip_endpoints_enabled != null ? [1] : []
     content {
       dynamic "dns_endpoint_config" {
-        for_each = var.dns_allow_external_traffic != null ? [1] : []
+        for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null ? [1] : []
         content {
-          allow_external_traffic = var.dns_allow_external_traffic
+          allow_external_traffic    = var.dns_allow_external_traffic
+          enable_k8s_tokens_via_dns = var.dns_enable_k8s_tokens_via_dns
         }
       }
       dynamic "ip_endpoints_config" {

--- a/modules/beta-autopilot-public-cluster/metadata.display.yaml
+++ b/modules/beta-autopilot-public-cluster/metadata.display.yaml
@@ -94,6 +94,9 @@ spec:
         dns_cache:
           name: dns_cache
           title: Dns Cache
+        dns_enable_k8s_tokens_via_dns:
+          name: dns_enable_k8s_tokens_via_dns
+          title: Dns Enable K8s Tokens Via Dns
         enable_binary_authorization:
           name: enable_binary_authorization
           title: Enable Binary Authorization

--- a/modules/beta-autopilot-public-cluster/metadata.yaml
+++ b/modules/beta-autopilot-public-cluster/metadata.yaml
@@ -505,6 +505,9 @@ spec:
       - name: dns_allow_external_traffic
         description: (Optional) Controls whether external traffic is allowed over the dns endpoint.
         varType: bool
+      - name: dns_enable_k8s_tokens_via_dns
+        description: (Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint.
+        varType: bool
       - name: ip_endpoints_enabled
         description: (Optional) Controls whether to allow direct IP access. Defaults to `true`.
         varType: bool

--- a/modules/beta-autopilot-public-cluster/variables.tf
+++ b/modules/beta-autopilot-public-cluster/variables.tf
@@ -669,6 +669,12 @@ variable "dns_allow_external_traffic" {
   default     = null
 }
 
+variable "dns_enable_k8s_tokens_via_dns" {
+  description = "(Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint."
+  type        = bool
+  default     = null
+}
+
 variable "ip_endpoints_enabled" {
   description = "(Optional) Controls whether to allow direct IP access. Defaults to `true`."
   type        = bool

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -202,6 +202,7 @@ Then perform the following commands on the root folder:
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | `bool` | `true` | no |
 | dns\_allow\_external\_traffic | (Optional) Controls whether external traffic is allowed over the dns endpoint. | `bool` | `null` | no |
 | dns\_cache | The status of the NodeLocal DNSCache addon. | `bool` | `false` | no |
+| dns\_enable\_k8s\_tokens\_via\_dns | (Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint. | `bool` | `null` | no |
 | enable\_binary\_authorization | Enable BinAuthZ Admission controller | `bool` | `false` | no |
 | enable\_cilium\_clusterwide\_network\_policy | Enable Cilium Cluster Wide Network Policies on the cluster | `bool` | `false` | no |
 | enable\_confidential\_nodes | An optional flag to enable confidential node config. | `bool` | `false` | no |

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -700,12 +700,13 @@ resource "google_container_cluster" "primary" {
   }
 
   dynamic "control_plane_endpoints_config" {
-    for_each = var.dns_allow_external_traffic != null || var.ip_endpoints_enabled != null ? [1] : []
+    for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null || var.ip_endpoints_enabled != null ? [1] : []
     content {
       dynamic "dns_endpoint_config" {
-        for_each = var.dns_allow_external_traffic != null ? [1] : []
+        for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null ? [1] : []
         content {
-          allow_external_traffic = var.dns_allow_external_traffic
+          allow_external_traffic    = var.dns_allow_external_traffic
+          enable_k8s_tokens_via_dns = var.dns_enable_k8s_tokens_via_dns
         }
       }
       dynamic "ip_endpoints_config" {

--- a/modules/beta-private-cluster-update-variant/metadata.display.yaml
+++ b/modules/beta-private-cluster-update-variant/metadata.display.yaml
@@ -130,6 +130,9 @@ spec:
         dns_cache:
           name: dns_cache
           title: Dns Cache
+        dns_enable_k8s_tokens_via_dns:
+          name: dns_enable_k8s_tokens_via_dns
+          title: Dns Enable K8s Tokens Via Dns
         enable_binary_authorization:
           name: enable_binary_authorization
           title: Enable Binary Authorization

--- a/modules/beta-private-cluster-update-variant/metadata.yaml
+++ b/modules/beta-private-cluster-update-variant/metadata.yaml
@@ -812,6 +812,9 @@ spec:
       - name: dns_allow_external_traffic
         description: (Optional) Controls whether external traffic is allowed over the dns endpoint.
         varType: bool
+      - name: dns_enable_k8s_tokens_via_dns
+        description: (Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint.
+        varType: bool
       - name: ip_endpoints_enabled
         description: (Optional) Controls whether to allow direct IP access. Defaults to `true`.
         varType: bool

--- a/modules/beta-private-cluster-update-variant/variables.tf
+++ b/modules/beta-private-cluster-update-variant/variables.tf
@@ -1135,6 +1135,12 @@ variable "dns_allow_external_traffic" {
   default     = null
 }
 
+variable "dns_enable_k8s_tokens_via_dns" {
+  description = "(Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint."
+  type        = bool
+  default     = null
+}
+
 variable "ip_endpoints_enabled" {
   description = "(Optional) Controls whether to allow direct IP access. Defaults to `true`."
   type        = bool

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -180,6 +180,7 @@ Then perform the following commands on the root folder:
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | `bool` | `true` | no |
 | dns\_allow\_external\_traffic | (Optional) Controls whether external traffic is allowed over the dns endpoint. | `bool` | `null` | no |
 | dns\_cache | The status of the NodeLocal DNSCache addon. | `bool` | `false` | no |
+| dns\_enable\_k8s\_tokens\_via\_dns | (Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint. | `bool` | `null` | no |
 | enable\_binary\_authorization | Enable BinAuthZ Admission controller | `bool` | `false` | no |
 | enable\_cilium\_clusterwide\_network\_policy | Enable Cilium Cluster Wide Network Policies on the cluster | `bool` | `false` | no |
 | enable\_confidential\_nodes | An optional flag to enable confidential node config. | `bool` | `false` | no |

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -700,12 +700,13 @@ resource "google_container_cluster" "primary" {
   }
 
   dynamic "control_plane_endpoints_config" {
-    for_each = var.dns_allow_external_traffic != null || var.ip_endpoints_enabled != null ? [1] : []
+    for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null || var.ip_endpoints_enabled != null ? [1] : []
     content {
       dynamic "dns_endpoint_config" {
-        for_each = var.dns_allow_external_traffic != null ? [1] : []
+        for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null ? [1] : []
         content {
-          allow_external_traffic = var.dns_allow_external_traffic
+          allow_external_traffic    = var.dns_allow_external_traffic
+          enable_k8s_tokens_via_dns = var.dns_enable_k8s_tokens_via_dns
         }
       }
       dynamic "ip_endpoints_config" {

--- a/modules/beta-private-cluster/metadata.display.yaml
+++ b/modules/beta-private-cluster/metadata.display.yaml
@@ -130,6 +130,9 @@ spec:
         dns_cache:
           name: dns_cache
           title: Dns Cache
+        dns_enable_k8s_tokens_via_dns:
+          name: dns_enable_k8s_tokens_via_dns
+          title: Dns Enable K8s Tokens Via Dns
         enable_binary_authorization:
           name: enable_binary_authorization
           title: Enable Binary Authorization

--- a/modules/beta-private-cluster/metadata.yaml
+++ b/modules/beta-private-cluster/metadata.yaml
@@ -812,6 +812,9 @@ spec:
       - name: dns_allow_external_traffic
         description: (Optional) Controls whether external traffic is allowed over the dns endpoint.
         varType: bool
+      - name: dns_enable_k8s_tokens_via_dns
+        description: (Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint.
+        varType: bool
       - name: ip_endpoints_enabled
         description: (Optional) Controls whether to allow direct IP access. Defaults to `true`.
         varType: bool

--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -1135,6 +1135,12 @@ variable "dns_allow_external_traffic" {
   default     = null
 }
 
+variable "dns_enable_k8s_tokens_via_dns" {
+  description = "(Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint."
+  type        = bool
+  default     = null
+}
+
 variable "ip_endpoints_enabled" {
   description = "(Optional) Controls whether to allow direct IP access. Defaults to `true`."
   type        = bool

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -195,6 +195,7 @@ Then perform the following commands on the root folder:
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | `bool` | `true` | no |
 | dns\_allow\_external\_traffic | (Optional) Controls whether external traffic is allowed over the dns endpoint. | `bool` | `null` | no |
 | dns\_cache | The status of the NodeLocal DNSCache addon. | `bool` | `false` | no |
+| dns\_enable\_k8s\_tokens\_via\_dns | (Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint. | `bool` | `null` | no |
 | enable\_binary\_authorization | Enable BinAuthZ Admission controller | `bool` | `false` | no |
 | enable\_cilium\_clusterwide\_network\_policy | Enable Cilium Cluster Wide Network Policies on the cluster | `bool` | `false` | no |
 | enable\_confidential\_nodes | An optional flag to enable confidential node config. | `bool` | `false` | no |

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -678,12 +678,13 @@ resource "google_container_cluster" "primary" {
   }
 
   dynamic "control_plane_endpoints_config" {
-    for_each = var.dns_allow_external_traffic != null || var.ip_endpoints_enabled != null ? [1] : []
+    for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null || var.ip_endpoints_enabled != null ? [1] : []
     content {
       dynamic "dns_endpoint_config" {
-        for_each = var.dns_allow_external_traffic != null ? [1] : []
+        for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null ? [1] : []
         content {
-          allow_external_traffic = var.dns_allow_external_traffic
+          allow_external_traffic    = var.dns_allow_external_traffic
+          enable_k8s_tokens_via_dns = var.dns_enable_k8s_tokens_via_dns
         }
       }
       dynamic "ip_endpoints_config" {

--- a/modules/beta-public-cluster-update-variant/metadata.display.yaml
+++ b/modules/beta-public-cluster-update-variant/metadata.display.yaml
@@ -127,6 +127,9 @@ spec:
         dns_cache:
           name: dns_cache
           title: Dns Cache
+        dns_enable_k8s_tokens_via_dns:
+          name: dns_enable_k8s_tokens_via_dns
+          title: Dns Enable K8s Tokens Via Dns
         enable_binary_authorization:
           name: enable_binary_authorization
           title: Enable Binary Authorization

--- a/modules/beta-public-cluster-update-variant/metadata.yaml
+++ b/modules/beta-public-cluster-update-variant/metadata.yaml
@@ -790,6 +790,9 @@ spec:
       - name: dns_allow_external_traffic
         description: (Optional) Controls whether external traffic is allowed over the dns endpoint.
         varType: bool
+      - name: dns_enable_k8s_tokens_via_dns
+        description: (Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint.
+        varType: bool
       - name: ip_endpoints_enabled
         description: (Optional) Controls whether to allow direct IP access. Defaults to `true`.
         varType: bool

--- a/modules/beta-public-cluster-update-variant/variables.tf
+++ b/modules/beta-public-cluster-update-variant/variables.tf
@@ -1099,6 +1099,12 @@ variable "dns_allow_external_traffic" {
   default     = null
 }
 
+variable "dns_enable_k8s_tokens_via_dns" {
+  description = "(Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint."
+  type        = bool
+  default     = null
+}
+
 variable "ip_endpoints_enabled" {
   description = "(Optional) Controls whether to allow direct IP access. Defaults to `true`."
   type        = bool

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -173,6 +173,7 @@ Then perform the following commands on the root folder:
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | `bool` | `true` | no |
 | dns\_allow\_external\_traffic | (Optional) Controls whether external traffic is allowed over the dns endpoint. | `bool` | `null` | no |
 | dns\_cache | The status of the NodeLocal DNSCache addon. | `bool` | `false` | no |
+| dns\_enable\_k8s\_tokens\_via\_dns | (Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint. | `bool` | `null` | no |
 | enable\_binary\_authorization | Enable BinAuthZ Admission controller | `bool` | `false` | no |
 | enable\_cilium\_clusterwide\_network\_policy | Enable Cilium Cluster Wide Network Policies on the cluster | `bool` | `false` | no |
 | enable\_confidential\_nodes | An optional flag to enable confidential node config. | `bool` | `false` | no |

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -678,12 +678,13 @@ resource "google_container_cluster" "primary" {
   }
 
   dynamic "control_plane_endpoints_config" {
-    for_each = var.dns_allow_external_traffic != null || var.ip_endpoints_enabled != null ? [1] : []
+    for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null || var.ip_endpoints_enabled != null ? [1] : []
     content {
       dynamic "dns_endpoint_config" {
-        for_each = var.dns_allow_external_traffic != null ? [1] : []
+        for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null ? [1] : []
         content {
-          allow_external_traffic = var.dns_allow_external_traffic
+          allow_external_traffic    = var.dns_allow_external_traffic
+          enable_k8s_tokens_via_dns = var.dns_enable_k8s_tokens_via_dns
         }
       }
       dynamic "ip_endpoints_config" {

--- a/modules/beta-public-cluster/metadata.display.yaml
+++ b/modules/beta-public-cluster/metadata.display.yaml
@@ -127,6 +127,9 @@ spec:
         dns_cache:
           name: dns_cache
           title: Dns Cache
+        dns_enable_k8s_tokens_via_dns:
+          name: dns_enable_k8s_tokens_via_dns
+          title: Dns Enable K8s Tokens Via Dns
         enable_binary_authorization:
           name: enable_binary_authorization
           title: Enable Binary Authorization

--- a/modules/beta-public-cluster/metadata.yaml
+++ b/modules/beta-public-cluster/metadata.yaml
@@ -790,6 +790,9 @@ spec:
       - name: dns_allow_external_traffic
         description: (Optional) Controls whether external traffic is allowed over the dns endpoint.
         varType: bool
+      - name: dns_enable_k8s_tokens_via_dns
+        description: (Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint.
+        varType: bool
       - name: ip_endpoints_enabled
         description: (Optional) Controls whether to allow direct IP access. Defaults to `true`.
         varType: bool

--- a/modules/beta-public-cluster/variables.tf
+++ b/modules/beta-public-cluster/variables.tf
@@ -1099,6 +1099,12 @@ variable "dns_allow_external_traffic" {
   default     = null
 }
 
+variable "dns_enable_k8s_tokens_via_dns" {
+  description = "(Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint."
+  type        = bool
+  default     = null
+}
+
 variable "ip_endpoints_enabled" {
   description = "(Optional) Controls whether to allow direct IP access. Defaults to `true`."
   type        = bool

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -197,6 +197,7 @@ Then perform the following commands on the root folder:
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | `bool` | `true` | no |
 | dns\_allow\_external\_traffic | (Optional) Controls whether external traffic is allowed over the dns endpoint. | `bool` | `null` | no |
 | dns\_cache | The status of the NodeLocal DNSCache addon. | `bool` | `false` | no |
+| dns\_enable\_k8s\_tokens\_via\_dns | (Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint. | `bool` | `null` | no |
 | enable\_binary\_authorization | Enable BinAuthZ Admission controller | `bool` | `false` | no |
 | enable\_cilium\_clusterwide\_network\_policy | Enable Cilium Cluster Wide Network Policies on the cluster | `bool` | `false` | no |
 | enable\_confidential\_nodes | An optional flag to enable confidential node config. | `bool` | `false` | no |

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -658,12 +658,13 @@ resource "google_container_cluster" "primary" {
   }
 
   dynamic "control_plane_endpoints_config" {
-    for_each = var.dns_allow_external_traffic != null || var.ip_endpoints_enabled != null ? [1] : []
+    for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null || var.ip_endpoints_enabled != null ? [1] : []
     content {
       dynamic "dns_endpoint_config" {
-        for_each = var.dns_allow_external_traffic != null ? [1] : []
+        for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null ? [1] : []
         content {
-          allow_external_traffic = var.dns_allow_external_traffic
+          allow_external_traffic    = var.dns_allow_external_traffic
+          enable_k8s_tokens_via_dns = var.dns_enable_k8s_tokens_via_dns
         }
       }
       dynamic "ip_endpoints_config" {

--- a/modules/private-cluster-update-variant/metadata.display.yaml
+++ b/modules/private-cluster-update-variant/metadata.display.yaml
@@ -121,6 +121,9 @@ spec:
         dns_cache:
           name: dns_cache
           title: Dns Cache
+        dns_enable_k8s_tokens_via_dns:
+          name: dns_enable_k8s_tokens_via_dns
+          title: Dns Enable K8s Tokens Via Dns
         enable_binary_authorization:
           name: enable_binary_authorization
           title: Enable Binary Authorization

--- a/modules/private-cluster-update-variant/metadata.yaml
+++ b/modules/private-cluster-update-variant/metadata.yaml
@@ -777,6 +777,9 @@ spec:
       - name: dns_allow_external_traffic
         description: (Optional) Controls whether external traffic is allowed over the dns endpoint.
         varType: bool
+      - name: dns_enable_k8s_tokens_via_dns
+        description: (Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint.
+        varType: bool
       - name: ip_endpoints_enabled
         description: (Optional) Controls whether to allow direct IP access. Defaults to `true`.
         varType: bool

--- a/modules/private-cluster-update-variant/variables.tf
+++ b/modules/private-cluster-update-variant/variables.tf
@@ -1081,6 +1081,12 @@ variable "dns_allow_external_traffic" {
   default     = null
 }
 
+variable "dns_enable_k8s_tokens_via_dns" {
+  description = "(Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint."
+  type        = bool
+  default     = null
+}
+
 variable "ip_endpoints_enabled" {
   description = "(Optional) Controls whether to allow direct IP access. Defaults to `true`."
   type        = bool

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -175,6 +175,7 @@ Then perform the following commands on the root folder:
 | disable\_legacy\_metadata\_endpoints | Disable the /0.1/ and /v1beta1/ metadata server endpoints on the node. Changing this value will cause all node pools to be recreated. | `bool` | `true` | no |
 | dns\_allow\_external\_traffic | (Optional) Controls whether external traffic is allowed over the dns endpoint. | `bool` | `null` | no |
 | dns\_cache | The status of the NodeLocal DNSCache addon. | `bool` | `false` | no |
+| dns\_enable\_k8s\_tokens\_via\_dns | (Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint. | `bool` | `null` | no |
 | enable\_binary\_authorization | Enable BinAuthZ Admission controller | `bool` | `false` | no |
 | enable\_cilium\_clusterwide\_network\_policy | Enable Cilium Cluster Wide Network Policies on the cluster | `bool` | `false` | no |
 | enable\_confidential\_nodes | An optional flag to enable confidential node config. | `bool` | `false` | no |

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -658,12 +658,13 @@ resource "google_container_cluster" "primary" {
   }
 
   dynamic "control_plane_endpoints_config" {
-    for_each = var.dns_allow_external_traffic != null || var.ip_endpoints_enabled != null ? [1] : []
+    for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null || var.ip_endpoints_enabled != null ? [1] : []
     content {
       dynamic "dns_endpoint_config" {
-        for_each = var.dns_allow_external_traffic != null ? [1] : []
+        for_each = var.dns_allow_external_traffic != null || var.dns_enable_k8s_tokens_via_dns != null ? [1] : []
         content {
-          allow_external_traffic = var.dns_allow_external_traffic
+          allow_external_traffic    = var.dns_allow_external_traffic
+          enable_k8s_tokens_via_dns = var.dns_enable_k8s_tokens_via_dns
         }
       }
       dynamic "ip_endpoints_config" {

--- a/modules/private-cluster/metadata.display.yaml
+++ b/modules/private-cluster/metadata.display.yaml
@@ -121,6 +121,9 @@ spec:
         dns_cache:
           name: dns_cache
           title: Dns Cache
+        dns_enable_k8s_tokens_via_dns:
+          name: dns_enable_k8s_tokens_via_dns
+          title: Dns Enable K8s Tokens Via Dns
         enable_binary_authorization:
           name: enable_binary_authorization
           title: Enable Binary Authorization

--- a/modules/private-cluster/metadata.yaml
+++ b/modules/private-cluster/metadata.yaml
@@ -777,6 +777,9 @@ spec:
       - name: dns_allow_external_traffic
         description: (Optional) Controls whether external traffic is allowed over the dns endpoint.
         varType: bool
+      - name: dns_enable_k8s_tokens_via_dns
+        description: (Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint.
+        varType: bool
       - name: ip_endpoints_enabled
         description: (Optional) Controls whether to allow direct IP access. Defaults to `true`.
         varType: bool

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -1081,6 +1081,12 @@ variable "dns_allow_external_traffic" {
   default     = null
 }
 
+variable "dns_enable_k8s_tokens_via_dns" {
+  description = "(Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint."
+  type        = bool
+  default     = null
+}
+
 variable "ip_endpoints_enabled" {
   description = "(Optional) Controls whether to allow direct IP access. Defaults to `true`."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -1045,6 +1045,12 @@ variable "dns_allow_external_traffic" {
   default     = null
 }
 
+variable "dns_enable_k8s_tokens_via_dns" {
+  description = "(Optional) Controls whether Kubernetes ServiceAccount token authentication is allowed via the DNS endpoint."
+  type        = bool
+  default     = null
+}
+
 variable "ip_endpoints_enabled" {
   description = "(Optional) Controls whether to allow direct IP access. Defaults to `true`."
   type        = bool


### PR DESCRIPTION
## Summary

Expose `enable_k8s_tokens_via_dns` through the module as `dns_enable_k8s_tokens_via_dns` for GKE DNS endpoints.

Fixes #2578

## Changes

- add `dns_enable_k8s_tokens_via_dns` as an optional module variable
- wire the variable into `control_plane_endpoints_config.dns_endpoint_config.enable_k8s_tokens_via_dns`
- regenerate generated module variants and metadata

## Why

This closes a gap in the `private-cluster` module by allowing callers to configure Kubernetes ServiceAccount token authentication over the DNS endpoint without out-of-band workarounds.

## Testing

- `make build`
