### PR TITLE
fix: avoid master_global_access_config drift when private endpoint is disabled

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -803,7 +803,7 @@ resource "google_container_cluster" "primary" {
       master_ipv4_cidr_block      = var.private_endpoint_subnetwork == null ? private_cluster_config.value.master_ipv4_cidr_block : null
       private_endpoint_subnetwork = private_cluster_config.value.private_endpoint_subnetwork
       dynamic "master_global_access_config" {
-        for_each = var.master_global_access_enabled ? [var.master_global_access_enabled] : []
+        for_each = var.master_global_access_enabled && var.enable_private_endpoint ? [var.master_global_access_enabled] : []
         content {
           enabled = master_global_access_config.value
         }

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -423,7 +423,7 @@ resource "google_container_cluster" "primary" {
       master_ipv4_cidr_block      = var.private_endpoint_subnetwork == null ? private_cluster_config.value.master_ipv4_cidr_block : null
       private_endpoint_subnetwork = private_cluster_config.value.private_endpoint_subnetwork
       dynamic "master_global_access_config" {
-        for_each = var.master_global_access_enabled ? [var.master_global_access_enabled] : []
+        for_each = var.master_global_access_enabled && var.enable_private_endpoint ? [var.master_global_access_enabled] : []
         content {
           enabled = master_global_access_config.value
         }

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -691,7 +691,7 @@ resource "google_container_cluster" "primary" {
       master_ipv4_cidr_block      = var.private_endpoint_subnetwork == null ? private_cluster_config.value.master_ipv4_cidr_block : null
       private_endpoint_subnetwork = private_cluster_config.value.private_endpoint_subnetwork
       dynamic "master_global_access_config" {
-        for_each = var.master_global_access_enabled ? [var.master_global_access_enabled] : []
+        for_each = var.master_global_access_enabled && var.enable_private_endpoint ? [var.master_global_access_enabled] : []
         content {
           enabled = master_global_access_config.value
         }

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -691,7 +691,7 @@ resource "google_container_cluster" "primary" {
       master_ipv4_cidr_block      = var.private_endpoint_subnetwork == null ? private_cluster_config.value.master_ipv4_cidr_block : null
       private_endpoint_subnetwork = private_cluster_config.value.private_endpoint_subnetwork
       dynamic "master_global_access_config" {
-        for_each = var.master_global_access_enabled ? [var.master_global_access_enabled] : []
+        for_each = var.master_global_access_enabled && var.enable_private_endpoint ? [var.master_global_access_enabled] : []
         content {
           enabled = master_global_access_config.value
         }

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -649,7 +649,7 @@ resource "google_container_cluster" "primary" {
       master_ipv4_cidr_block      = var.private_endpoint_subnetwork == null ? private_cluster_config.value.master_ipv4_cidr_block : null
       private_endpoint_subnetwork = private_cluster_config.value.private_endpoint_subnetwork
       dynamic "master_global_access_config" {
-        for_each = var.master_global_access_enabled ? [var.master_global_access_enabled] : []
+        for_each = var.master_global_access_enabled && var.enable_private_endpoint ? [var.master_global_access_enabled] : []
         content {
           enabled = master_global_access_config.value
         }

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -649,7 +649,7 @@ resource "google_container_cluster" "primary" {
       master_ipv4_cidr_block      = var.private_endpoint_subnetwork == null ? private_cluster_config.value.master_ipv4_cidr_block : null
       private_endpoint_subnetwork = private_cluster_config.value.private_endpoint_subnetwork
       dynamic "master_global_access_config" {
-        for_each = var.master_global_access_enabled ? [var.master_global_access_enabled] : []
+        for_each = var.master_global_access_enabled && var.enable_private_endpoint ? [var.master_global_access_enabled] : []
         content {
           enabled = master_global_access_config.value
         }


### PR DESCRIPTION
## What does this PR do?

Prevents `master_global_access_config` from being created for clusters with `enable_private_endpoint = false`.

## Why is this needed?

`master_global_access_enabled` defaults to `true`, which causes the module to create `master_global_access_config` even for clusters using public endpoints.

This can lead to permanent Terraform drift where the provider/API continuously reconciles the configuration.

## Changes made

Updated the `master_global_access_config` dynamic block condition so it is created only when both:

* `master_global_access_enabled = true`
* `enable_private_endpoint = true`

Fixes: #2585 