### PR TITLE
fix: avoid empty security_posture_config block

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -539,9 +539,12 @@ resource "google_container_cluster" "primary" {
   }
   {% endif %}
 
-  security_posture_config {
-    mode               = var.security_posture_mode
-    vulnerability_mode = var.security_posture_vulnerability_mode
+  dynamic "security_posture_config" {
+    for_each = var.security_posture_mode != null || var.security_posture_vulnerability_mode != null ? [1] : []
+    content {
+      mode               = var.security_posture_mode
+      vulnerability_mode = var.security_posture_vulnerability_mode
+    }
   }
 
   dynamic "fleet" {

--- a/cluster.tf
+++ b/cluster.tf
@@ -405,10 +405,12 @@ resource "google_container_cluster" "primary" {
 
   datapath_provider = var.datapath_provider
 
-
-  security_posture_config {
-    mode               = var.security_posture_mode
-    vulnerability_mode = var.security_posture_vulnerability_mode
+  dynamic "security_posture_config" {
+    for_each = var.security_posture_mode != null || var.security_posture_vulnerability_mode != null ? [1] : []
+    content {
+      mode               = var.security_posture_mode
+      vulnerability_mode = var.security_posture_vulnerability_mode
+    }
   }
 
   dynamic "fleet" {

--- a/cluster.tf
+++ b/cluster.tf
@@ -405,6 +405,7 @@ resource "google_container_cluster" "primary" {
 
   datapath_provider = var.datapath_provider
 
+
   dynamic "security_posture_config" {
     for_each = var.security_posture_mode != null || var.security_posture_vulnerability_mode != null ? [1] : []
     content {

--- a/modules/beta-autopilot-private-cluster/cluster.tf
+++ b/modules/beta-autopilot-private-cluster/cluster.tf
@@ -308,9 +308,12 @@ resource "google_container_cluster" "primary" {
     workload_vulnerability_mode = var.workload_vulnerability_mode
   }
 
-  security_posture_config {
-    mode               = var.security_posture_mode
-    vulnerability_mode = var.security_posture_vulnerability_mode
+  dynamic "security_posture_config" {
+    for_each = var.security_posture_mode != null || var.security_posture_vulnerability_mode != null ? [1] : []
+    content {
+      mode               = var.security_posture_mode
+      vulnerability_mode = var.security_posture_vulnerability_mode
+    }
   }
 
   dynamic "fleet" {

--- a/modules/beta-autopilot-public-cluster/cluster.tf
+++ b/modules/beta-autopilot-public-cluster/cluster.tf
@@ -308,9 +308,12 @@ resource "google_container_cluster" "primary" {
     workload_vulnerability_mode = var.workload_vulnerability_mode
   }
 
-  security_posture_config {
-    mode               = var.security_posture_mode
-    vulnerability_mode = var.security_posture_vulnerability_mode
+  dynamic "security_posture_config" {
+    for_each = var.security_posture_mode != null || var.security_posture_vulnerability_mode != null ? [1] : []
+    content {
+      mode               = var.security_posture_mode
+      vulnerability_mode = var.security_posture_vulnerability_mode
+    }
   }
 
   dynamic "fleet" {

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -441,9 +441,12 @@ resource "google_container_cluster" "primary" {
     workload_vulnerability_mode = var.workload_vulnerability_mode
   }
 
-  security_posture_config {
-    mode               = var.security_posture_mode
-    vulnerability_mode = var.security_posture_vulnerability_mode
+  dynamic "security_posture_config" {
+    for_each = var.security_posture_mode != null || var.security_posture_vulnerability_mode != null ? [1] : []
+    content {
+      mode               = var.security_posture_mode
+      vulnerability_mode = var.security_posture_vulnerability_mode
+    }
   }
 
   dynamic "fleet" {

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -441,9 +441,12 @@ resource "google_container_cluster" "primary" {
     workload_vulnerability_mode = var.workload_vulnerability_mode
   }
 
-  security_posture_config {
-    mode               = var.security_posture_mode
-    vulnerability_mode = var.security_posture_vulnerability_mode
+  dynamic "security_posture_config" {
+    for_each = var.security_posture_mode != null || var.security_posture_vulnerability_mode != null ? [1] : []
+    content {
+      mode               = var.security_posture_mode
+      vulnerability_mode = var.security_posture_vulnerability_mode
+    }
   }
 
   dynamic "fleet" {

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -441,9 +441,12 @@ resource "google_container_cluster" "primary" {
     workload_vulnerability_mode = var.workload_vulnerability_mode
   }
 
-  security_posture_config {
-    mode               = var.security_posture_mode
-    vulnerability_mode = var.security_posture_vulnerability_mode
+  dynamic "security_posture_config" {
+    for_each = var.security_posture_mode != null || var.security_posture_vulnerability_mode != null ? [1] : []
+    content {
+      mode               = var.security_posture_mode
+      vulnerability_mode = var.security_posture_vulnerability_mode
+    }
   }
 
   dynamic "fleet" {

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -441,9 +441,12 @@ resource "google_container_cluster" "primary" {
     workload_vulnerability_mode = var.workload_vulnerability_mode
   }
 
-  security_posture_config {
-    mode               = var.security_posture_mode
-    vulnerability_mode = var.security_posture_vulnerability_mode
+  dynamic "security_posture_config" {
+    for_each = var.security_posture_mode != null || var.security_posture_vulnerability_mode != null ? [1] : []
+    content {
+      mode               = var.security_posture_mode
+      vulnerability_mode = var.security_posture_vulnerability_mode
+    }
   }
 
   dynamic "fleet" {

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -405,10 +405,12 @@ resource "google_container_cluster" "primary" {
 
   datapath_provider = var.datapath_provider
 
-
-  security_posture_config {
-    mode               = var.security_posture_mode
-    vulnerability_mode = var.security_posture_vulnerability_mode
+  dynamic "security_posture_config" {
+    for_each = var.security_posture_mode != null || var.security_posture_vulnerability_mode != null ? [1] : []
+    content {
+      mode               = var.security_posture_mode
+      vulnerability_mode = var.security_posture_vulnerability_mode
+    }
   }
 
   dynamic "fleet" {

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -405,6 +405,7 @@ resource "google_container_cluster" "primary" {
 
   datapath_provider = var.datapath_provider
 
+
   dynamic "security_posture_config" {
     for_each = var.security_posture_mode != null || var.security_posture_vulnerability_mode != null ? [1] : []
     content {

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -405,10 +405,12 @@ resource "google_container_cluster" "primary" {
 
   datapath_provider = var.datapath_provider
 
-
-  security_posture_config {
-    mode               = var.security_posture_mode
-    vulnerability_mode = var.security_posture_vulnerability_mode
+  dynamic "security_posture_config" {
+    for_each = var.security_posture_mode != null || var.security_posture_vulnerability_mode != null ? [1] : []
+    content {
+      mode               = var.security_posture_mode
+      vulnerability_mode = var.security_posture_vulnerability_mode
+    }
   }
 
   dynamic "fleet" {

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -405,6 +405,7 @@ resource "google_container_cluster" "primary" {
 
   datapath_provider = var.datapath_provider
 
+
   dynamic "security_posture_config" {
     for_each = var.security_posture_mode != null || var.security_posture_vulnerability_mode != null ? [1] : []
     content {


### PR DESCRIPTION
## Summary

Fixes an issue where the module generated an empty `security_posture_config` block when both:

* `security_posture_mode`
* `security_posture_vulnerability_mode`

were unset (`null`).

This caused Terraform apply operations to fail with:

```text
Error 400: Must specify a field to update
```

The issue occurred because the provider still sent an empty nested block to the API even when no security posture configuration values were defined.

---

## Root Cause

Previously, the module always rendered:

```hcl
security_posture_config {
  mode               = var.security_posture_mode
  vulnerability_mode = var.security_posture_vulnerability_mode
}
```

When both variables were `null`, Terraform produced an empty block:

```hcl
security_posture_config {}
```

which resulted in the GKE API rejecting the update request.

---

## Changes Made

Replaced static `security_posture_config` blocks with conditional dynamic blocks across all affected modules and templates.

The block is now rendered only when at least one related variable is non-null:

```hcl
dynamic "security_posture_config" {
  for_each = var.security_posture_mode != null || var.security_posture_vulnerability_mode != null ? [1] : []

  content {
    mode               = var.security_posture_mode
    vulnerability_mode = var.security_posture_vulnerability_mode
  }
}
```

---

## Files Updated

* `cluster.tf`
* `autogen/main/cluster.tf.tmpl`
* `modules/private-cluster/cluster.tf`
* `modules/private-cluster-update-variant/cluster.tf`
* `modules/beta-private-cluster/cluster.tf`
* `modules/beta-private-cluster-update-variant/cluster.tf`
* `modules/beta-public-cluster/cluster.tf`
* `modules/beta-public-cluster-update-variant/cluster.tf`
* `modules/beta-autopilot-private-cluster/cluster.tf`
* `modules/beta-autopilot-public-cluster/cluster.tf`

---

## Validation

* Ran `terraform fmt -recursive`
* Ran `terraform validate`
* Verified all static `security_posture_config` blocks were replaced
* Confirmed no remaining unconditional block definitions exist

---

## Related Issue

Closes #2583
