### PR TITLE
feat(workload-identity)!: replace kubectl-wrapper with native kubernetes_annotations

### DIFF
--- a/docs/upgrading_to_v45.0.md
+++ b/docs/upgrading_to_v45.0.md
@@ -1,0 +1,88 @@
+# Upgrading to v45.0
+
+The v45.0 release of *terraform-google-kubernetes-engine* contains breaking interface changes in the `workload-identity` submodule.
+
+## Workload Identity Submodule (`modules/workload-identity`)
+
+### 1. Native `kubernetes_annotations` Replacement
+
+The `workload-identity` submodule no longer uses `kubectl-wrapper` (`local-exec` bash script execution) to annotate existing Kubernetes Service Accounts. Instead, it uses the native [`kubernetes_annotations`](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/annotations) resource from the `hashicorp/kubernetes` provider.
+
+#### Kubernetes Provider Prerequisite
+Because `kubernetes_annotations` is a native Terraform provider resource, callers **must** have an initialized and authenticated `kubernetes` provider configured in their root module context:
+
+```hcl
+provider "kubernetes" {
+  host                   = "https://${module.gke.endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(module.gke.ca_certificate)
+}
+```
+
+> **Note:** If you previously configured `ignore_annotations` in your `kubernetes` provider block to ignore Workload Identity annotations (e.g., `ignore_annotations = ["^iam.gke.io\\/.*"]`) to prevent conflicts with the legacy `kubectl-wrapper`, you must remove that configuration. Otherwise, the new native `kubernetes_annotations` resource will not function correctly.
+
+---
+
+### 2. Removed Input Variables
+
+The following input variables were previously used to configure `gcloud container clusters get-credentials` and `kubectl` inside `kubectl_wrapper.sh`. They have been removed as they are no longer required by the module:
+
+- `cluster_name`
+- `location`
+- `impersonate_service_account`
+- `use_existing_context`
+
+#### Expected Error if Unchanged
+If you attempt to apply module calls containing these deleted inputs, Terraform will return an error during configuration validation:
+
+```text
+Error: Unsupported argument
+
+  on main.tf line 32, in module "workload_identity":
+  32:   cluster_name = module.gke.name
+
+An argument named "cluster_name" is not expected here.
+```
+
+#### Migration Example
+
+Update your `module "workload_identity"` calls to remove the deleted arguments:
+
+```diff
+module "workload_identity" {
+  source  = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
+-  version = "~> 44.0"
++  version = "~> 45.0"
+
+  project_id          = var.project_id
+  name                = "my-app"
+-  cluster_name        = module.gke.name
+-  location            = module.gke.location
+  namespace           = "default"
+  use_existing_k8s_sa = true
+  k8s_sa_name         = "existing-ksa"
+}
+```
+
+---
+
+### 3. State Migration Strategy
+
+For existing deployments where `use_existing_k8s_sa = true` and `annotate_k8s_sa = true`:
+
+1. Terraform will plan to destroy the legacy `module.annotate-sa` resources and create `kubernetes_annotations.main[0]`.
+2. `kubernetes_annotations.main[0]` uses `force = true` and Server-Side Apply to adopt the existing `"iam.gke.io/gcp-service-account"` annotation seamlessly.
+3. **Proactive State Cleanup for CI/CD Runners:** Standard CI/CD runner environments (Terraform Cloud, Spacelift, Atlantis, minimal GitHub Actions runners) typically lack local `gcloud` and `kubectl` binaries. Attempting to run `terraform apply` directly may fail during the destroy phase of `module.annotate-sa`.
+
+To prevent build failures, remove the legacy module state **prior to running `terraform apply`**:
+
+```bash
+# Standard module call
+terraform state rm 'module.workload_identity.module.annotate-sa'
+
+# Module call using count or for_each
+terraform state rm 'module.workload_identity["app"].module.annotate-sa'
+terraform state rm 'module.workload_identity[0].module.annotate-sa'
+```
+
+*Note: Deployments created with `use_existing_k8s_sa = false` (default) do not use `module.annotate-sa` and require no state migration.*

--- a/examples/acm-terraform-blog-part3/terraform/gke.tf
+++ b/examples/acm-terraform-blog-part3/terraform/gke.tf
@@ -50,9 +50,7 @@ module "wi" {
   source              = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
   version             = "~> 44.0"
   gcp_sa_name         = "cnrmsa"
-  cluster_name        = module.gke.name
   name                = "cnrm-controller-manager"
-  location            = var.zone
   use_existing_k8s_sa = true
   annotate_k8s_sa     = false
   namespace           = "cnrm-system"

--- a/examples/workload_identity/main.tf
+++ b/examples/workload_identity/main.tf
@@ -79,8 +79,6 @@ module "workload_identity_existing_ksa" {
 
   project_id          = var.project_id
   name                = "existing-${module.gke.name}"
-  cluster_name        = module.gke.name
-  location            = module.gke.location
   namespace           = "default"
   use_existing_k8s_sa = true
   k8s_sa_name         = kubernetes_service_account_v1.test.metadata[0].name
@@ -101,5 +99,8 @@ module "workload_identity_existing_gsa" {
   use_existing_gcp_sa = true
   # wait till custom GSA is created to force module data source read during apply
   # https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1059
-  depends_on = [google_service_account.custom]
+  depends_on = [
+    google_service_account.custom,
+    module.gke,
+  ]
 }

--- a/modules/workload-identity/README.md
+++ b/modules/workload-identity/README.md
@@ -83,8 +83,6 @@ resource "kubernetes_service_account_v1" "preexisting" {
 module "my-app-workload-identity" {
   source              = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
   use_existing_k8s_sa = true
-  cluster_name        = "my-k8s-cluster-name"
-  location            = "my-k8s-cluster-location"
   name                = kubernetes_service_account_v1.preexisting.metadata[0].name
   namespace           = kubernetes_service_account_v1.preexisting.metadata[0].namespace
   project_id          = var.project_id
@@ -147,22 +145,18 @@ Error: Get "http://localhost/api/v1/namespaces/default/serviceaccounts/your-serv
 | additional\_projects | A list of roles to be added to the created service account for additional projects | `map(list(string))` | `{}` | no |
 | annotate\_k8s\_sa | Annotate the kubernetes service account with 'iam.gke.io/gcp-service-account' annotation. Valid in cases when an existing SA is used. | `bool` | `true` | no |
 | automount\_service\_account\_token | Enable automatic mounting of the service account token | `bool` | `false` | no |
-| cluster\_name | Cluster name. Required if using existing KSA. | `string` | `""` | no |
 | gcp\_sa\_create\_ignore\_already\_exists | If set to true, skip service account creation if a service account with the same email already exists. | `bool` | `null` | no |
 | gcp\_sa\_description | The Service Google service account desciption; if null, will be left out | `string` | `null` | no |
 | gcp\_sa\_display\_name | The Google service account display name; if null, a default string will be used | `string` | `null` | no |
 | gcp\_sa\_name | Name for the Google service account; overrides `var.name`. | `string` | `null` | no |
 | image\_pull\_secrets | A list of references to secrets in the same namespace to use for pulling any images in pods that reference this Service Account | `list(string)` | `[]` | no |
-| impersonate\_service\_account | An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials. | `string` | `""` | no |
-| k8s\_sa\_name | Name for the Kubernetes service account; overrides `var.name`. `cluster_name` and `location` must be set when this input is specified. | `string` | `null` | no |
+| k8s\_sa\_name | Name for the Kubernetes service account; overrides `var.name`. | `string` | `null` | no |
 | k8s\_sa\_project\_id | GCP project ID of the k8s service account; overrides `var.project_id`. | `string` | `null` | no |
-| location | Cluster location (region if regional cluster, zone if zonal cluster). Required if using existing KSA. | `string` | `""` | no |
 | module\_depends\_on | List of modules or resources to depend on before annotating KSA. If multiple, all items must be the same type. | `list(any)` | `[]` | no |
 | name | Name for both service accounts. The GCP SA will be truncated to the first 30 chars if necessary. | `string` | n/a | yes |
 | namespace | Namespace for the Kubernetes service account | `string` | `"default"` | no |
 | project\_id | GCP project ID | `string` | n/a | yes |
 | roles | A list of roles to be added to the created service account | `list(string)` | `[]` | no |
-| use\_existing\_context | An optional flag to use local kubectl config context. | `bool` | `false` | no |
 | use\_existing\_gcp\_sa | Use an existing Google service account instead of creating one | `bool` | `false` | no |
 | use\_existing\_k8s\_sa | Use an existing kubernetes service account instead of creating one | `bool` | `false` | no |
 

--- a/modules/workload-identity/main.tf
+++ b/modules/workload-identity/main.tf
@@ -27,7 +27,7 @@ locals {
   output_k8s_namespace = var.use_existing_k8s_sa ? var.namespace : kubernetes_service_account_v1.main[0].metadata[0].namespace
 
   k8s_sa_project_id       = var.k8s_sa_project_id != null ? var.k8s_sa_project_id : var.project_id
-  k8s_sa_gcp_derived_name = "serviceAccount:${local.k8s_sa_project_id}.svc.id.goog[${var.namespace}/${local.output_k8s_name}]"
+  k8s_sa_gcp_derived_name = "serviceAccount:${local.k8s_sa_project_id}.svc.id.goog[${var.namespace}/${local.k8s_given_name}]"
 
   sa_binding_additional_project = distinct(flatten([for project, roles in var.additional_projects : [for role in roles : { project_id = project, role_name = role }]]))
 }
@@ -74,30 +74,44 @@ resource "kubernetes_service_account_v1" "main" {
       "iam.gke.io/gcp-service-account" = local.gcp_sa_email
     }
   }
+
+  depends_on = [
+    google_service_account_iam_member.main,
+    var.module_depends_on,
+  ]
 }
 
-module "annotate-sa" {
-  source  = "terraform-google-modules/gcloud/google//modules/kubectl-wrapper"
-  version = "~> 4.0"
+resource "kubernetes_annotations" "main" {
+  count = var.use_existing_k8s_sa && var.annotate_k8s_sa ? 1 : 0
 
-  enabled                     = var.use_existing_k8s_sa && var.annotate_k8s_sa
-  skip_download               = true
-  cluster_name                = var.cluster_name
-  cluster_location            = var.location
-  project_id                  = local.k8s_sa_project_id
-  impersonate_service_account = var.impersonate_service_account
-  use_existing_context        = var.use_existing_context
+  api_version = "v1"
+  kind        = "ServiceAccount"
 
-  kubectl_create_command  = "kubectl annotate --overwrite sa -n ${local.output_k8s_namespace} ${local.k8s_given_name} iam.gke.io/gcp-service-account=${local.gcp_sa_email}"
-  kubectl_destroy_command = "kubectl annotate sa -n ${local.output_k8s_namespace} ${local.k8s_given_name} iam.gke.io/gcp-service-account-"
+  metadata {
+    name      = local.k8s_given_name
+    namespace = local.output_k8s_namespace
+  }
 
-  module_depends_on = var.module_depends_on
+  annotations = {
+    "iam.gke.io/gcp-service-account" = local.gcp_sa_email
+  }
+
+  force = true
+
+  depends_on = [
+    google_service_account_iam_member.main,
+    var.module_depends_on,
+  ]
 }
 
 resource "google_service_account_iam_member" "main" {
   service_account_id = var.use_existing_gcp_sa ? data.google_service_account.cluster_service_account[0].name : google_service_account.cluster_service_account[0].name
   role               = "roles/iam.workloadIdentityUser"
   member             = local.k8s_sa_gcp_derived_name
+
+  depends_on = [
+    var.module_depends_on,
+  ]
 }
 
 resource "google_project_iam_member" "workload_identity_sa_bindings" {

--- a/modules/workload-identity/metadata.display.yaml
+++ b/modules/workload-identity/metadata.display.yaml
@@ -37,9 +37,6 @@ spec:
         automount_service_account_token:
           name: automount_service_account_token
           title: Automount Service Account Token
-        cluster_name:
-          name: cluster_name
-          title: Cluster Name
         gcp_sa_create_ignore_already_exists:
           name: gcp_sa_create_ignore_already_exists
           title: Gcp Sa Create Ignore Already Exists
@@ -55,18 +52,12 @@ spec:
         image_pull_secrets:
           name: image_pull_secrets
           title: Image Pull Secrets
-        impersonate_service_account:
-          name: impersonate_service_account
-          title: Impersonate Service Account
         k8s_sa_name:
           name: k8s_sa_name
           title: K8s Sa Name
         k8s_sa_project_id:
           name: k8s_sa_project_id
           title: K8s Sa Project Id
-        location:
-          name: location
-          title: Location
         module_depends_on:
           name: module_depends_on
           title: Module Depends On
@@ -82,9 +73,6 @@ spec:
         roles:
           name: roles
           title: Roles
-        use_existing_context:
-          name: use_existing_context
-          title: Use Existing Context
         use_existing_gcp_sa:
           name: use_existing_gcp_sa
           title: Use Existing Gcp Sa

--- a/modules/workload-identity/metadata.yaml
+++ b/modules/workload-identity/metadata.yaml
@@ -145,16 +145,8 @@ spec:
         description: Use an existing Google service account instead of creating one
         varType: bool
         defaultValue: false
-      - name: cluster_name
-        description: Cluster name. Required if using existing KSA.
-        varType: string
-        defaultValue: ""
-      - name: location
-        description: Cluster location (region if regional cluster, zone if zonal cluster). Required if using existing KSA.
-        varType: string
-        defaultValue: ""
       - name: k8s_sa_name
-        description: Name for the Kubernetes service account; overrides `var.name`. `cluster_name` and `location` must be set when this input is specified.
+        description: Name for the Kubernetes service account; overrides `var.name`.
         varType: string
       - name: k8s_sa_project_id
         description: GCP project ID of the k8s service account; overrides `var.project_id`.
@@ -183,14 +175,6 @@ spec:
         description: A list of roles to be added to the created service account
         varType: list(string)
         defaultValue: []
-      - name: impersonate_service_account
-        description: An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials.
-        varType: string
-        defaultValue: ""
-      - name: use_existing_context
-        description: An optional flag to use local kubectl config context.
-        varType: bool
-        defaultValue: false
       - name: module_depends_on
         description: List of modules or resources to depend on before annotating KSA. If multiple, all items must be the same type.
         varType: list(any)

--- a/modules/workload-identity/variables.tf
+++ b/modules/workload-identity/variables.tf
@@ -36,20 +36,9 @@ variable "use_existing_gcp_sa" {
   default     = false
 }
 
-variable "cluster_name" {
-  description = "Cluster name. Required if using existing KSA."
-  type        = string
-  default     = ""
-}
-
-variable "location" {
-  description = "Cluster location (region if regional cluster, zone if zonal cluster). Required if using existing KSA."
-  type        = string
-  default     = ""
-}
 
 variable "k8s_sa_name" {
-  description = "Name for the Kubernetes service account; overrides `var.name`. `cluster_name` and `location` must be set when this input is specified."
+  description = "Name for the Kubernetes service account; overrides `var.name`."
   type        = string
   default     = null
 }
@@ -96,17 +85,6 @@ variable "roles" {
   default     = []
 }
 
-variable "impersonate_service_account" {
-  description = "An optional service account to impersonate for gcloud commands. If this service account is not specified, the module will use Application Default Credentials."
-  type        = string
-  default     = ""
-}
-
-variable "use_existing_context" {
-  description = "An optional flag to use local kubectl config context."
-  type        = bool
-  default     = false
-}
 
 variable "module_depends_on" {
   description = "List of modules or resources to depend on before annotating KSA. If multiple, all items must be the same type."


### PR DESCRIPTION
Replace the legacy `module "annotate-sa"` (which executed `kubectl_wrapper.sh` via local-exec) in `modules/workload-identity` with the native `resource "kubernetes_annotations" "main"` from `hashicorp/kubernetes`.

This resolves Python `AttributeError: 'Credentials' object has no attribute 'private_key_id'` failures in `gke-gcloud-auth-plugin` / `gcloud config config-helper` when executing inside keyless authentication pipelines (Service Account Impersonation, Workload Identity Federation, ADC).

Key changes:
- Replace `kubectl-wrapper` local-exec bash execution with declarative `kubernetes_annotations` using Server-Side Apply (`force = true`).
- Remove obsolete input variables (`cluster_name`, `location`, `impersonate_service_account`, `use_existing_context`).
- Ensure `google_service_account_iam_member.main` and `var.module_depends_on` are explicitly included in `depends_on` for both KSA creation and annotation resources to prevent IAM propagation race conditions.
- Update module metadata (`metadata.yaml`, `metadata.display.yaml`), README, and examples.
- Add upgrade guide `docs/upgrading_to_v45.0.md` detailing breaking changes, provider prerequisites, and state migration.