### PR TITLE
fix: make add_shadow_firewall_rules independent of add_cluster_firewall_rules

### DIFF
--- a/autogen/main/main.tf.tmpl
+++ b/autogen/main/main.tf.tmpl
@@ -90,12 +90,12 @@ locals {
   default_auto_upgrade = var.regional || var.release_channel != "UNSPECIFIED" ? true : false
 {% endif %}
 
-  cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
-  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
+  cluster_subnet_cidr       = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
+  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
 {% if autopilot_cluster != true %}
-  pod_all_ip_ranges         = var.add_cluster_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0], [for k, v in merge(local.node_pools, local.windows_node_pools) : local.cluster_alias_ranges_cidr[v.pod_range] if length(lookup(v, "pod_range", "")) > 0])) : []
+  pod_all_ip_ranges         = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0], [for k, v in merge(local.node_pools, local.windows_node_pools) : local.cluster_alias_ranges_cidr[v.pod_range] if length(lookup(v, "pod_range", "")) > 0])) : []
 {% else %}
-  pod_all_ip_ranges         = var.add_cluster_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0])) : []
+  pod_all_ip_ranges         = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0])) : []
 {% endif %}
 
 {% if autopilot_cluster != true %}

--- a/autogen/main/networks.tf.tmpl
+++ b/autogen/main/networks.tf.tmpl
@@ -19,7 +19,7 @@
 data "google_compute_subnetwork" "gke_subnetwork" {
   provider = google
 
-  count   = var.add_cluster_firewall_rules ? 1 : 0
+  count   = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? 1 : 0
   name    = var.subnetwork
   region  = local.region
   project = local.network_project_id

--- a/main.tf
+++ b/main.tf
@@ -78,9 +78,9 @@ locals {
   // When a release channel is used, node auto-upgrade is enabled and cannot be disabled.
   default_auto_upgrade = var.regional || var.release_channel != "UNSPECIFIED" ? true : false
 
-  cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
-  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
-  pod_all_ip_ranges         = var.add_cluster_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0], [for k, v in merge(local.node_pools, local.windows_node_pools) : local.cluster_alias_ranges_cidr[v.pod_range] if length(lookup(v, "pod_range", "")) > 0])) : []
+  cluster_subnet_cidr       = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
+  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
+  pod_all_ip_ranges         = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0], [for k, v in merge(local.node_pools, local.windows_node_pools) : local.cluster_alias_ranges_cidr[v.pod_range] if length(lookup(v, "pod_range", "")) > 0])) : []
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/modules/beta-autopilot-private-cluster/main.tf
+++ b/modules/beta-autopilot-private-cluster/main.tf
@@ -60,9 +60,9 @@ locals {
   zone_count         = length(var.zones)
   cluster_type       = var.regional ? "regional" : "zonal"
 
-  cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
-  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
-  pod_all_ip_ranges         = var.add_cluster_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0])) : []
+  cluster_subnet_cidr       = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
+  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
+  pod_all_ip_ranges         = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0])) : []
 
   gke_backup_agent_config = var.gke_backup_agent_config ? [{ enabled = true }] : [{ enabled = false }]
   stateful_ha_config      = var.stateful_ha ? [{ enabled = true }] : []

--- a/modules/beta-autopilot-private-cluster/networks.tf
+++ b/modules/beta-autopilot-private-cluster/networks.tf
@@ -19,7 +19,7 @@
 data "google_compute_subnetwork" "gke_subnetwork" {
   provider = google
 
-  count   = var.add_cluster_firewall_rules ? 1 : 0
+  count   = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? 1 : 0
   name    = var.subnetwork
   region  = local.region
   project = local.network_project_id

--- a/modules/beta-autopilot-public-cluster/main.tf
+++ b/modules/beta-autopilot-public-cluster/main.tf
@@ -60,9 +60,9 @@ locals {
   zone_count         = length(var.zones)
   cluster_type       = var.regional ? "regional" : "zonal"
 
-  cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
-  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
-  pod_all_ip_ranges         = var.add_cluster_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0])) : []
+  cluster_subnet_cidr       = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
+  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
+  pod_all_ip_ranges         = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0])) : []
 
   gke_backup_agent_config = var.gke_backup_agent_config ? [{ enabled = true }] : [{ enabled = false }]
   stateful_ha_config      = var.stateful_ha ? [{ enabled = true }] : []

--- a/modules/beta-autopilot-public-cluster/networks.tf
+++ b/modules/beta-autopilot-public-cluster/networks.tf
@@ -19,7 +19,7 @@
 data "google_compute_subnetwork" "gke_subnetwork" {
   provider = google
 
-  count   = var.add_cluster_firewall_rules ? 1 : 0
+  count   = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? 1 : 0
   name    = var.subnetwork
   region  = local.region
   project = local.network_project_id

--- a/modules/beta-private-cluster-update-variant/main.tf
+++ b/modules/beta-private-cluster-update-variant/main.tf
@@ -78,9 +78,9 @@ locals {
   // When a release channel is used, node auto-upgrade is enabled and cannot be disabled.
   default_auto_upgrade = var.regional || var.release_channel != "UNSPECIFIED" ? true : false
 
-  cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
-  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
-  pod_all_ip_ranges         = var.add_cluster_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0], [for k, v in merge(local.node_pools, local.windows_node_pools) : local.cluster_alias_ranges_cidr[v.pod_range] if length(lookup(v, "pod_range", "")) > 0])) : []
+  cluster_subnet_cidr       = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
+  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
+  pod_all_ip_ranges         = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0], [for k, v in merge(local.node_pools, local.windows_node_pools) : local.cluster_alias_ranges_cidr[v.pod_range] if length(lookup(v, "pod_range", "")) > 0])) : []
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/modules/beta-private-cluster-update-variant/networks.tf
+++ b/modules/beta-private-cluster-update-variant/networks.tf
@@ -19,7 +19,7 @@
 data "google_compute_subnetwork" "gke_subnetwork" {
   provider = google
 
-  count   = var.add_cluster_firewall_rules ? 1 : 0
+  count   = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? 1 : 0
   name    = var.subnetwork
   region  = local.region
   project = local.network_project_id

--- a/modules/beta-private-cluster/main.tf
+++ b/modules/beta-private-cluster/main.tf
@@ -78,9 +78,9 @@ locals {
   // When a release channel is used, node auto-upgrade is enabled and cannot be disabled.
   default_auto_upgrade = var.regional || var.release_channel != "UNSPECIFIED" ? true : false
 
-  cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
-  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
-  pod_all_ip_ranges         = var.add_cluster_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0], [for k, v in merge(local.node_pools, local.windows_node_pools) : local.cluster_alias_ranges_cidr[v.pod_range] if length(lookup(v, "pod_range", "")) > 0])) : []
+  cluster_subnet_cidr       = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
+  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
+  pod_all_ip_ranges         = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0], [for k, v in merge(local.node_pools, local.windows_node_pools) : local.cluster_alias_ranges_cidr[v.pod_range] if length(lookup(v, "pod_range", "")) > 0])) : []
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/modules/beta-private-cluster/networks.tf
+++ b/modules/beta-private-cluster/networks.tf
@@ -19,7 +19,7 @@
 data "google_compute_subnetwork" "gke_subnetwork" {
   provider = google
 
-  count   = var.add_cluster_firewall_rules ? 1 : 0
+  count   = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? 1 : 0
   name    = var.subnetwork
   region  = local.region
   project = local.network_project_id

--- a/modules/beta-public-cluster-update-variant/main.tf
+++ b/modules/beta-public-cluster-update-variant/main.tf
@@ -78,9 +78,9 @@ locals {
   // When a release channel is used, node auto-upgrade is enabled and cannot be disabled.
   default_auto_upgrade = var.regional || var.release_channel != "UNSPECIFIED" ? true : false
 
-  cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
-  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
-  pod_all_ip_ranges         = var.add_cluster_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0], [for k, v in merge(local.node_pools, local.windows_node_pools) : local.cluster_alias_ranges_cidr[v.pod_range] if length(lookup(v, "pod_range", "")) > 0])) : []
+  cluster_subnet_cidr       = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
+  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
+  pod_all_ip_ranges         = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0], [for k, v in merge(local.node_pools, local.windows_node_pools) : local.cluster_alias_ranges_cidr[v.pod_range] if length(lookup(v, "pod_range", "")) > 0])) : []
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/modules/beta-public-cluster-update-variant/networks.tf
+++ b/modules/beta-public-cluster-update-variant/networks.tf
@@ -19,7 +19,7 @@
 data "google_compute_subnetwork" "gke_subnetwork" {
   provider = google
 
-  count   = var.add_cluster_firewall_rules ? 1 : 0
+  count   = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? 1 : 0
   name    = var.subnetwork
   region  = local.region
   project = local.network_project_id

--- a/modules/beta-public-cluster/main.tf
+++ b/modules/beta-public-cluster/main.tf
@@ -78,9 +78,9 @@ locals {
   // When a release channel is used, node auto-upgrade is enabled and cannot be disabled.
   default_auto_upgrade = var.regional || var.release_channel != "UNSPECIFIED" ? true : false
 
-  cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
-  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
-  pod_all_ip_ranges         = var.add_cluster_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0], [for k, v in merge(local.node_pools, local.windows_node_pools) : local.cluster_alias_ranges_cidr[v.pod_range] if length(lookup(v, "pod_range", "")) > 0])) : []
+  cluster_subnet_cidr       = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
+  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
+  pod_all_ip_ranges         = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0], [for k, v in merge(local.node_pools, local.windows_node_pools) : local.cluster_alias_ranges_cidr[v.pod_range] if length(lookup(v, "pod_range", "")) > 0])) : []
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/modules/beta-public-cluster/networks.tf
+++ b/modules/beta-public-cluster/networks.tf
@@ -19,7 +19,7 @@
 data "google_compute_subnetwork" "gke_subnetwork" {
   provider = google
 
-  count   = var.add_cluster_firewall_rules ? 1 : 0
+  count   = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? 1 : 0
   name    = var.subnetwork
   region  = local.region
   project = local.network_project_id

--- a/modules/private-cluster-update-variant/main.tf
+++ b/modules/private-cluster-update-variant/main.tf
@@ -78,9 +78,9 @@ locals {
   // When a release channel is used, node auto-upgrade is enabled and cannot be disabled.
   default_auto_upgrade = var.regional || var.release_channel != "UNSPECIFIED" ? true : false
 
-  cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
-  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
-  pod_all_ip_ranges         = var.add_cluster_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0], [for k, v in merge(local.node_pools, local.windows_node_pools) : local.cluster_alias_ranges_cidr[v.pod_range] if length(lookup(v, "pod_range", "")) > 0])) : []
+  cluster_subnet_cidr       = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
+  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
+  pod_all_ip_ranges         = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0], [for k, v in merge(local.node_pools, local.windows_node_pools) : local.cluster_alias_ranges_cidr[v.pod_range] if length(lookup(v, "pod_range", "")) > 0])) : []
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/modules/private-cluster-update-variant/networks.tf
+++ b/modules/private-cluster-update-variant/networks.tf
@@ -19,7 +19,7 @@
 data "google_compute_subnetwork" "gke_subnetwork" {
   provider = google
 
-  count   = var.add_cluster_firewall_rules ? 1 : 0
+  count   = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? 1 : 0
   name    = var.subnetwork
   region  = local.region
   project = local.network_project_id

--- a/modules/private-cluster/main.tf
+++ b/modules/private-cluster/main.tf
@@ -78,9 +78,9 @@ locals {
   // When a release channel is used, node auto-upgrade is enabled and cannot be disabled.
   default_auto_upgrade = var.regional || var.release_channel != "UNSPECIFIED" ? true : false
 
-  cluster_subnet_cidr       = var.add_cluster_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
-  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
-  pod_all_ip_ranges         = var.add_cluster_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0], [for k, v in merge(local.node_pools, local.windows_node_pools) : local.cluster_alias_ranges_cidr[v.pod_range] if length(lookup(v, "pod_range", "")) > 0])) : []
+  cluster_subnet_cidr       = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? data.google_compute_subnetwork.gke_subnetwork[0].ip_cidr_range : null
+  cluster_alias_ranges_cidr = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? { for range in toset(data.google_compute_subnetwork.gke_subnetwork[0].secondary_ip_range) : range.range_name => range.ip_cidr_range } : {}
+  pod_all_ip_ranges         = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? compact(concat([local.cluster_alias_ranges_cidr[var.ip_range_pods]], [for range in var.additional_ip_range_pods : local.cluster_alias_ranges_cidr[range] if length(range) > 0], [for k, v in merge(local.node_pools, local.windows_node_pools) : local.cluster_alias_ranges_cidr[v.pod_range] if length(lookup(v, "pod_range", "")) > 0])) : []
 
   cluster_network_policy = var.network_policy ? [{
     enabled  = true

--- a/modules/private-cluster/networks.tf
+++ b/modules/private-cluster/networks.tf
@@ -19,7 +19,7 @@
 data "google_compute_subnetwork" "gke_subnetwork" {
   provider = google
 
-  count   = var.add_cluster_firewall_rules ? 1 : 0
+  count   = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? 1 : 0
   name    = var.subnetwork
   region  = local.region
   project = local.network_project_id

--- a/networks.tf
+++ b/networks.tf
@@ -19,7 +19,7 @@
 data "google_compute_subnetwork" "gke_subnetwork" {
   provider = google
 
-  count   = var.add_cluster_firewall_rules ? 1 : 0
+  count   = var.add_cluster_firewall_rules || var.add_shadow_firewall_rules ? 1 : 0
   name    = var.subnetwork
   region  = local.region
   project = local.network_project_id


### PR DESCRIPTION
## Description

Fixes #2602

`add_shadow_firewall_rules = true` alone (without `add_cluster_firewall_rules = true`) fails at plan time because the shadow firewall rules depend on locals that are only populated when `add_cluster_firewall_rules` is set. The two flags should be independent.

## Root Cause

`google_compute_firewall.shadow_allow_nodes` uses `source_ranges = [local.cluster_subnet_cidr]` and `shadow_allow_pods` uses `local.pod_all_ip_ranges`, but the `gke_subnetwork` data source and the `cluster_subnet_cidr` / `cluster_alias_ranges_cidr` / `pod_all_ip_ranges` locals are all gated on `var.add_cluster_firewall_rules` only. With shadow rules enabled but cluster rules disabled, `cluster_subnet_cidr` is `null`, producing:

```
Error: Null value found in list
  with google_compute_firewall.shadow_allow_nodes[0]
  source_ranges = [local.cluster_subnet_cidr]
```

## Solution

Gate the subnetwork data source and the three derived locals on `var.add_cluster_firewall_rules || var.add_shadow_firewall_rules`, so the data needed by the shadow rules is available whenever either flag is set. Changes are made in `autogen/` and the modules regenerated via `make build`.

## Affected Modules

Root, private-cluster(-update-variant), beta-public-cluster(-update-variant), beta-private-cluster(-update-variant), beta-autopilot-public-cluster, beta-autopilot-private-cluster.

## Validation

- `terraform validate` passes on root, private-cluster, and beta-autopilot-private-cluster.
- Backward compatible: when `add_cluster_firewall_rules` is true (any shadow value) or both are false, behavior is unchanged; only the shadow-only path changes from a plan error to working.
- No new variable/output, so module interfaces (READMEs) are unchanged.
