### PR TITLE
feat(private-cluster): add node pool refresh skip option

### DIFF
--- a/autogen/main/README.md
+++ b/autogen/main/README.md
@@ -20,6 +20,19 @@ Sub modules are provided for creating private clusters, beta private clusters, a
 For details on configuring private clusters with this module, check the [troubleshooting guide](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/master/docs/private_clusters.md).
 
 {% endif %}
+{% if node_pool_refresh_skip_option %}
+## Skipping Node Pool Refresh
+
+Set `skip_node_pool_refresh = true` when every node pool is managed through
+separate `google_container_node_pool` resources or GKE node auto-provisioning.
+This prevents the provider from materializing those pools in the cluster state,
+which avoids slow refreshes and false diffs for ephemeral auto-provisioned
+pools.
+
+When enabled, the module omits its inline node pool configuration and
+automatically removes the one-node bootstrap default pool required by GKE.
+
+{% endif %}
 {% if update_variant %}
 ## Node Pool Update Variant
 
@@ -324,7 +337,7 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 {% if beta_cluster %}
 - [Terraform Provider for GCP Beta][terraform-provider-google-beta] v6.47+
 {% else %}
-- [Terraform Provider for GCP][terraform-provider-google] v6.47+
+- [Terraform Provider for GCP][terraform-provider-google] v{% if node_pool_refresh_skip_option %}7.38{% else %}6.47{% endif %}+
 {% endif %}
 
 #### gcloud

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -36,6 +36,10 @@ resource "google_container_cluster" "primary" {
   cluster_ipv4_cidr   = var.cluster_ipv4_cidr
   network             = "projects/${local.network_project_id}/global/networks/${var.network}"
   deletion_protection = var.deletion_protection
+  {% if node_pool_refresh_skip_option %}
+  initial_node_count     = var.skip_node_pool_refresh ? max(1, var.initial_node_count) : null
+  skip_node_pool_refresh = var.skip_node_pool_refresh
+  {% endif %}
 
   dynamic "enable_k8s_beta_apis" {
     for_each = length(var.enable_k8s_beta_apis) > 0 ? [1] : []
@@ -661,7 +665,13 @@ resource "google_container_cluster" "primary" {
     delete = lookup(var.timeouts, "delete", "45m")
   }
   {% if autopilot_cluster != true %}
+  {% if node_pool_refresh_skip_option %}
+  dynamic "node_pool" {
+    for_each = var.skip_node_pool_refresh ? [] : [1]
+    content {
+  {% else %}
   node_pool {
+  {% endif %}
     name               = "default-pool"
     initial_node_count = var.initial_node_count
 
@@ -786,6 +796,9 @@ resource "google_container_cluster" "primary" {
       max_run_duration          = lookup(local.head_node_pool, "max_run_duration", null)
       flex_start                = lookup(local.head_node_pool, "flex_start", null)
     }
+  {% if node_pool_refresh_skip_option %}
+    }
+  {% endif %}
   }
   {% endif %}
 
@@ -849,7 +862,11 @@ resource "google_container_cluster" "primary" {
   }
 
   {% if autopilot_cluster != true %}
+  {% if node_pool_refresh_skip_option %}
+  remove_default_node_pool = var.skip_node_pool_refresh ? true : var.remove_default_node_pool
+  {% else %}
   remove_default_node_pool = var.remove_default_node_pool
+  {% endif %}
   {% endif %}
 
   dynamic "database_encryption" {

--- a/autogen/main/variables.tf.tmpl
+++ b/autogen/main/variables.tf.tmpl
@@ -857,6 +857,14 @@ variable "initial_node_count" {
   default     = 0
 }
 
+{% if node_pool_refresh_skip_option %}
+variable "skip_node_pool_refresh" {
+  type        = bool
+  description = "If true, do not refresh node pools into the cluster state. Use only when all node pools are managed with separate google_container_node_pool resources or GKE node auto-provisioning."
+  default     = false
+}
+
+{% endif %}
 variable "remove_default_node_pool" {
   type        = bool
   description = "Remove default node pool while setting up the cluster"

--- a/autogen/main/versions.tf.tmpl
+++ b/autogen/main/versions.tf.tmpl
@@ -50,7 +50,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.17.0, < 8"
+      version = "{% if node_pool_refresh_skip_option %}>= 7.38.0, < 8{% else %}>= 7.17.0, < 8{% endif %}"
     }
 {% endif %}
     kubernetes = {

--- a/autogen_modules.json
+++ b/autogen_modules.json
@@ -11,7 +11,8 @@
     "path": "./modules/private-cluster",
     "options": {
       "module_path": "//modules/private-cluster",
-      "private_cluster": true
+      "private_cluster": true,
+      "node_pool_refresh_skip_option": true
     }
   },
   {

--- a/examples/simple_regional_private_no_pool/README.md
+++ b/examples/simple_regional_private_no_pool/README.md
@@ -1,6 +1,6 @@
 # Simple Regional Private Cluster with No Node Pools
 
-This example illustrates how to create a regional private cluster while skipping the creation of node pools and enabling the default compute class.
+This example illustrates how to create a regional private cluster while skipping the creation and refresh of node pools and enabling the default compute class.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs

--- a/examples/simple_regional_private_no_pool/main.tf
+++ b/examples/simple_regional_private_no_pool/main.tf
@@ -50,6 +50,7 @@ module "gke" {
   enable_secret_manager_addon = true
   default_max_pods_per_node   = 20
   remove_default_node_pool    = true
+  skip_node_pool_refresh      = true
   deletion_protection         = false
   enable_k8s_beta_apis        = var.enable_k8s_beta_apis
 

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -15,6 +15,17 @@ Sub modules are provided for creating private clusters, beta private clusters, a
 
 For details on configuring private clusters with this module, check the [troubleshooting guide](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/master/docs/private_clusters.md).
 
+## Skipping Node Pool Refresh
+
+Set `skip_node_pool_refresh = true` when every node pool is managed through
+separate `google_container_node_pool` resources or GKE node auto-provisioning.
+This prevents the provider from materializing those pools in the cluster state,
+which avoids slow refreshes and false diffs for ephemeral auto-provisioned
+pools.
+
+When enabled, the module omits its inline node pool configuration and
+automatically removes the one-node bootstrap default pool required by GKE.
+
 ## Compatibility
 
 This module is meant for use with Terraform 1.3+ and tested using Terraform 1.10+.
@@ -287,6 +298,7 @@ Then perform the following commands on the root folder:
 | service\_external\_ips | Whether external ips specified by a service will be allowed in this cluster | `bool` | `false` | no |
 | shadow\_firewall\_rules\_log\_config | The log\_config for shadow firewall rules. You can set this variable to `null` to disable logging. | <pre>object({<br>    metadata = string<br>  })</pre> | <pre>{<br>  "metadata": "INCLUDE_ALL_METADATA"<br>}</pre> | no |
 | shadow\_firewall\_rules\_priority | The firewall priority of GKE shadow firewall rules. The priority should be less than default firewall, which is 1000. | `number` | `999` | no |
+| skip\_node\_pool\_refresh | If true, do not refresh node pools into the cluster state. Use only when all node pools are managed with separate google_container_node_pool resources or GKE node auto-provisioning. | `bool` | `false` | no |
 | stack\_type | The stack type to use for this cluster. Either `IPV4` or `IPV4_IPV6`. Defaults to `IPV4`. | `string` | `"IPV4"` | no |
 | stateful\_ha | Whether the Stateful HA Addon is enabled for this cluster. | `bool` | `false` | no |
 | stub\_domains | Map of stub domains and their resolvers to forward DNS queries for a certain domain to an external DNS server | `map(list(string))` | `{}` | no |
@@ -464,7 +476,7 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 #### Terraform and Plugins
 
 - [Terraform](https://www.terraform.io/downloads.html) 1.3+
-- [Terraform Provider for GCP][terraform-provider-google] v6.47+
+- [Terraform Provider for GCP][terraform-provider-google] v7.38+
 
 #### gcloud
 

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -27,11 +27,13 @@ resource "google_container_cluster" "primary" {
   project         = var.project_id
   resource_labels = var.cluster_resource_labels
 
-  location            = local.location
-  node_locations      = local.node_locations
-  cluster_ipv4_cidr   = var.cluster_ipv4_cidr
-  network             = "projects/${local.network_project_id}/global/networks/${var.network}"
-  deletion_protection = var.deletion_protection
+  location               = local.location
+  node_locations         = local.node_locations
+  cluster_ipv4_cidr      = var.cluster_ipv4_cidr
+  network                = "projects/${local.network_project_id}/global/networks/${var.network}"
+  deletion_protection    = var.deletion_protection
+  initial_node_count     = var.skip_node_pool_refresh ? max(1, var.initial_node_count) : null
+  skip_node_pool_refresh = var.skip_node_pool_refresh
 
   dynamic "enable_k8s_beta_apis" {
     for_each = length(var.enable_k8s_beta_apis) > 0 ? [1] : []
@@ -518,121 +520,124 @@ resource "google_container_cluster" "primary" {
     update = lookup(var.timeouts, "update", "45m")
     delete = lookup(var.timeouts, "delete", "45m")
   }
-  node_pool {
-    name               = "default-pool"
-    initial_node_count = var.initial_node_count
+  dynamic "node_pool" {
+    for_each = var.skip_node_pool_refresh ? [] : [1]
+    content {
+      name               = "default-pool"
+      initial_node_count = var.initial_node_count
 
-    management {
-      auto_repair  = lookup(var.cluster_autoscaling, "auto_repair", true)
-      auto_upgrade = lookup(var.cluster_autoscaling, "auto_upgrade", true)
-    }
-
-    node_config {
-      image_type                  = lookup(local.head_node_pool, "image_type", "COS_CONTAINERD")
-      machine_type                = lookup(local.head_node_pool, "machine_type", "e2-medium")
-      min_cpu_platform            = lookup(local.head_node_pool, "min_cpu_platform", "")
-      enable_confidential_storage = lookup(local.head_node_pool, "enable_confidential_storage", false)
-      disk_type                   = lookup(local.head_node_pool, "disk_type", null)
-
-      dynamic "boot_disk" {
-        for_each = lookup(local.head_node_pool, "provisioned_iops", null) != null || lookup(local.head_node_pool, "provisioned_throughput", null) != null ? [1] : []
-        content {
-          provisioned_iops       = lookup(local.head_node_pool, "provisioned_iops", null)
-          provisioned_throughput = lookup(local.head_node_pool, "provisioned_throughput", null)
-        }
+      management {
+        auto_repair  = lookup(var.cluster_autoscaling, "auto_repair", true)
+        auto_upgrade = lookup(var.cluster_autoscaling, "auto_upgrade", true)
       }
 
-      dynamic "gcfs_config" {
-        for_each = lookup(local.head_node_pool, "enable_gcfs", null) != null ? [local.head_node_pool.enable_gcfs] : []
-        content {
-          enabled = gcfs_config.value
+      node_config {
+        image_type                  = lookup(local.head_node_pool, "image_type", "COS_CONTAINERD")
+        machine_type                = lookup(local.head_node_pool, "machine_type", "e2-medium")
+        min_cpu_platform            = lookup(local.head_node_pool, "min_cpu_platform", "")
+        enable_confidential_storage = lookup(local.head_node_pool, "enable_confidential_storage", false)
+        disk_type                   = lookup(local.head_node_pool, "disk_type", null)
+
+        dynamic "boot_disk" {
+          for_each = lookup(local.head_node_pool, "provisioned_iops", null) != null || lookup(local.head_node_pool, "provisioned_throughput", null) != null ? [1] : []
+          content {
+            provisioned_iops       = lookup(local.head_node_pool, "provisioned_iops", null)
+            provisioned_throughput = lookup(local.head_node_pool, "provisioned_throughput", null)
+          }
         }
-      }
 
-      dynamic "gvnic" {
-        for_each = lookup(local.head_node_pool, "enable_gvnic", false) ? [true] : []
-        content {
-          enabled = gvnic.value
+        dynamic "gcfs_config" {
+          for_each = lookup(local.head_node_pool, "enable_gcfs", null) != null ? [local.head_node_pool.enable_gcfs] : []
+          content {
+            enabled = gcfs_config.value
+          }
         }
-      }
 
-      dynamic "fast_socket" {
-        for_each = lookup(local.head_node_pool, "enable_fast_socket", null) != null ? [local.head_node_pool.enable_fast_socket] : []
-        content {
-          enabled = fast_socket.value
+        dynamic "gvnic" {
+          for_each = lookup(local.head_node_pool, "enable_gvnic", false) ? [true] : []
+          content {
+            enabled = gvnic.value
+          }
         }
-      }
 
-      dynamic "kubelet_config" {
-        for_each = length(setintersection(
-          keys(local.head_node_pool),
-          ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls"]
-        )) != 0 || var.insecure_kubelet_readonly_port_enabled != null ? [1] : []
-
-        content {
-          cpu_manager_policy                     = lookup(local.head_node_pool, "cpu_manager_policy", "static")
-          cpu_cfs_quota                          = lookup(local.head_node_pool, "cpu_cfs_quota", null)
-          cpu_cfs_quota_period                   = lookup(local.head_node_pool, "cpu_cfs_quota_period", null)
-          insecure_kubelet_readonly_port_enabled = lookup(local.head_node_pool, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled) != null ? upper(tostring(lookup(local.head_node_pool, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled))) : null
-          pod_pids_limit                         = lookup(local.head_node_pool, "pod_pids_limit", null)
-          container_log_max_size                 = lookup(local.head_node_pool, "container_log_max_size", null)
-          container_log_max_files                = lookup(local.head_node_pool, "container_log_max_files", null)
-          image_gc_low_threshold_percent         = lookup(local.head_node_pool, "image_gc_low_threshold_percent", null)
-          image_gc_high_threshold_percent        = lookup(local.head_node_pool, "image_gc_high_threshold_percent", null)
-          image_minimum_gc_age                   = lookup(local.head_node_pool, "image_minimum_gc_age", null)
-          image_maximum_gc_age                   = lookup(local.head_node_pool, "image_maximum_gc_age", null)
-          allowed_unsafe_sysctls                 = lookup(local.head_node_pool, "allowed_unsafe_sysctls", null) == null ? null : [for s in split(",", lookup(local.head_node_pool, "allowed_unsafe_sysctls", null)) : trimspace(s)]
+        dynamic "fast_socket" {
+          for_each = lookup(local.head_node_pool, "enable_fast_socket", null) != null ? [local.head_node_pool.enable_fast_socket] : []
+          content {
+            enabled = fast_socket.value
+          }
         }
-      }
 
-      dynamic "sole_tenant_config" {
-        # node_affinity is currently the only member of sole_tenant_config
-        for_each = lookup(local.head_node_pool, "node_affinity", null) != null ? [true] : []
-        content {
-          dynamic "node_affinity" {
-            for_each = lookup(local.head_node_pool, "node_affinity", null) != null ? [lookup(local.head_node_pool, "node_affinity", null)] : []
-            content {
-              key      = lookup(jsondecode(node_affinity.value), "key", null)
-              operator = lookup(jsondecode(node_affinity.value), "operator", null)
-              values   = lookup(jsondecode(node_affinity.value), "values", [])
+        dynamic "kubelet_config" {
+          for_each = length(setintersection(
+            keys(local.head_node_pool),
+            ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls"]
+          )) != 0 || var.insecure_kubelet_readonly_port_enabled != null ? [1] : []
+
+          content {
+            cpu_manager_policy                     = lookup(local.head_node_pool, "cpu_manager_policy", "static")
+            cpu_cfs_quota                          = lookup(local.head_node_pool, "cpu_cfs_quota", null)
+            cpu_cfs_quota_period                   = lookup(local.head_node_pool, "cpu_cfs_quota_period", null)
+            insecure_kubelet_readonly_port_enabled = lookup(local.head_node_pool, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled) != null ? upper(tostring(lookup(local.head_node_pool, "insecure_kubelet_readonly_port_enabled", var.insecure_kubelet_readonly_port_enabled))) : null
+            pod_pids_limit                         = lookup(local.head_node_pool, "pod_pids_limit", null)
+            container_log_max_size                 = lookup(local.head_node_pool, "container_log_max_size", null)
+            container_log_max_files                = lookup(local.head_node_pool, "container_log_max_files", null)
+            image_gc_low_threshold_percent         = lookup(local.head_node_pool, "image_gc_low_threshold_percent", null)
+            image_gc_high_threshold_percent        = lookup(local.head_node_pool, "image_gc_high_threshold_percent", null)
+            image_minimum_gc_age                   = lookup(local.head_node_pool, "image_minimum_gc_age", null)
+            image_maximum_gc_age                   = lookup(local.head_node_pool, "image_maximum_gc_age", null)
+            allowed_unsafe_sysctls                 = lookup(local.head_node_pool, "allowed_unsafe_sysctls", null) == null ? null : [for s in split(",", lookup(local.head_node_pool, "allowed_unsafe_sysctls", null)) : trimspace(s)]
+          }
+        }
+
+        dynamic "sole_tenant_config" {
+          # node_affinity is currently the only member of sole_tenant_config
+          for_each = lookup(local.head_node_pool, "node_affinity", null) != null ? [true] : []
+          content {
+            dynamic "node_affinity" {
+              for_each = lookup(local.head_node_pool, "node_affinity", null) != null ? [lookup(local.head_node_pool, "node_affinity", null)] : []
+              content {
+                key      = lookup(jsondecode(node_affinity.value), "key", null)
+                operator = lookup(jsondecode(node_affinity.value), "operator", null)
+                values   = lookup(jsondecode(node_affinity.value), "values", [])
+              }
             }
           }
         }
-      }
 
-      service_account = lookup(local.head_node_pool, "service_account", local.service_account)
+        service_account = lookup(local.head_node_pool, "service_account", local.service_account)
 
-      tags = concat(
-        lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
-        lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
-        lookup(local.node_pools_tags, "all", []),
-        length(var.node_pools) > 0 ? lookup(local.node_pools_tags, local.head_node_pool.name, []) : [],
-      )
+        tags = concat(
+          lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
+          lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
+          lookup(local.node_pools_tags, "all", []),
+          length(var.node_pools) > 0 ? lookup(local.node_pools_tags, local.head_node_pool.name, []) : [],
+        )
 
-      logging_variant = lookup(local.head_node_pool, "logging_variant", "DEFAULT")
+        logging_variant = lookup(local.head_node_pool, "logging_variant", "DEFAULT")
 
-      dynamic "workload_metadata_config" {
-        for_each = local.cluster_node_metadata_config
+        dynamic "workload_metadata_config" {
+          for_each = local.cluster_node_metadata_config
 
-        content {
-          mode = workload_metadata_config.value.mode
+          content {
+            mode = workload_metadata_config.value.mode
+          }
         }
+
+        metadata = local.node_pools_metadata["all"]
+
+        boot_disk_kms_key = lookup(local.head_node_pool, "boot_disk_kms_key", var.boot_disk_kms_key)
+
+        storage_pools = lookup(local.head_node_pool, "storage_pools", null) != null ? [local.head_node_pool.storage_pools] : []
+
+        shielded_instance_config {
+          enable_secure_boot          = lookup(local.head_node_pool, "enable_secure_boot", false)
+          enable_integrity_monitoring = lookup(local.head_node_pool, "enable_integrity_monitoring", true)
+        }
+
+        local_ssd_encryption_mode = lookup(local.head_node_pool, "local_ssd_encryption_mode", null)
+        max_run_duration          = lookup(local.head_node_pool, "max_run_duration", null)
+        flex_start                = lookup(local.head_node_pool, "flex_start", null)
       }
-
-      metadata = local.node_pools_metadata["all"]
-
-      boot_disk_kms_key = lookup(local.head_node_pool, "boot_disk_kms_key", var.boot_disk_kms_key)
-
-      storage_pools = lookup(local.head_node_pool, "storage_pools", null) != null ? [local.head_node_pool.storage_pools] : []
-
-      shielded_instance_config {
-        enable_secure_boot          = lookup(local.head_node_pool, "enable_secure_boot", false)
-        enable_integrity_monitoring = lookup(local.head_node_pool, "enable_integrity_monitoring", true)
-      }
-
-      local_ssd_encryption_mode = lookup(local.head_node_pool, "local_ssd_encryption_mode", null)
-      max_run_duration          = lookup(local.head_node_pool, "max_run_duration", null)
-      flex_start                = lookup(local.head_node_pool, "flex_start", null)
     }
   }
 
@@ -693,7 +698,7 @@ resource "google_container_cluster" "primary" {
     }
   }
 
-  remove_default_node_pool = var.remove_default_node_pool
+  remove_default_node_pool = var.skip_node_pool_refresh ? true : var.remove_default_node_pool
 
   dynamic "database_encryption" {
     for_each = var.database_encryption

--- a/modules/private-cluster/metadata.display.yaml
+++ b/modules/private-cluster/metadata.display.yaml
@@ -457,6 +457,9 @@ spec:
         shadow_firewall_rules_priority:
           name: shadow_firewall_rules_priority
           title: Shadow Firewall Rules Priority
+        skip_node_pool_refresh:
+          name: skip_node_pool_refresh
+          title: Skip Node Pool Refresh
         stack_type:
           name: stack_type
           title: Stack Type

--- a/modules/private-cluster/metadata.yaml
+++ b/modules/private-cluster/metadata.yaml
@@ -631,6 +631,10 @@ spec:
         description: The number of nodes to create in this cluster's default node pool.
         varType: number
         defaultValue: 0
+      - name: skip_node_pool_refresh
+        description: If true, do not refresh node pools into the cluster state. Use only when all node pools are managed with separate google_container_node_pool resources or GKE node auto-provisioning.
+        varType: bool
+        defaultValue: false
       - name: remove_default_node_pool
         description: Remove default node pool while setting up the cluster
         varType: bool
@@ -885,7 +889,7 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.17.0, < 8"
+        version: ">= 7.38.0, < 8"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -787,6 +787,12 @@ variable "initial_node_count" {
   default     = 0
 }
 
+variable "skip_node_pool_refresh" {
+  type        = bool
+  description = "If true, do not refresh node pools into the cluster state. Use only when all node pools are managed with separate google_container_node_pool resources or GKE node auto-provisioning."
+  default     = false
+}
+
 variable "remove_default_node_pool" {
   type        = bool
   description = "Remove default node pool while setting up the cluster"

--- a/modules/private-cluster/versions.tf
+++ b/modules/private-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.17.0, < 8"
+      version = ">= 7.38.0, < 8"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## What

- Add an opt-in `skip_node_pool_refresh` variable to the existing `private-cluster` module; it defaults to `false`.
- When enabled, conditionally omit the inline cluster `node_pool` block, set the provider field, and automatically remove the one-node bootstrap default pool required by GKE.
- Exercise the option through the existing `simple_regional_private_no_pool` integration example, whose verifier asserts a no-op plan after apply.
- Require Google provider v7.38.0 only for `private-cluster`, where this field is available.

All other generated module variants remain unchanged.

## Why

GKE node auto-provisioning can create and delete many ephemeral pools. Refreshing those pools into `google_container_cluster` state produces slow plans and false removal diffs even though the pools are managed by GKE rather than the cluster resource.

Google provider v7.38.0 added `skip_node_pool_refresh` specifically for this case. The provider rejects that setting when an inline `node_pool` block is present, so the module uses a conditional dynamic block that expands to zero blocks only when the option is enabled. Existing behavior is unchanged by default.

Provider implementation: https://github.com/hashicorp/terraform-provider-google/pull/27896

## Validation

- `terraform fmt -check -recursive`
- `terraform init -backend=false` and `terraform validate` for `private-cluster`
- Plans with the conditional block enabled and disabled using Google provider v7.41.0
- Existing private no-pool example plan confirms `initial_node_count = 1`, `remove_default_node_pool = true`, and `skip_node_pool_refresh = true` without the provider raw-config conflict
- Generated Terraform and README output compared with the Jinja templates
- Metadata YAML and `autogen_modules.json` parsed successfully

The apparent reindent inside `modules/private-cluster/cluster.tf` is the formatter-required nesting of the existing inline pool body inside `dynamic "node_pool"`; ignoring whitespace, that resource change is nine added lines and two removed lines.
