### PR TITLE
chore: remove UNSPECIFIED release_channel from safer cluster examples

### DIFF
--- a/examples/confidential_safer_cluster/README.md
+++ b/examples/confidential_safer_cluster/README.md
@@ -18,7 +18,6 @@ with confidential nodes enabled and database encrypted with KMS key.
 | ca\_certificate | The cluster ca certificate (base64 encoded). |
 | client\_token | The bearer token for auth. |
 | cluster\_name | Cluster name. |
-| explicit\_k8s\_version | Explicit version used for cluster creation. |
 | keyring | The name of the keyring. |
 | kms\_key\_name | KMS Key Name. |
 | kubernetes\_endpoint | The cluster endpoint. |

--- a/examples/confidential_safer_cluster/main.tf
+++ b/examples/confidential_safer_cluster/main.tf
@@ -38,20 +38,8 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(module.gke.ca_certificate)
 }
 
-// A random valid k8s version is retrived
-// to specify as an explicit version.
-data "google_container_engine_versions" "current" {
-  project  = var.project_id
-  location = var.region
-}
-
 data "google_project" "main" {
   project_id = var.project_id
-}
-
-resource "random_shuffle" "version" {
-  input        = data.google_container_engine_versions.current.valid_master_versions
-  result_count = 1
 }
 
 resource "google_kms_crypto_key_iam_member" "main" {
@@ -75,8 +63,6 @@ module "gke" {
   master_ipv4_cidr_block     = "172.16.0.0/28"
   add_cluster_firewall_rules = true
   firewall_inbound_ports     = ["9443", "15017"]
-  kubernetes_version         = random_shuffle.version.result[0]
-  release_channel            = "UNSPECIFIED"
   deletion_protection        = false
   enable_private_endpoint    = true
   enable_confidential_nodes  = true

--- a/examples/confidential_safer_cluster/outputs.tf
+++ b/examples/confidential_safer_cluster/outputs.tf
@@ -75,11 +75,6 @@ output "project_id" {
   value       = var.project_id
 }
 
-output "explicit_k8s_version" {
-  description = "Explicit version used for cluster creation."
-  value       = random_shuffle.version.result[0]
-}
-
 output "keyring" {
   description = "The name of the keyring."
   value       = module.kms.keyring

--- a/examples/safer_cluster/README.md
+++ b/examples/safer_cluster/README.md
@@ -17,7 +17,6 @@ This example illustrates how to instantiate the opinionated Safer Cluster module
 | ca\_certificate | The cluster ca certificate (base64 encoded) |
 | client\_token | The bearer token for auth |
 | cluster\_name | Cluster name |
-| explicit\_k8s\_version | Explicit version used for cluster creation |
 | kubernetes\_endpoint | The cluster endpoint |
 | location | n/a |
 | master\_kubernetes\_version | Kubernetes version of the master |

--- a/examples/safer_cluster/main.tf
+++ b/examples/safer_cluster/main.tf
@@ -38,18 +38,6 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(module.gke.ca_certificate)
 }
 
-// A random valid k8s version is retrived
-// to specify as an explicit version.
-data "google_container_engine_versions" "current" {
-  project  = var.project_id
-  location = var.region
-}
-
-resource "random_shuffle" "version" {
-  input        = data.google_container_engine_versions.current.valid_master_versions
-  result_count = 1
-}
-
 module "gke" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/safer-cluster"
   version = "~> 44.0"
@@ -65,8 +53,6 @@ module "gke" {
   master_ipv4_cidr_block     = "172.16.0.0/28"
   add_cluster_firewall_rules = true
   firewall_inbound_ports     = ["9443", "15017"]
-  kubernetes_version         = random_shuffle.version.result[0]
-  release_channel            = "UNSPECIFIED"
   deletion_protection        = false
 
   master_authorized_networks = [

--- a/examples/safer_cluster/outputs.tf
+++ b/examples/safer_cluster/outputs.tf
@@ -75,7 +75,3 @@ output "project_id" {
   value       = var.project_id
 }
 
-output "explicit_k8s_version" {
-  description = "Explicit version used for cluster creation"
-  value       = random_shuffle.version.result[0]
-}

--- a/test/fixtures/safer_cluster/outputs.tf
+++ b/test/fixtures/safer_cluster/outputs.tf
@@ -56,6 +56,3 @@ output "service_account" {
   value       = module.example.service_account
 }
 
-output "explicit_k8s_version" {
-  value = module.example.explicit_k8s_version
-}

--- a/test/integration/confidential_safer_cluster/testdata/TestConfidentialSaferCluster.json
+++ b/test/integration/confidential_safer_cluster/testdata/TestConfidentialSaferCluster.json
@@ -311,7 +311,9 @@
     "enableInsecureBindingSystemAuthenticated": true,
     "enableInsecureBindingSystemUnauthenticated": true
   },
-  "releaseChannel": {},
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
   "resourceLabels": {
     "goog-terraform-provisioned": "true"
   },

--- a/test/integration/safer_cluster/testdata/TestSaferCluster.json
+++ b/test/integration/safer_cluster/testdata/TestSaferCluster.json
@@ -247,7 +247,9 @@
     "privateEndpoint": "172.16.0.2",
     "publicEndpoint": "35.226.10.245"
   },
-  "releaseChannel": {},
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
   "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/CLUSTER_NAME",
   "servicesIpv4Cidr": "192.168.64.0/18",
   "shieldedNodes": {

--- a/test/integration/testutils/utils.go
+++ b/test/integration/testutils/utils.go
@@ -32,6 +32,9 @@ import (
 
 var (
 	RetryableTransientErrors = map[string]string{
+		// HTTP/2 transport connection drops
+		".*http2: client connection lost.*": "HTTP/2 connection lost.",
+
 		// Error 409: unable to queue the operation
 		".*Error 409.*unable to queue the operation": "Unable to queue operation.",
 


### PR DESCRIPTION
GKE API no longer permits creating new clusters with 'No channel' (release_channel = "UNSPECIFIED").

Remove UNSPECIFIED release_channel and random_shuffle version logic from examples/safer_cluster and examples/confidential_safer_cluster, allowing release_channel to default to REGULAR.