### PR TITLE
chore: reduce CI flakes across integration tests and pipeline

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -19,7 +19,7 @@ steps:
   args: ['module-swapper']
 - id: prepare
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && prepare_environment ; chmod 600 /builder/home/.netrc && sleep 120']
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && prepare_environment && (chmod 600 /builder/home/.netrc || true) && sleep 120']
   env:
   - 'TF_VAR_org_id=$_ORG_ID'
   - 'TF_VAR_folder_id=$_FOLDER_ID'
@@ -564,4 +564,4 @@ substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
   _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.26'
 options:
-  machineType: 'E2_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_32'

--- a/examples/confidential_safer_cluster/README.md
+++ b/examples/confidential_safer_cluster/README.md
@@ -18,7 +18,6 @@ with confidential nodes enabled and database encrypted with KMS key.
 | ca\_certificate | The cluster ca certificate (base64 encoded). |
 | client\_token | The bearer token for auth. |
 | cluster\_name | Cluster name. |
-| explicit\_k8s\_version | Explicit version used for cluster creation. |
 | keyring | The name of the keyring. |
 | kms\_key\_name | KMS Key Name. |
 | kubernetes\_endpoint | The cluster endpoint. |

--- a/examples/confidential_safer_cluster/main.tf
+++ b/examples/confidential_safer_cluster/main.tf
@@ -38,20 +38,8 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(module.gke.ca_certificate)
 }
 
-// A random valid k8s version is retrived
-// to specify as an explicit version.
-data "google_container_engine_versions" "current" {
-  project  = var.project_id
-  location = var.region
-}
-
 data "google_project" "main" {
   project_id = var.project_id
-}
-
-resource "random_shuffle" "version" {
-  input        = data.google_container_engine_versions.current.valid_master_versions
-  result_count = 1
 }
 
 resource "google_kms_crypto_key_iam_member" "main" {
@@ -75,8 +63,6 @@ module "gke" {
   master_ipv4_cidr_block     = "172.16.0.0/28"
   add_cluster_firewall_rules = true
   firewall_inbound_ports     = ["9443", "15017"]
-  kubernetes_version         = random_shuffle.version.result[0]
-  release_channel            = "UNSPECIFIED"
   deletion_protection        = false
   enable_private_endpoint    = true
   enable_confidential_nodes  = true

--- a/examples/confidential_safer_cluster/outputs.tf
+++ b/examples/confidential_safer_cluster/outputs.tf
@@ -75,11 +75,6 @@ output "project_id" {
   value       = var.project_id
 }
 
-output "explicit_k8s_version" {
-  description = "Explicit version used for cluster creation."
-  value       = random_shuffle.version.result[0]
-}
-
 output "keyring" {
   description = "The name of the keyring."
   value       = module.kms.keyring

--- a/examples/regional_private_node_pool_oauth_scopes/network.tf
+++ b/examples/regional_private_node_pool_oauth_scopes/network.tf
@@ -23,9 +23,10 @@ module "gke-network" {
 
   subnets = [
     {
-      subnet_name   = "random-gke-subnet"
-      subnet_ip     = "10.0.0.0/24"
-      subnet_region = "us-west1"
+      subnet_name           = "random-gke-subnet"
+      subnet_ip             = "10.0.0.0/24"
+      subnet_region         = "us-west1"
+      subnet_private_access = "true"
     },
   ]
 

--- a/examples/safer_cluster/README.md
+++ b/examples/safer_cluster/README.md
@@ -17,7 +17,6 @@ This example illustrates how to instantiate the opinionated Safer Cluster module
 | ca\_certificate | The cluster ca certificate (base64 encoded) |
 | client\_token | The bearer token for auth |
 | cluster\_name | Cluster name |
-| explicit\_k8s\_version | Explicit version used for cluster creation |
 | kubernetes\_endpoint | The cluster endpoint |
 | location | n/a |
 | master\_kubernetes\_version | Kubernetes version of the master |

--- a/examples/safer_cluster/main.tf
+++ b/examples/safer_cluster/main.tf
@@ -38,18 +38,6 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(module.gke.ca_certificate)
 }
 
-// A random valid k8s version is retrived
-// to specify as an explicit version.
-data "google_container_engine_versions" "current" {
-  project  = var.project_id
-  location = var.region
-}
-
-resource "random_shuffle" "version" {
-  input        = data.google_container_engine_versions.current.valid_master_versions
-  result_count = 1
-}
-
 module "gke" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/safer-cluster"
   version = "~> 44.0"
@@ -65,8 +53,6 @@ module "gke" {
   master_ipv4_cidr_block     = "172.16.0.0/28"
   add_cluster_firewall_rules = true
   firewall_inbound_ports     = ["9443", "15017"]
-  kubernetes_version         = random_shuffle.version.result[0]
-  release_channel            = "UNSPECIFIED"
   deletion_protection        = false
 
   master_authorized_networks = [

--- a/examples/safer_cluster/network.tf
+++ b/examples/safer_cluster/network.tf
@@ -23,14 +23,16 @@ module "gcp-network" {
 
   subnets = [
     {
-      subnet_name   = local.subnet_name
-      subnet_ip     = "10.0.0.0/17"
-      subnet_region = var.region
+      subnet_name           = local.subnet_name
+      subnet_ip             = "10.0.0.0/17"
+      subnet_region         = var.region
+      subnet_private_access = "true"
     },
     {
-      subnet_name   = local.master_auth_subnetwork
-      subnet_ip     = "10.60.0.0/17"
-      subnet_region = var.region
+      subnet_name           = local.master_auth_subnetwork
+      subnet_ip             = "10.60.0.0/17"
+      subnet_region         = var.region
+      subnet_private_access = "true"
     },
   ]
 

--- a/examples/safer_cluster/outputs.tf
+++ b/examples/safer_cluster/outputs.tf
@@ -75,7 +75,3 @@ output "project_id" {
   value       = var.project_id
 }
 
-output "explicit_k8s_version" {
-  description = "Explicit version used for cluster creation"
-  value       = random_shuffle.version.result[0]
-}

--- a/examples/simple_autopilot_private_cmek/main.tf
+++ b/examples/simple_autopilot_private_cmek/main.tf
@@ -30,6 +30,12 @@ data "google_project" "main" {
   project_id = var.project_id
 }
 
+resource "random_string" "suffix" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
 module "kms" {
   source  = "terraform-google-modules/kms/google"
   version = "~> 4.0"
@@ -37,7 +43,7 @@ module "kms" {
   project_id           = var.project_id
   key_protection_level = "HSM"
   location             = "us-central1"
-  keyring              = "keyring"
+  keyring              = "keyring-${random_string.suffix.result}"
   keys                 = ["key"]
   prevent_destroy      = false
 }

--- a/examples/simple_regional_with_networking/main.tf
+++ b/examples/simple_regional_with_networking/main.tf
@@ -31,9 +31,10 @@ module "gcp-network" {
 
   subnets = [
     {
-      subnet_name   = var.subnetwork
-      subnet_ip     = "10.0.0.0/17"
-      subnet_region = var.region
+      subnet_name           = var.subnetwork
+      subnet_ip             = "10.0.0.0/17"
+      subnet_region         = var.region
+      subnet_private_access = "true"
     },
   ]
 

--- a/test/fixtures/safer_cluster/outputs.tf
+++ b/test/fixtures/safer_cluster/outputs.tf
@@ -56,6 +56,3 @@ output "service_account" {
   value       = module.example.service_account
 }
 
-output "explicit_k8s_version" {
-  value = module.example.explicit_k8s_version
-}

--- a/test/integration/autopilot_private_firewalls/autopilot_private_firewalls_test.go
+++ b/test/integration/autopilot_private_firewalls/autopilot_private_firewalls_test.go
@@ -16,15 +16,19 @@ package autopilot_private_firewalls
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/golden"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
 	"github.com/stretchr/testify/assert"
+	"github.com/terraform-google-modules/terraform-google-kubernetes-engine/test/integration/testutils"
 )
 
 func TestAutopilotPrivateFirewalls(t *testing.T) {
-	bpt := tft.NewTFBlueprintTest(t)
+	bpt := tft.NewTFBlueprintTest(t,
+		tft.WithRetryableTerraformErrors(testutils.RetryableTransientErrors, 3, 2*time.Minute),
+	)
 	bpt.DefineVerify(func(assert *assert.Assertions) {
 		bpt.DefaultVerify(assert)
 		projectId := bpt.GetStringOutput("project_id")

--- a/test/integration/beta_cluster/beta_cluster_test.go
+++ b/test/integration/beta_cluster/beta_cluster_test.go
@@ -46,7 +46,6 @@ func TestBetaCluster(t *testing.T) {
 		)
 		// assert json paths against goldenfile data
 		validateJSONPaths := []string{
-			"status",
 			"location",
 			"locations",
 			"privateClusterConfig.enablePrivateEndpoint",
@@ -66,6 +65,7 @@ func TestBetaCluster(t *testing.T) {
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)
 		}
+		assert.Contains([]string{"RUNNING", "RECONCILING"}, op.Get("status").String())
 
 		for _, np := range op.Get("nodePools").Array() {
 			npName := np.Get("name").String()

--- a/test/integration/confidential_safer_cluster/confidential_safer_cluster_test.go
+++ b/test/integration/confidential_safer_cluster/confidential_safer_cluster_test.go
@@ -42,13 +42,10 @@ func TestConfidentialSaferCluster(t *testing.T) {
 
 		op := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
 		g := golden.NewOrUpdate(t, op.String(),
-			golden.WithSanitizer(golden.StringSanitizer(serviceAccount, "SERVICE_ACCOUNT")),
 			golden.WithSanitizer(golden.StringSanitizer(keyName, "KEY_NAME")),
-			golden.WithSanitizer(golden.StringSanitizer(projectId, "PROJECT_ID")),
-			golden.WithSanitizer(golden.StringSanitizer(clusterName, "CLUSTER_NAME")),
+			golden.WithSanitizer(testutils.GKEClusterSanitizer(serviceAccount, projectId, clusterName, op)),
 		)
 		validateJSONPaths := []string{
-			"status",
 			"location",
 			"confidentialNodes.enabled",
 			"databaseEncryption.keyName",
@@ -82,6 +79,7 @@ func TestConfidentialSaferCluster(t *testing.T) {
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)
 		}
+		assert.Contains([]string{"RUNNING", "RECONCILING"}, op.Get("status").String())
 	})
 
 	bpt.Test()

--- a/test/integration/confidential_safer_cluster/testdata/TestConfidentialSaferCluster.json
+++ b/test/integration/confidential_safer_cluster/testdata/TestConfidentialSaferCluster.json
@@ -311,7 +311,9 @@
     "enableInsecureBindingSystemAuthenticated": true,
     "enableInsecureBindingSystemUnauthenticated": true
   },
-  "releaseChannel": {},
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
   "resourceLabels": {
     "goog-terraform-provisioned": "true"
   },

--- a/test/integration/deploy_service/deploy_service_test.go
+++ b/test/integration/deploy_service/deploy_service_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -41,28 +42,49 @@ func TestDeployService(t *testing.T) {
 		clusterName := bpt.GetStringOutput("cluster_name")
 		gcloud.Runf(t, "container clusters get-credentials %s --region %s --project %s", clusterName, location, projectId)
 		k8sOpts := k8s.KubectlOptions{}
-		listServices, err := k8s.RunKubectlAndGetOutputE(t, &k8sOpts, "get", "svc", "terraform-example", "-o", "json")
-		assert.NoError(err)
-		kubeService := utils.ParseKubectlJSONResult(t, listServices)
-		serviceIp := kubeService.Get("status.loadBalancer.ingress").Array()[0].Get("ip")
+
+		var serviceIp string
+		utils.Poll(t, func() (bool, error) {
+			listServices, err := k8s.RunKubectlAndGetOutputE(t, &k8sOpts, "get", "svc", "terraform-example", "-o", "json")
+			if err != nil {
+				return true, err
+			}
+			kubeService := utils.ParseKubectlJSONResult(t, listServices)
+			ip := kubeService.Get("status.loadBalancer.ingress.0.ip").String()
+			if ip == "" {
+				return true, fmt.Errorf("waiting for load balancer IP allocation")
+			}
+			serviceIp = ip
+			return false, nil
+		}, 30, 10*time.Second)
+
 		serviceUrl := fmt.Sprintf("http://%s:8080", serviceIp)
 
+		var responseData []byte
 		pollHTTPEndPoint := func(cmd string) func() (bool, error) {
 			return func() (bool, error) {
-				_, err := http.Get(cmd)
+				resp, err := http.Get(cmd)
 				if err != nil {
 					t.Logf("%s", err)
 					return true, err
 				}
+				defer resp.Body.Close()
+				if resp.StatusCode != http.StatusOK {
+					return true, fmt.Errorf("expected status 200, got %d", resp.StatusCode)
+				}
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return true, err
+				}
+				if !strings.Contains(string(body), "Thank you for using nginx.") {
+					return true, fmt.Errorf("response body does not yet contain expected content")
+				}
+				responseData = body
 				return false, nil
 			}
 		}
 
 		utils.Poll(t, pollHTTPEndPoint(serviceUrl), 20, 10*time.Second)
-		response, err := http.Get(serviceUrl)
-		assert.NoError(err)
-		responseData, err := io.ReadAll(response.Body)
-		assert.NoError(err)
 		assert.Contains(string(responseData), "Thank you for using nginx.", "Service is Functional")
 	})
 

--- a/test/integration/disable_client_cert/disable_client_cert_test.go
+++ b/test/integration/disable_client_cert/disable_client_cert_test.go
@@ -33,6 +33,7 @@ func TestDisableClientCert(t *testing.T) {
 	bpt.DefineVerify(func(assert *assert.Assertions) {
 		//Skipping Default Verify as the Verify Stage fails due to change in Client Cert Token
 		// bpt.DefaultVerify(assert)
+		testutils.TGKEVerify(t, bpt, assert) // Verify Resources
 
 		projectId := bpt.GetStringOutput("project_id")
 		location := bpt.GetStringOutput("location")
@@ -44,7 +45,6 @@ func TestDisableClientCert(t *testing.T) {
 			golden.WithSanitizer(golden.StringSanitizer(clusterName, "CLUSTER_NAME")),
 		)
 		validateJSONPaths := []string{
-			"status",
 			"masterAuth.clientCertificate",
 			"masterAuth.username",
 			"masterAuth.password",
@@ -52,6 +52,7 @@ func TestDisableClientCert(t *testing.T) {
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)
 		}
+		assert.Contains([]string{"RUNNING", "RECONCILING"}, op.Get("status").String())
 	})
 	bpt.Test()
 }

--- a/test/integration/node_pool/node_pool_test.go
+++ b/test/integration/node_pool/node_pool_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/stretchr/testify/assert"
 	"github.com/terraform-google-modules/terraform-google-kubernetes-engine/test/integration/testutils"
+	"github.com/tidwall/gjson"
 )
 
 func TestNodePool(t *testing.T) {
@@ -49,8 +50,7 @@ func TestNodePool(t *testing.T) {
 
 		// Setup golden image with sanitizers
 		g := golden.NewOrUpdate(t, cluster.String(),
-			golden.WithSanitizer(golden.StringSanitizer(nodeServiceAccount, "NODE_SERVICE_ACCOUNT")),
-			golden.WithSanitizer(golden.StringSanitizer(projectId, "PROJECT_ID")),
+			golden.WithSanitizer(testutils.GKEClusterSanitizer(nodeServiceAccount, projectId, clusterName, cluster)),
 			golden.WithSanitizer(golden.StringSanitizer(randomString, "RANDOM_STRING")),
 			golden.WithSanitizer(golden.StringSanitizer(kubernetesEndpoint, "KUBERNETES_ENDPOINT")),
 		)
@@ -68,9 +68,21 @@ func TestNodePool(t *testing.T) {
 		gcloud.Runf(t, "container clusters get-credentials %s --region %s --project %s", clusterName, location, projectId)
 		k8sOpts := k8s.NewKubectlOptions(fmt.Sprintf("gke_%s_%s_%s", projectId, location, clusterName), "", "")
 
-		nodesOutput, err := k8s.RunKubectlAndGetOutputE(t, k8sOpts, "get", "nodes", "-o", "json")
-		assert.NoError(err)
-		nodes := utils.ParseKubectlJSONResult(t, nodesOutput)
+		var nodes gjson.Result
+		utils.Poll(t, func() (bool, error) {
+			nodesOutput, err := k8s.RunKubectlAndGetOutputE(t, k8sOpts, "get", "nodes", "-o", "json")
+			if err != nil {
+				return true, err
+			}
+			nodes = utils.ParseKubectlJSONResult(t, nodesOutput)
+			pool01Taints := nodes.Get("items.#(metadata.labels.node_pool==\"pool-01\").spec.taints")
+			pool02Taints := nodes.Get("items.#(metadata.labels.node_pool==\"pool-02\").spec.taints")
+			pool03Taints := nodes.Get("items.#(metadata.labels.node_pool==\"pool-03\").spec.taints")
+			if !pool01Taints.Exists() || !pool02Taints.Exists() || !pool03Taints.Exists() {
+				return true, fmt.Errorf("waiting for node pools to register nodes with taints")
+			}
+			return false, nil
+		}, 30, 10*time.Second)
 
 		assert.JSONEq(`[
 				{

--- a/test/integration/node_pool/testdata/TestNodePool.json
+++ b/test/integration/node_pool/testdata/TestNodePool.json
@@ -144,7 +144,7 @@
     }
   },
   "monitoringService": "monitoring.googleapis.com/kubernetes",
-  "name": "node-pool-cluster-RANDOM_STRING",
+  "name": "CLUSTER_NAME",
   "network": "cft-gke-test-RANDOM_STRING",
   "networkConfig": {
     "defaultSnatStatus": {},
@@ -175,8 +175,8 @@
       "enableIntegrityMonitoring": true
     },
     "tags": [
-      "gke-node-pool-cluster-RANDOM_STRING",
-      "gke-node-pool-cluster-RANDOM_STRING-default-pool",
+      "gke-CLUSTER_NAME",
+      "gke-CLUSTER_NAME-default-pool",
       "all-node-example",
       "pool-01-example"
     ],
@@ -218,13 +218,13 @@
           "https://www.googleapis.com/auth/userinfo.email",
           "https://www.googleapis.com/auth/cloud-platform"
         ],
-        "serviceAccount": "NODE_SERVICE_ACCOUNT",
+        "serviceAccount": "SERVICE_ACCOUNT",
         "shieldedInstanceConfig": {
           "enableIntegrityMonitoring": true
         },
         "tags": [
-          "gke-node-pool-cluster-RANDOM_STRING",
-          "gke-node-pool-cluster-RANDOM_STRING-default-pool",
+          "gke-CLUSTER_NAME",
+          "gke-CLUSTER_NAME-default-pool",
           "all-node-example",
           "pool-01-example"
         ],
@@ -249,7 +249,7 @@
         "podRange": "cft-gke-test-pods-RANDOM_STRING"
       },
       "podIpv4CidrSize": 24,
-      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/europe-west4/clusters/node-pool-cluster-RANDOM_STRING/nodePools/default-pool",
+      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/europe-west4/clusters/CLUSTER_NAME/nodePools/default-pool",
       "status": "RUNNING",
       "upgradeSettings": {
         "maxSurge": 1,
@@ -302,7 +302,7 @@
       },
       "placementPolicy": {},
       "podIpv4CidrSize": 24,
-      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/europe-west4/clusters/node-pool-cluster-RANDOM_STRING/nodePools/nap-e2-medium-1d469r1p",
+      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/europe-west4/clusters/CLUSTER_NAME/nodePools/nap-e2-medium-1d469r1p",
       "status": "RUNNING",
       "upgradeSettings": {
         "maxSurge": 1,
@@ -324,7 +324,7 @@
         "imageType": "COS_CONTAINERD",
         "labels": {
           "all-pools-example": "true",
-          "cluster_name": "node-pool-cluster-RANDOM_STRING",
+          "cluster_name": "CLUSTER_NAME",
           "node_pool": "pool-01",
           "pool-01-example": "true"
         },
@@ -345,7 +345,7 @@
         },
         "machineType": "e2-medium",
         "metadata": {
-          "cluster_name": "node-pool-cluster-RANDOM_STRING",
+          "cluster_name": "CLUSTER_NAME",
           "disable-legacy-endpoints": "false",
           "node_pool": "pool-01",
           "shutdown-script": "kubectl --kubeconfig=/var/lib/kubelet/kubeconfig drain --force=true --ignore-daemonsets=true --delete-local-data \"$HOSTNAME\""
@@ -353,13 +353,13 @@
         "oauthScopes": [
           "https://www.googleapis.com/auth/cloud-platform"
         ],
-        "serviceAccount": "NODE_SERVICE_ACCOUNT",
+        "serviceAccount": "SERVICE_ACCOUNT",
         "shieldedInstanceConfig": {
           "enableIntegrityMonitoring": true
         },
         "tags": [
-          "gke-node-pool-cluster-RANDOM_STRING",
-          "gke-node-pool-cluster-RANDOM_STRING-pool-01",
+          "gke-CLUSTER_NAME",
+          "gke-CLUSTER_NAME-pool-01",
           "all-node-example",
           "pool-01-example"
         ],
@@ -397,7 +397,7 @@
         "podRange": "cft-gke-test-pods-RANDOM_STRING"
       },
       "podIpv4CidrSize": 24,
-      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/europe-west4/clusters/node-pool-cluster-RANDOM_STRING/nodePools/pool-01",
+      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/europe-west4/clusters/CLUSTER_NAME/nodePools/pool-01",
       "status": "RUNNING",
       "upgradeSettings": {
         "maxSurge": 1,
@@ -427,7 +427,7 @@
         "imageType": "COS_CONTAINERD",
         "labels": {
           "all-pools-example": "true",
-          "cluster_name": "node-pool-cluster-RANDOM_STRING",
+          "cluster_name": "CLUSTER_NAME",
           "node_pool": "pool-02"
         },
         "linuxNodeConfig": {
@@ -446,20 +446,20 @@
         },
         "machineType": "g2-standard-4",
         "metadata": {
-          "cluster_name": "node-pool-cluster-RANDOM_STRING",
+          "cluster_name": "CLUSTER_NAME",
           "disable-legacy-endpoints": "false",
           "node_pool": "pool-02"
         },
         "oauthScopes": [
           "https://www.googleapis.com/auth/cloud-platform"
         ],
-        "serviceAccount": "NODE_SERVICE_ACCOUNT",
+        "serviceAccount": "SERVICE_ACCOUNT",
         "shieldedInstanceConfig": {
           "enableIntegrityMonitoring": true
         },
         "tags": [
-          "gke-node-pool-cluster-RANDOM_STRING",
-          "gke-node-pool-cluster-RANDOM_STRING-pool-02",
+          "gke-CLUSTER_NAME",
+          "gke-CLUSTER_NAME-pool-02",
           "all-node-example"
         ],
         "taints": [
@@ -495,7 +495,7 @@
         "podRange": "cft-gke-test-pods-RANDOM_STRING"
       },
       "podIpv4CidrSize": 24,
-      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/europe-west4/clusters/node-pool-cluster-RANDOM_STRING/nodePools/pool-02",
+      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/europe-west4/clusters/CLUSTER_NAME/nodePools/pool-02",
       "status": "RUNNING",
       "upgradeSettings": {
         "maxSurge": 1,
@@ -516,7 +516,7 @@
         },
         "labels": {
           "all-pools-example": "true",
-          "cluster_name": "node-pool-cluster-RANDOM_STRING",
+          "cluster_name": "CLUSTER_NAME",
           "node_pool": "pool-03",
           "sandbox.gke.io/runtime": "gvisor"
         },
@@ -536,7 +536,7 @@
         },
         "machineType": "n2-standard-2",
         "metadata": {
-          "cluster_name": "node-pool-cluster-RANDOM_STRING",
+          "cluster_name": "CLUSTER_NAME",
           "disable-legacy-endpoints": "false",
           "node_pool": "pool-03"
         },
@@ -546,13 +546,13 @@
         "sandboxConfig": {
           "type": "GVISOR"
         },
-        "serviceAccount": "NODE_SERVICE_ACCOUNT",
+        "serviceAccount": "SERVICE_ACCOUNT",
         "shieldedInstanceConfig": {
           "enableIntegrityMonitoring": true
         },
         "tags": [
-          "gke-node-pool-cluster-RANDOM_STRING",
-          "gke-node-pool-cluster-RANDOM_STRING-pool-03",
+          "gke-CLUSTER_NAME",
+          "gke-CLUSTER_NAME-pool-03",
           "all-node-example"
         ],
         "taints": [
@@ -591,7 +591,7 @@
         "podRange": "test"
       },
       "podIpv4CidrSize": 24,
-      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/europe-west4/clusters/node-pool-cluster-RANDOM_STRING/nodePools/pool-03",
+      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/europe-west4/clusters/CLUSTER_NAME/nodePools/pool-03",
       "status": "RUNNING",
       "upgradeSettings": {
         "maxSurge": 1,
@@ -614,7 +614,7 @@
         },
         "labels": {
           "all-pools-example": "true",
-          "cluster_name": "node-pool-cluster-RANDOM_STRING",
+          "cluster_name": "CLUSTER_NAME",
           "node_pool": "pool-04"
         },
         "linuxNodeConfig": {
@@ -633,7 +633,7 @@
         },
         "machineType": "e2-medium",
         "metadata": {
-          "cluster_name": "node-pool-cluster-RANDOM_STRING",
+          "cluster_name": "CLUSTER_NAME",
           "disable-legacy-endpoints": "false",
           "node_pool": "pool-04"
         },
@@ -643,13 +643,13 @@
         "reservationAffinity": {
           "consumeReservationType": "NO_RESERVATION"
         },
-        "serviceAccount": "NODE_SERVICE_ACCOUNT",
+        "serviceAccount": "SERVICE_ACCOUNT",
         "shieldedInstanceConfig": {
           "enableIntegrityMonitoring": true
         },
         "tags": [
-          "gke-node-pool-cluster-RANDOM_STRING",
-          "gke-node-pool-cluster-RANDOM_STRING-pool-04",
+          "gke-CLUSTER_NAME",
+          "gke-CLUSTER_NAME-pool-04",
           "all-node-example"
         ],
         "taints": [
@@ -688,7 +688,7 @@
       "queuedProvisioning": {
         "enabled": true
       },
-      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/europe-west4/clusters/node-pool-cluster-RANDOM_STRING/nodePools/pool-04",
+      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/europe-west4/clusters/CLUSTER_NAME/nodePools/pool-04",
       "status": "RUNNING",
       "upgradeSettings": {
         "strategy": "SHORT_LIVED"
@@ -711,7 +711,7 @@
         "imageType": "COS_CONTAINERD",
         "labels": {
           "all-pools-example": "true",
-          "cluster_name": "node-pool-cluster-RANDOM_STRING",
+          "cluster_name": "CLUSTER_NAME",
           "node_pool": "pool-05"
         },
         "linuxNodeConfig": {
@@ -732,7 +732,7 @@
         },
         "machineType": "c3-standard-4",
         "metadata": {
-          "cluster_name": "node-pool-cluster-RANDOM_STRING",
+          "cluster_name": "CLUSTER_NAME",
           "disable-legacy-endpoints": "false",
           "node_pool": "pool-05"
         },
@@ -744,8 +744,8 @@
           "enableIntegrityMonitoring": true
         },
         "tags": [
-          "gke-node-pool-cluster-RANDOM_STRING",
-          "gke-node-pool-cluster-RANDOM_STRING-pool-05",
+          "gke-CLUSTER_NAME",
+          "gke-CLUSTER_NAME-pool-05",
           "all-node-example"
         ],
         "taints": [
@@ -777,7 +777,7 @@
         "podRange": "cft-gke-test-pods-RANDOM_STRING"
       },
       "podIpv4CidrSize": 24,
-      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/europe-west4/clusters/node-pool-cluster-RANDOM_STRING/nodePools/pool-05",
+      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/europe-west4/clusters/CLUSTER_NAME/nodePools/pool-05",
       "status": "RUNNING",
       "upgradeSettings": {
         "maxSurge": 1,
@@ -805,7 +805,7 @@
     "mode": "DISABLED",
     "vulnerabilityMode": "VULNERABILITY_DISABLED"
   },
-  "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/europe-west4/clusters/node-pool-cluster-RANDOM_STRING",
+  "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/europe-west4/clusters/CLUSTER_NAME",
   "servicesIpv4Cidr": "192.168.64.0/18",
   "shieldedNodes": {
     "enabled": true

--- a/test/integration/private_zonal_with_networking/private_zonal_with_networking_test.go
+++ b/test/integration/private_zonal_with_networking/private_zonal_with_networking_test.go
@@ -15,6 +15,7 @@
 package private_zonal_with_networking
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -55,7 +56,6 @@ func TestPrivateZonalWithNetworking(t *testing.T) {
 		)
 		assert.Equal(peeringName, op.Get("privateClusterConfig.peeringName").String(), "has the correct PeeringName")
 		validateJSONPaths := []string{
-			"status",
 			"location",
 			"locations",
 			"privateClusterConfig.enablePrivateEndpoint",
@@ -67,6 +67,7 @@ func TestPrivateZonalWithNetworking(t *testing.T) {
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)
 		}
+		assert.Contains([]string{"RUNNING", "RECONCILING"}, op.Get("status").String())
 
 		for _, np := range op.Get("nodePools").Array() {
 			npName := np.Get("name").String()
@@ -84,11 +85,8 @@ func TestPrivateZonalWithNetworking(t *testing.T) {
 		}
 
 		sOp := gcloud.Runf(t, "compute networks subnets describe %s --project=%s --region=%s", subnetName, projectId, region)
-		assert.Contains(sOp.Get("secondaryIpRanges").Array()[0].Get("rangeName").String(), ipRangePodsName, "Contains Pod Address Name")
-		assert.Contains(sOp.Get("secondaryIpRanges").Array()[0].Get("ipCidrRange").String(), "192.168.0.0/18", "Contains Pod Address")
-		assert.Contains(sOp.Get("secondaryIpRanges").Array()[1].Get("rangeName").String(), ipRangeServicesName, "Contains SVC Address Name")
-		assert.Contains(sOp.Get("secondaryIpRanges").Array()[1].Get("ipCidrRange").String(), "192.168.64.0/18", "Contains SVC Address")
-
+		assert.Equal("192.168.0.0/18", sOp.Get(fmt.Sprintf("secondaryIpRanges.#(rangeName==\"%s\").ipCidrRange", ipRangePodsName)).String(), "Contains Pod Address")
+		assert.Equal("192.168.64.0/18", sOp.Get(fmt.Sprintf("secondaryIpRanges.#(rangeName==\"%s\").ipCidrRange", ipRangeServicesName)).String(), "Contains SVC Address")
 	})
 
 	bpt.Test()

--- a/test/integration/safer_cluster/safer_cluster_test.go
+++ b/test/integration/safer_cluster/safer_cluster_test.go
@@ -32,6 +32,7 @@ func TestSaferCluster(t *testing.T) {
 	bpt.DefineVerify(func(assert *assert.Assertions) {
 		//Skipping Default Verify as the Verify Stage fails due to change in Client Cert Token
 		// bpt.DefaultVerify(assert)
+		testutils.TGKEVerify(t, bpt, assert) // Verify Resources
 
 		projectId := bpt.GetStringOutput("project_id")
 		location := bpt.GetStringOutput("location")
@@ -40,12 +41,9 @@ func TestSaferCluster(t *testing.T) {
 
 		op := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
 		g := golden.NewOrUpdate(t, op.String(),
-			golden.WithSanitizer(golden.StringSanitizer(serviceAccount, "SERVICE_ACCOUNT")),
-			golden.WithSanitizer(golden.StringSanitizer(projectId, "PROJECT_ID")),
-			golden.WithSanitizer(golden.StringSanitizer(clusterName, "CLUSTER_NAME")),
+			golden.WithSanitizer(testutils.GKEClusterSanitizer(serviceAccount, projectId, clusterName, op)),
 		)
 		validateJSONPaths := []string{
-			"status",
 			"location",
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
@@ -69,6 +67,7 @@ func TestSaferCluster(t *testing.T) {
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)
 		}
+		assert.Contains([]string{"RUNNING", "RECONCILING"}, op.Get("status").String())
 		gcloud.Runf(t, "compute firewall-rules --project %s describe gke-%s-intra-cluster-egress", projectId, clusterName)
 		gcloud.Runf(t, "compute firewall-rules --project %s describe gke-%s-webhooks", projectId, clusterName)
 	})

--- a/test/integration/safer_cluster/testdata/TestSaferCluster.json
+++ b/test/integration/safer_cluster/testdata/TestSaferCluster.json
@@ -247,7 +247,9 @@
     "privateEndpoint": "172.16.0.2",
     "publicEndpoint": "35.226.10.245"
   },
-  "releaseChannel": {},
+  "releaseChannel": {
+    "channel": "REGULAR"
+  },
   "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/CLUSTER_NAME",
   "servicesIpv4Cidr": "192.168.64.0/18",
   "shieldedNodes": {

--- a/test/integration/safer_cluster_iap_bastion/safer_cluster_iap_bastion_test.go
+++ b/test/integration/safer_cluster_iap_bastion/safer_cluster_iap_bastion_test.go
@@ -21,8 +21,10 @@ import (
 
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/terraform-google-modules/terraform-google-kubernetes-engine/test/integration/testutils"
+	"github.com/tidwall/gjson"
 )
 
 func TestSaferClusterIapBastion(t *testing.T) {
@@ -37,16 +39,23 @@ func TestSaferClusterIapBastion(t *testing.T) {
 
 		testCommand, _ := strings.CutPrefix(bpt.GetStringOutput("test_command"), "gcloud ")
 
-		// pre run ssh command so that ssh-keygen can run
-		gcloud.RunCmd(t, testCommand,
-			gcloud.WithCommonArgs([]string{}),
-		)
-
 		clusterVersion := fmt.Sprintf("v%s", bpt.GetStringOutput("cluster_version"))
 
-		op := gcloud.Run(t, testCommand,
-			gcloud.WithCommonArgs([]string{}),
-		)
+		var op gjson.Result
+		utils.Poll(t, func() (bool, error) {
+			cmdOp, err := gcloud.RunCmdE(t, testCommand,
+				gcloud.WithCommonArgs([]string{}),
+			)
+			if err != nil {
+				t.Logf("Waiting for SSH connectivity via IAP: %v", err)
+				return true, err
+			}
+			op = gjson.Parse(cmdOp)
+			if !op.Get("gitVersion").Exists() {
+				return true, fmt.Errorf("gitVersion not yet present in output")
+			}
+			return false, nil
+		}, 20, 10*time.Second)
 
 		assert.Equal(clusterVersion, op.Get("gitVersion").String(), "SSH into VM and verify connectivity to GKE")
 	})

--- a/test/integration/sandbox_enabled/sandbox_enabled_test.go
+++ b/test/integration/sandbox_enabled/sandbox_enabled_test.go
@@ -41,12 +41,9 @@ func TestSandboxEnabled(t *testing.T) {
 
 		op := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
 		g := golden.NewOrUpdate(t, op.String(),
-			golden.WithSanitizer(golden.StringSanitizer(serviceAccount, "SERVICE_ACCOUNT")),
-			golden.WithSanitizer(golden.StringSanitizer(projectId, "PROJECT_ID")),
-			golden.WithSanitizer(golden.StringSanitizer(clusterName, "CLUSTER_NAME")),
+			golden.WithSanitizer(testutils.GKEClusterSanitizer(serviceAccount, projectId, clusterName, op)),
 		)
 		validateJSONPaths := []string{
-			"status",
 			"location",
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
@@ -59,6 +56,7 @@ func TestSandboxEnabled(t *testing.T) {
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)
 		}
+		assert.Contains([]string{"RUNNING", "RECONCILING"}, op.Get("status").String())
 	})
 
 	bpt.Test()

--- a/test/integration/shared_vpc/shared_vpc_test.go
+++ b/test/integration/shared_vpc/shared_vpc_test.go
@@ -31,13 +31,14 @@ func TestSharedVPC(t *testing.T) {
 	bpt.DefineVerify(func(assert *assert.Assertions) {
 		//Skipping Default Verify as the Verify Stage fails due to change in Client Cert Token
 		// bpt.DefaultVerify(assert)
+		testutils.TGKEVerify(t, bpt, assert) // Verify Resources
 
 		projectId := bpt.GetStringOutput("project_id")
 		location := bpt.GetStringOutput("location")
 		clusterName := bpt.GetStringOutput("cluster_name")
 
 		op := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
-		assert.Contains(op.Get("status").String(), "RUNNING", "Cluster is Running")
+		assert.Contains([]string{"RUNNING", "RECONCILING"}, op.Get("status").String(), "Cluster is Running or Reconciling")
 	})
 
 	bpt.Test()

--- a/test/integration/simple_fleet_app_operator_permissions/simple_fleet_app_operator_permissions_test.go
+++ b/test/integration/simple_fleet_app_operator_permissions/simple_fleet_app_operator_permissions_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/terraform-google-modules/terraform-google-kubernetes-engine/test/integration/testutils"
 )
@@ -49,29 +50,37 @@ func TestSimpleFleetAppOperatorPermissions(t *testing.T) {
 		filterFormat := "\"bindings.members:%s\""
 		flattenOpt := "bindings[].members"
 
-		scopeRrbList := gcloud.Runf(t, "container fleet scopes rbacrolebindings list --scope %s --project %s", scopeId, projectId).String()
-		assert.Equal(strings.Contains(scopeRrbList, appOperatorEmail), true, "app operator email should be in the list of Scope RBAC Role Bindings")
-		assert.Equal(strings.Contains(scopeRrbList, customAppOperatorEmail), true, "custom app operator email should be in the list of Scope RBAC Role Bindings")
+		utils.Poll(t, func() (bool, error) {
+			scopeRrbList := gcloud.Runf(t, "container fleet scopes rbacrolebindings list --scope %s --project %s", scopeId, projectId).String()
+			if !strings.Contains(scopeRrbList, appOperatorEmail) || !strings.Contains(scopeRrbList, customAppOperatorEmail) {
+				return true, fmt.Errorf("waiting for Scope RBAC Role Bindings")
+			}
 
-		scopeIam := gcloud.Runf(t, "container fleet scopes get-iam-policy %s --project %s --filter %s", scopeId, projectId, fmt.Sprintf(filterFormat, appOperatorPrincipal)).String()
-		assert.Equal(strings.Contains(scopeIam, scopeLevelRole), true, "app operator Scope role should be in the Scope IAM policy")
+			scopeIam := gcloud.Runf(t, "container fleet scopes get-iam-policy %s --project %s --filter %s", scopeId, projectId, fmt.Sprintf(filterFormat, appOperatorPrincipal)).String()
+			if !strings.Contains(scopeIam, scopeLevelRole) {
+				return true, fmt.Errorf("waiting for app operator Scope role in Scope IAM policy")
+			}
 
-		customScopeIam := gcloud.Runf(t, "container fleet scopes get-iam-policy %s --project %s --filter %s", scopeId, projectId, fmt.Sprintf(filterFormat, customAppOperatorPrincipal)).String()
-		assert.Equal(strings.Contains(customScopeIam, customScopeLevelRole), true, "custom app operator Scope role should be in the Scope IAM policy")
+			customScopeIam := gcloud.Runf(t, "container fleet scopes get-iam-policy %s --project %s --filter %s", scopeId, projectId, fmt.Sprintf(filterFormat, customAppOperatorPrincipal)).String()
+			if !strings.Contains(customScopeIam, customScopeLevelRole) {
+				return true, fmt.Errorf("waiting for custom app operator Scope role in Scope IAM policy")
+			}
 
-		projectIam := gcloud.Runf(t, "projects get-iam-policy %s --filter %s --flatten %s", projectId, fmt.Sprintf(filterFormat, appOperatorPrincipal), flattenOpt).String()
-		assert.Equal(strings.Contains(projectIam, projectLevelRole), true, "app operator Scope role should be in the project IAM policy")
-		assert.Equal(strings.Contains(projectIam, logViewRole), true, "app operator log view role should be in the project IAM policy")
-		assert.Equal(strings.Contains(projectIam, logViewContainerBucket), true, "app operator log view container bucket should be in the project IAM policy")
-		assert.Equal(strings.Contains(projectIam, logViewPodBucket), true, "app operator log view pod bucket should be in the project IAM policy")
+			projectIam := gcloud.Runf(t, "projects get-iam-policy %s --filter %s --flatten %s", projectId, fmt.Sprintf(filterFormat, appOperatorPrincipal), flattenOpt).String()
+			if !strings.Contains(projectIam, projectLevelRole) || !strings.Contains(projectIam, logViewRole) ||
+				!strings.Contains(projectIam, logViewContainerBucket) || !strings.Contains(projectIam, logViewPodBucket) {
+				return true, fmt.Errorf("waiting for app operator project IAM policy")
+			}
 
-		customProjectIam := gcloud.Runf(t, "projects get-iam-policy %s --filter %s --flatten %s", projectId, fmt.Sprintf(filterFormat, customAppOperatorPrincipal), flattenOpt).String()
-		assert.Equal(strings.Contains(customProjectIam, customProjectLevelRole), true, "custom app operator Scope role should be in the project IAM policy")
-		assert.Equal(strings.Contains(customProjectIam, logViewRole), true, "custom app operator log view role should be in the project IAM policy")
-		assert.Equal(strings.Contains(customProjectIam, logViewContainerBucket), true, "custom app operator log view container bucket should be in the project IAM policy")
-		assert.Equal(strings.Contains(customProjectIam, logViewPodBucket), true, "custom app operator log view pod bucket should be in the project IAM policy")
+			customProjectIam := gcloud.Runf(t, "projects get-iam-policy %s --filter %s --flatten %s", projectId, fmt.Sprintf(filterFormat, customAppOperatorPrincipal), flattenOpt).String()
+			if !strings.Contains(customProjectIam, customProjectLevelRole) || !strings.Contains(customProjectIam, logViewRole) ||
+				!strings.Contains(customProjectIam, logViewContainerBucket) || !strings.Contains(customProjectIam, logViewPodBucket) {
+				return true, fmt.Errorf("waiting for custom app operator project IAM policy")
+			}
+
+			return false, nil
+		}, 20, 5*time.Second)
 	})
 
 	appOppT.Test()
 }
-

--- a/test/integration/simple_regional/simple_regional_test.go
+++ b/test/integration/simple_regional/simple_regional_test.go
@@ -32,6 +32,7 @@ func TestSimpleRegional(t *testing.T) {
 	bpt.DefineVerify(func(assert *assert.Assertions) {
 		//Skipping Default Verify as the Verify Stage fails due to change in Client Cert Token
 		// bpt.DefaultVerify(assert)
+		testutils.TGKEVerify(t, bpt, assert) // Verify Resources
 
 		projectId := bpt.GetStringOutput("project_id")
 		location := bpt.GetStringOutput("location")
@@ -43,7 +44,6 @@ func TestSimpleRegional(t *testing.T) {
 			golden.WithSanitizer(testutils.GKEClusterSanitizer(serviceAccount, projectId, clusterName, op)),
 		)
 		validateJSONPaths := []string{
-			"status",
 			"location",
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
@@ -62,6 +62,7 @@ func TestSimpleRegional(t *testing.T) {
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)
 		}
+		assert.Contains([]string{"RUNNING", "RECONCILING"}, op.Get("status").String())
 	})
 
 	bpt.Test()

--- a/test/integration/simple_regional_additional_ip_ranges/simple_regional_additional_ip_ranges_test.go
+++ b/test/integration/simple_regional_additional_ip_ranges/simple_regional_additional_ip_ranges_test.go
@@ -32,6 +32,7 @@ func TestSimpleRegionalAdditionalIPRanges(t *testing.T) {
 	bpt.DefineVerify(func(assert *assert.Assertions) {
 		//Skipping Default Verify as the Verify Stage fails due to change in Client Cert Token
 		// bpt.DefaultVerify(assert)
+		testutils.TGKEVerify(t, bpt, assert) // Verify Resources
 
 		projectId := bpt.GetStringOutput("project_id")
 		location := bpt.GetStringOutput("location")
@@ -43,7 +44,6 @@ func TestSimpleRegionalAdditionalIPRanges(t *testing.T) {
 			golden.WithSanitizer(testutils.GKEClusterSanitizer(serviceAccount, projectId, clusterName, op)),
 		)
 		validateJSONPaths := []string{
-			"status",
 			"location",
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
@@ -60,7 +60,7 @@ func TestSimpleRegionalAdditionalIPRanges(t *testing.T) {
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)
 		}
-
+		assert.Contains([]string{"RUNNING", "RECONCILING"}, op.Get("status").String())
 	})
 
 	bpt.Test()

--- a/test/integration/simple_regional_private/simple_regional_private_test.go
+++ b/test/integration/simple_regional_private/simple_regional_private_test.go
@@ -41,12 +41,9 @@ func TestSimpleRegionalPrivate(t *testing.T) {
 
 		op := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
 		g := golden.NewOrUpdate(t, op.String(),
-			golden.WithSanitizer(golden.StringSanitizer(serviceAccount, "SERVICE_ACCOUNT")),
-			golden.WithSanitizer(golden.StringSanitizer(projectId, "PROJECT_ID")),
-			golden.WithSanitizer(golden.StringSanitizer(clusterName, "CLUSTER_NAME")),
+			golden.WithSanitizer(testutils.GKEClusterSanitizer(serviceAccount, projectId, clusterName, op)),
 		)
 		validateJSONPaths := []string{
-			"status",
 			"location",
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
@@ -68,7 +65,7 @@ func TestSimpleRegionalPrivate(t *testing.T) {
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)
 		}
-
+		assert.Contains([]string{"RUNNING", "RECONCILING"}, op.Get("status").String())
 	})
 
 	bpt.Test()

--- a/test/integration/simple_regional_with_gateway_api/simple_regional_with_gateway_api_test.go
+++ b/test/integration/simple_regional_with_gateway_api/simple_regional_with_gateway_api_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package node_pool
+package simple_regional_with_gateway_api
 
 import (
 	"testing"
@@ -46,8 +46,7 @@ func TestSimpleRegionalWithGatewayAPI(t *testing.T) {
 
 		// Setup golden image with sanitizers
 		g := golden.NewOrUpdate(t, cluster.String(),
-			golden.WithSanitizer(golden.StringSanitizer(nodeServiceAccount, "NODE_SERVICE_ACCOUNT")),
-			golden.WithSanitizer(golden.StringSanitizer(projectId, "PROJECT_ID")),
+			golden.WithSanitizer(testutils.GKEClusterSanitizer(nodeServiceAccount, projectId, clusterName, cluster)),
 			golden.WithSanitizer(golden.StringSanitizer(randomString, "RANDOM_STRING")),
 			golden.WithSanitizer(golden.StringSanitizer(kubernetesEndpoint, "KUBERNETES_ENDPOINT")),
 		)

--- a/test/integration/simple_regional_with_gateway_api/testdata/TestSimpleRegionalWithGatewayAPI.json
+++ b/test/integration/simple_regional_with_gateway_api/testdata/TestSimpleRegionalWithGatewayAPI.json
@@ -111,7 +111,7 @@
     }
   },
   "monitoringService": "monitoring.googleapis.com/kubernetes",
-  "name": "simple-regional-gatewayapi-cluster-RANDOM_STRING",
+  "name": "CLUSTER_NAME",
   "network": "cft-gke-test-RANDOM_STRING",
   "networkConfig": {
     "defaultSnatStatus": {},
@@ -145,8 +145,8 @@
       "enableIntegrityMonitoring": true
     },
     "tags": [
-      "gke-simple-regional-gatewayapi-cluster-RANDOM_STRING",
-      "gke-simple-regional-gatewayapi-cluster-RANDOM_STRING-default-pool"
+      "gke-CLUSTER_NAME",
+      "gke-CLUSTER_NAME-default-pool"
     ],
     "windowsNodeConfig": {},
     "workloadMetadataConfig": {
@@ -186,13 +186,13 @@
           "https://www.googleapis.com/auth/userinfo.email",
           "https://www.googleapis.com/auth/cloud-platform"
         ],
-        "serviceAccount": "NODE_SERVICE_ACCOUNT",
+        "serviceAccount": "SERVICE_ACCOUNT",
         "shieldedInstanceConfig": {
           "enableIntegrityMonitoring": true
         },
         "tags": [
-          "gke-simple-regional-gatewayapi-cluster-RANDOM_STRING",
-          "gke-simple-regional-gatewayapi-cluster-RANDOM_STRING-default-pool"
+          "gke-CLUSTER_NAME",
+          "gke-CLUSTER_NAME-default-pool"
         ],
         "windowsNodeConfig": {},
         "workloadMetadataConfig": {
@@ -212,7 +212,7 @@
         "podRange": "cft-gke-test-pods-RANDOM_STRING"
       },
       "podIpv4CidrSize": 24,
-      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/simple-regional-gatewayapi-cluster-RANDOM_STRING/nodePools/default-pool",
+      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/CLUSTER_NAME/nodePools/default-pool",
       "status": "RUNNING",
       "upgradeSettings": {
         "maxSurge": 1,
@@ -243,7 +243,7 @@
     "mode": "DISABLED",
     "vulnerabilityMode": "VULNERABILITY_DISABLED"
   },
-  "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/simple-regional-gatewayapi-cluster-RANDOM_STRING",
+  "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/CLUSTER_NAME",
   "servicesIpv4Cidr": "192.168.64.0/18",
   "shieldedNodes": {
     "enabled": true

--- a/test/integration/simple_regional_with_ipv6/simple_regional_with_ipv6_test.go
+++ b/test/integration/simple_regional_with_ipv6/simple_regional_with_ipv6_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package node_pool
+package simple_regional_with_ipv6
 
 import (
 	"testing"
@@ -24,7 +24,7 @@ import (
 	"github.com/terraform-google-modules/terraform-google-kubernetes-engine/test/integration/testutils"
 )
 
-func TestSimpleRegionalWithGatewayAPI(t *testing.T) {
+func TestSimpleRegionalWithIPV6(t *testing.T) {
 	bpt := tft.NewTFBlueprintTest(t,
 		tft.WithRetryableTerraformErrors(testutils.RetryableTransientErrors, 3, 2*time.Minute),
 	)
@@ -46,8 +46,7 @@ func TestSimpleRegionalWithGatewayAPI(t *testing.T) {
 
 		// Setup golden image with sanitizers
 		g := golden.NewOrUpdate(t, cluster.String(),
-			golden.WithSanitizer(golden.StringSanitizer(nodeServiceAccount, "NODE_SERVICE_ACCOUNT")),
-			golden.WithSanitizer(golden.StringSanitizer(projectId, "PROJECT_ID")),
+			golden.WithSanitizer(testutils.GKEClusterSanitizer(nodeServiceAccount, projectId, clusterName, cluster)),
 			golden.WithSanitizer(golden.StringSanitizer(randomString, "RANDOM_STRING")),
 			golden.WithSanitizer(golden.StringSanitizer(kubernetesEndpoint, "KUBERNETES_ENDPOINT")),
 		)

--- a/test/integration/simple_regional_with_ipv6/testdata/TestSimpleRegionalWithIPV6.json
+++ b/test/integration/simple_regional_with_ipv6/testdata/TestSimpleRegionalWithIPV6.json
@@ -110,7 +110,7 @@
     }
   },
   "monitoringService": "monitoring.googleapis.com/kubernetes",
-  "name": "simple-regional-ipv6-cluster-RANDOM_STRING",
+  "name": "CLUSTER_NAME",
   "network": "cft-gke-test-RANDOM_STRING",
   "networkConfig": {
     "defaultSnatStatus": {},
@@ -141,8 +141,8 @@
       "enableIntegrityMonitoring": true
     },
     "tags": [
-      "gke-simple-regional-ipv6-cluster-RANDOM_STRING",
-      "gke-simple-regional-ipv6-cluster-RANDOM_STRING-default-pool"
+      "gke-CLUSTER_NAME",
+      "gke-CLUSTER_NAME-default-pool"
     ],
     "windowsNodeConfig": {},
     "workloadMetadataConfig": {
@@ -174,7 +174,7 @@
         "gcfsConfig": {},
         "imageType": "COS_CONTAINERD",
         "labels": {
-          "cluster_name": "simple-regional-gatewayapi-cluster-RANDOM_STRING",
+          "cluster_name": "CLUSTER_NAME",
           "node_pool": "default-node-pool"
         },
         "loggingConfig": {
@@ -190,13 +190,13 @@
           "https://www.googleapis.com/auth/userinfo.email",
           "https://www.googleapis.com/auth/cloud-platform"
         ],
-        "serviceAccount": "NODE_SERVICE_ACCOUNT",
+        "serviceAccount": "SERVICE_ACCOUNT",
         "shieldedInstanceConfig": {
           "enableIntegrityMonitoring": true
         },
         "tags": [
-          "gke-node-pool-cluster-RANDOM_STRING",
-          "gke-node-pool-cluster-RANDOM_STRING-default-pool"
+          "gke-CLUSTER_NAME",
+          "gke-CLUSTER_NAME-default-pool"
         ],
         "windowsNodeConfig": {},
         "workloadMetadataConfig": {
@@ -219,7 +219,7 @@
         "podRange": "cft-gke-test-pods-RANDOM_STRING"
       },
       "podIpv4CidrSize": 24,
-      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/europe-west4/clusters/node-pool-cluster-RANDOM_STRING/nodePools/default-pool",
+      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/europe-west4/clusters/CLUSTER_NAME/nodePools/default-pool",
       "status": "RUNNING",
       "upgradeSettings": {
         "maxSurge": 1,
@@ -250,7 +250,7 @@
     "mode": "DISABLED",
     "vulnerabilityMode": "VULNERABILITY_DISABLED"
   },
-  "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/simple-regional-ipv6-cluster-RANDOM_STRING",
+  "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/CLUSTER_NAME",
   "servicesIpv4Cidr": "192.168.64.0/18",
   "shieldedNodes": {
     "enabled": true

--- a/test/integration/simple_regional_with_kubeconfig/simple_regional_with_kubeconfig_test.go
+++ b/test/integration/simple_regional_with_kubeconfig/simple_regional_with_kubeconfig_test.go
@@ -32,6 +32,7 @@ func TestSimpleRegionalWithKubeConfig(t *testing.T) {
 	bpt.DefineVerify(func(assert *assert.Assertions) {
 		//Skipping Default Verify as the Verify Stage fails due to change in Client Cert Token
 		// bpt.DefaultVerify(assert)
+		testutils.TGKEVerify(t, bpt, assert) // Verify Resources
 
 		projectId := bpt.GetStringOutput("project_id")
 		location := bpt.GetStringOutput("location")
@@ -40,12 +41,9 @@ func TestSimpleRegionalWithKubeConfig(t *testing.T) {
 
 		op := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
 		g := golden.NewOrUpdate(t, op.String(),
-			golden.WithSanitizer(golden.StringSanitizer(serviceAccount, "SERVICE_ACCOUNT")),
-			golden.WithSanitizer(golden.StringSanitizer(projectId, "PROJECT_ID")),
-			golden.WithSanitizer(golden.StringSanitizer(clusterName, "CLUSTER_NAME")),
+			golden.WithSanitizer(testutils.GKEClusterSanitizer(serviceAccount, projectId, clusterName, op)),
 		)
 		validateJSONPaths := []string{
-			"status",
 			"location",
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
@@ -66,7 +64,7 @@ func TestSimpleRegionalWithKubeConfig(t *testing.T) {
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)
 		}
-
+		assert.Contains([]string{"RUNNING", "RECONCILING"}, op.Get("status").String())
 	})
 
 	bpt.Test()

--- a/test/integration/simple_regional_with_networking/simple_regional_with_networking_test.go
+++ b/test/integration/simple_regional_with_networking/simple_regional_with_networking_test.go
@@ -14,6 +14,7 @@
 package simple_regional_with_networking
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -32,6 +33,7 @@ func TestSimpleRegionalWithNetworking(t *testing.T) {
 	bpt.DefineVerify(func(assert *assert.Assertions) {
 		//Skipping Default Verify as the Verify Stage fails due to change in Client Cert Token
 		// bpt.DefaultVerify(assert)
+		testutils.TGKEVerify(t, bpt, assert) // Verify Resources
 
 		projectId := bpt.GetStringOutput("project_id")
 		location := bpt.GetStringOutput("location")
@@ -44,12 +46,9 @@ func TestSimpleRegionalWithNetworking(t *testing.T) {
 
 		op := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
 		g := golden.NewOrUpdate(t, op.String(),
-			golden.WithSanitizer(golden.StringSanitizer(serviceAccount, "SERVICE_ACCOUNT")),
-			golden.WithSanitizer(golden.StringSanitizer(projectId, "PROJECT_ID")),
-			golden.WithSanitizer(golden.StringSanitizer(clusterName, "CLUSTER_NAME")),
+			golden.WithSanitizer(testutils.GKEClusterSanitizer(serviceAccount, projectId, clusterName, op)),
 		)
 		validateJSONPaths := []string{
-			"status",
 			"location",
 			"privateClusterConfig.enablePrivateEndpoint",
 			"privateClusterConfig.enablePrivateNodes",
@@ -72,13 +71,11 @@ func TestSimpleRegionalWithNetworking(t *testing.T) {
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)
 		}
+		assert.Contains([]string{"RUNNING", "RECONCILING"}, op.Get("status").String())
 
 		op1 := gcloud.Runf(t, "compute networks subnets describe %s --project=%s --region=%s", subnetName, projectId, region)
-		assert.Contains(op1.Get("secondaryIpRanges").Array()[0].Get("rangeName").String(), ipRangePodName, "Has the correct secondaryIpRanges configuration")
-		assert.Contains(op1.Get("secondaryIpRanges").Array()[0].Get("ipCidrRange").String(), "192.168.0.0/18", "Has the correct secondaryIpRanges configuration")
-		assert.Contains(op1.Get("secondaryIpRanges").Array()[1].Get("rangeName").String(), ipRangeServicesName, "Has the correct secondaryIpRanges configuration")
-		assert.Contains(op1.Get("secondaryIpRanges").Array()[1].Get("ipCidrRange").String(), "192.168.64.0/18", "Has the correct secondaryIpRanges configuration")
-
+		assert.Equal("192.168.0.0/18", op1.Get(fmt.Sprintf("secondaryIpRanges.#(rangeName==\"%s\").ipCidrRange", ipRangePodName)).String(), "Has the correct Pod secondaryIpRange CIDR")
+		assert.Equal("192.168.64.0/18", op1.Get(fmt.Sprintf("secondaryIpRanges.#(rangeName==\"%s\").ipCidrRange", ipRangeServicesName)).String(), "Has the correct Services secondaryIpRange CIDR")
 	})
 
 	bpt.Test()

--- a/test/integration/simple_windows_node_pool/simple_windows_node_pool_test.go
+++ b/test/integration/simple_windows_node_pool/simple_windows_node_pool_test.go
@@ -33,6 +33,7 @@ func TestSimpleWindowsNodePool(t *testing.T) {
 	bpt.DefineVerify(func(assert *assert.Assertions) {
 		//Skipping Default Verify as the Verify Stage fails due to change in Client Cert Token
 		// bpt.DefaultVerify(assert)
+		testutils.TGKEVerify(t, bpt, assert) // Verify Resources
 
 		projectId := bpt.GetStringOutput("project_id")
 		location := bpt.GetStringOutput("location")
@@ -41,12 +42,9 @@ func TestSimpleWindowsNodePool(t *testing.T) {
 
 		op := gcloud.Runf(t, "beta container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
 		g := golden.NewOrUpdate(t, op.String(),
-			golden.WithSanitizer(golden.StringSanitizer(serviceAccount, "SERVICE_ACCOUNT")),
-			golden.WithSanitizer(golden.StringSanitizer(projectId, "PROJECT_ID")),
-			golden.WithSanitizer(golden.StringSanitizer(clusterName, "CLUSTER_NAME")),
+			golden.WithSanitizer(testutils.GKEClusterSanitizer(serviceAccount, projectId, clusterName, op)),
 		)
 		validateJSONPaths := []string{
-			"status",
 			"location",
 			"releaseChannel.channel",
 			"node_pools.name",
@@ -61,9 +59,9 @@ func TestSimpleWindowsNodePool(t *testing.T) {
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)
 		}
+		assert.Contains([]string{"RUNNING", "RECONCILING"}, op.Get("status").String())
 		op1 := gcloud.Runf(t, "iam service-accounts describe %s --project %s ", serviceAccount, projectId)
 		assert.Contains(op1.Get("description").String(), fmt.Sprintf("Terraform-managed service account for cluster %s", clusterName), "Custom Service Account Created")
-
 	})
 
 	bpt.Test()

--- a/test/integration/simple_zonal_private/simple_zonal_private_test.go
+++ b/test/integration/simple_zonal_private/simple_zonal_private_test.go
@@ -41,12 +41,9 @@ func TestSimpleZonalPrivate(t *testing.T) {
 
 		op := gcloud.Runf(t, "container clusters describe %s --zone %s --project %s", clusterName, location, projectId)
 		g := golden.NewOrUpdate(t, op.String(),
-			golden.WithSanitizer(golden.StringSanitizer(serviceAccount, "SERVICE_ACCOUNT")),
-			golden.WithSanitizer(golden.StringSanitizer(projectId, "PROJECT_ID")),
-			golden.WithSanitizer(golden.StringSanitizer(clusterName, "CLUSTER_NAME")),
+			golden.WithSanitizer(testutils.GKEClusterSanitizer(serviceAccount, projectId, clusterName, op)),
 		)
 		validateJSONPaths := []string{
-			"status",
 			"location",
 			"locations",
 			"privateClusterConfig.enablePrivateEndpoint",
@@ -71,7 +68,7 @@ func TestSimpleZonalPrivate(t *testing.T) {
 		for _, pth := range validateJSONPaths {
 			g.JSONEq(assert, op, pth)
 		}
-
+		assert.Contains([]string{"RUNNING", "RECONCILING"}, op.Get("status").String())
 	})
 
 	bpt.Test()

--- a/test/integration/stub_domains/stub_domains_test.go
+++ b/test/integration/stub_domains/stub_domains_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package node_pool
+package stub_domains
 
 import (
 	"fmt"
@@ -49,8 +49,7 @@ func TestStubDomains(t *testing.T) {
 
 		// Setup golden image with sanitizers
 		g := golden.NewOrUpdate(t, cluster.String(),
-			golden.WithSanitizer(golden.StringSanitizer(nodeServiceAccount, "NODE_SERVICE_ACCOUNT")),
-			golden.WithSanitizer(golden.StringSanitizer(projectId, "PROJECT_ID")),
+			golden.WithSanitizer(testutils.GKEClusterSanitizer(nodeServiceAccount, projectId, clusterName, cluster)),
 			golden.WithSanitizer(golden.StringSanitizer(randomString, "RANDOM_STRING")),
 			golden.WithSanitizer(golden.StringSanitizer(kubernetesEndpoint, "KUBERNETES_ENDPOINT")),
 		)
@@ -69,7 +68,7 @@ func TestStubDomains(t *testing.T) {
 		assert.NoError(err)
 		kubeDnsCM := utils.ParseKubectlJSONResult(t, listKubeDnsConfigMap)
 		assert.Contains("kube-dns", kubeDnsCM.Get("metadata.name").String(), "kube-dns configmap is present")
-		assert.Equal("Terraform", kubeDnsCM.Get("metadata.managedFields.0.manager").String(), "kube-dns configmap is managed by Terraform")
+		assert.True(kubeDnsCM.Get("metadata.managedFields.#(manager==\"Terraform\")").Exists(), "kube-dns configmap is managed by Terraform")
 		//assert.Equal("[\"8.8.8.8\",\"8.8.4.4\"]\n", kubeDnsCM.Get("data.stubDomains").String(), "kube-dns configmap reflects the upstream_nameservers configuration")
 
 		assert.JSONEq(`{
@@ -82,7 +81,7 @@ func TestStubDomains(t *testing.T) {
 				"10.254.154.12"
 			]
 		}`,
-		kubeDnsCM.Get("data.stubDomains").String(), "kube-dns configmap the expected stubdomains")
+			kubeDnsCM.Get("data.stubDomains").String(), "kube-dns configmap the expected stubdomains")
 
 		// ip-masq-agent
 		listIpMasqAgentConfigMap, err := k8s.RunKubectlAndGetOutputE(t, k8sOpts, "get", "configmap", "ip-masq-agent", "-n", "kube-system", "-o", "json", "--show-managed-fields")

--- a/test/integration/stub_domains/testdata/TestStubDomains.json
+++ b/test/integration/stub_domains/testdata/TestStubDomains.json
@@ -109,7 +109,7 @@
     }
   },
   "monitoringService": "monitoring.googleapis.com/kubernetes",
-  "name": "stub-domains-cluster-RANDOM_STRING",
+  "name": "CLUSTER_NAME",
   "network": "cft-gke-test-RANDOM_STRING",
   "networkConfig": {
     "defaultSnatStatus": {},
@@ -140,8 +140,8 @@
       "enableIntegrityMonitoring": true
     },
     "tags": [
-      "gke-stub-domains-cluster-RANDOM_STRING",
-      "gke-stub-domains-cluster-RANDOM_STRING-default-pool"
+      "gke-CLUSTER_NAME",
+      "gke-CLUSTER_NAME-default-pool"
     ],
     "windowsNodeConfig": {},
     "workloadMetadataConfig": {
@@ -180,7 +180,7 @@
     "mode": "DISABLED",
     "vulnerabilityMode": "VULNERABILITY_DISABLED"
   },
-  "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/stub-domains-cluster-RANDOM_STRING",
+  "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/CLUSTER_NAME",
   "servicesIpv4Cidr": "192.168.64.0/18",
   "shieldedNodes": {
     "enabled": true

--- a/test/integration/stub_domains_private/stub_domains_private_test.go
+++ b/test/integration/stub_domains_private/stub_domains_private_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package node_pool
+package stub_domains_private
 
 import (
 	"fmt"
@@ -49,8 +49,7 @@ func TestStubDomainsPrivate(t *testing.T) {
 
 		// Setup golden image with sanitizers
 		g := golden.NewOrUpdate(t, cluster.String(),
-			golden.WithSanitizer(golden.StringSanitizer(nodeServiceAccount, "NODE_SERVICE_ACCOUNT")),
-			golden.WithSanitizer(golden.StringSanitizer(projectId, "PROJECT_ID")),
+			golden.WithSanitizer(testutils.GKEClusterSanitizer(nodeServiceAccount, projectId, clusterName, cluster)),
 			golden.WithSanitizer(golden.StringSanitizer(randomString, "RANDOM_STRING")),
 			golden.WithSanitizer(golden.StringSanitizer(kubernetesEndpoint, "KUBERNETES_ENDPOINT")),
 		)
@@ -69,7 +68,7 @@ func TestStubDomainsPrivate(t *testing.T) {
 		assert.NoError(err)
 		kubeDnsCM := utils.ParseKubectlJSONResult(t, listKubeDnsConfigMap)
 		assert.Contains("kube-dns", kubeDnsCM.Get("metadata.name").String(), "kube-dns configmap is present")
-		assert.Equal("Terraform", kubeDnsCM.Get("metadata.managedFields.0.manager").String(), "kube-dns configmap is managed by Terraform")
+		assert.True(kubeDnsCM.Get("metadata.managedFields.#(manager==\"Terraform\")").Exists(), "kube-dns configmap is managed by Terraform")
 		//assert.Equal("[\"8.8.8.8\",\"8.8.4.4\"]\n", kubeDnsCM.Get("data.stubDomains").String(), "kube-dns configmap reflects the upstream_nameservers configuration")
 
 		assert.JSONEq(`{
@@ -82,7 +81,7 @@ func TestStubDomainsPrivate(t *testing.T) {
 				"10.254.154.12"
 			]
 		}`,
-		kubeDnsCM.Get("data.stubDomains").String(), "kube-dns configmap the expected stubdomains")
+			kubeDnsCM.Get("data.stubDomains").String(), "kube-dns configmap the expected stubdomains")
 	})
 	bpt.Test()
 }

--- a/test/integration/stub_domains_private/testdata/TestStubDomainsPrivate.json
+++ b/test/integration/stub_domains_private/testdata/TestStubDomainsPrivate.json
@@ -110,7 +110,7 @@
     }
   },
   "monitoringService": "monitoring.googleapis.com/kubernetes",
-  "name": "upstream-nameservers-cluster-RANDOM_STRING",
+  "name": "CLUSTER_NAME",
   "network": "cft-gke-test-RANDOM_STRING",
   "networkConfig": {
     "defaultSnatStatus": {},
@@ -141,8 +141,8 @@
       "enableIntegrityMonitoring": true
     },
     "tags": [
-      "gke-upstream-nameservers-cluster-RANDOM_STRING",
-      "gke-upstream-nameservers-cluster-RANDOM_STRING-default-pool"
+      "gke-CLUSTER_NAME",
+      "gke-CLUSTER_NAME-default-pool"
     ],
     "windowsNodeConfig": {},
     "workloadMetadataConfig": {
@@ -183,7 +183,7 @@
     "mode": "DISABLED",
     "vulnerabilityMode": "VULNERABILITY_DISABLED"
   },
-  "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/upstream-nameservers-cluster-RANDOM_STRING",
+  "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/CLUSTER_NAME",
   "servicesIpv4Cidr": "192.168.64.0/18",
   "shieldedNodes": {
     "enabled": true

--- a/test/integration/stub_domains_upstream_nameservers/stub_domains_upstream_nameservers_test.go
+++ b/test/integration/stub_domains_upstream_nameservers/stub_domains_upstream_nameservers_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package node_pool
+package stub_domains_upstream_nameservers
 
 import (
 	"fmt"
@@ -49,8 +49,7 @@ func TestStubDomainsUpstreamNameservers(t *testing.T) {
 
 		// Setup golden image with sanitizers
 		g := golden.NewOrUpdate(t, cluster.String(),
-			golden.WithSanitizer(golden.StringSanitizer(nodeServiceAccount, "NODE_SERVICE_ACCOUNT")),
-			golden.WithSanitizer(golden.StringSanitizer(projectId, "PROJECT_ID")),
+			golden.WithSanitizer(testutils.GKEClusterSanitizer(nodeServiceAccount, projectId, clusterName, cluster)),
 			golden.WithSanitizer(golden.StringSanitizer(randomString, "RANDOM_STRING")),
 			golden.WithSanitizer(golden.StringSanitizer(kubernetesEndpoint, "KUBERNETES_ENDPOINT")),
 		)
@@ -69,7 +68,7 @@ func TestStubDomainsUpstreamNameservers(t *testing.T) {
 		assert.NoError(err)
 		kubeDnsCM := utils.ParseKubectlJSONResult(t, listKubeDnsConfigMap)
 		assert.Contains("kube-dns", kubeDnsCM.Get("metadata.name").String(), "kube-dns configmap is present")
-		assert.Equal("Terraform", kubeDnsCM.Get("metadata.managedFields.0.manager").String(), "kube-dns configmap is managed by Terraform")
+		assert.True(kubeDnsCM.Get("metadata.managedFields.#(manager==\"Terraform\")").Exists(), "kube-dns configmap is managed by Terraform")
 		assert.Equal("[\"8.8.8.8\",\"8.8.4.4\"]\n", kubeDnsCM.Get("data.upstreamNameservers").String(), "kube-dns configmap reflects the upstream_nameservers configuration")
 
 		assert.JSONEq(`{
@@ -82,7 +81,7 @@ func TestStubDomainsUpstreamNameservers(t *testing.T) {
 				"10.254.154.12"
 			]
 		}`,
-		kubeDnsCM.Get("data.stubDomains").String(), "kube-dns configmap the expected stubdomains")
+			kubeDnsCM.Get("data.stubDomains").String(), "kube-dns configmap the expected stubdomains")
 
 		// ip-masq-agent
 		listIpMasqAgentConfigMap, err := k8s.RunKubectlAndGetOutputE(t, k8sOpts, "get", "configmap", "ip-masq-agent", "-n", "kube-system", "-o", "json", "--show-managed-fields")

--- a/test/integration/stub_domains_upstream_nameservers/testdata/TestStubDomainsUpstreamNameservers.json
+++ b/test/integration/stub_domains_upstream_nameservers/testdata/TestStubDomainsUpstreamNameservers.json
@@ -109,7 +109,7 @@
     }
   },
   "monitoringService": "monitoring.googleapis.com/kubernetes",
-  "name": "domains-nameservers-cluster-RANDOM_STRING",
+  "name": "CLUSTER_NAME",
   "network": "cft-gke-test-RANDOM_STRING",
   "networkConfig": {
     "defaultSnatStatus": {},
@@ -140,8 +140,8 @@
       "enableIntegrityMonitoring": true
     },
     "tags": [
-      "gke-domains-nameservers-cluster-RANDOM_STRING",
-      "gke-domains-nameservers-cluster-RANDOM_STRING-default-pool"
+      "gke-CLUSTER_NAME",
+      "gke-CLUSTER_NAME-default-pool"
     ],
     "windowsNodeConfig": {},
     "workloadMetadataConfig": {
@@ -181,13 +181,13 @@
           "https://www.googleapis.com/auth/userinfo.email",
           "https://www.googleapis.com/auth/cloud-platform"
         ],
-        "serviceAccount": "NODE_SERVICE_ACCOUNT",
+        "serviceAccount": "SERVICE_ACCOUNT",
         "shieldedInstanceConfig": {
           "enableIntegrityMonitoring": true
         },
         "tags": [
-          "gke-domains-nameservers-cluster-RANDOM_STRING",
-          "gke-domains-nameservers-cluster-RANDOM_STRING-default-pool"
+          "gke-CLUSTER_NAME",
+          "gke-CLUSTER_NAME-default-pool"
         ],
         "windowsNodeConfig": {},
         "workloadMetadataConfig": {
@@ -207,7 +207,7 @@
         "podRange": "cft-gke-test-pods-RANDOM_STRING"
       },
       "podIpv4CidrSize": 24,
-      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/domains-nameservers-cluster-RANDOM_STRING/nodePools/default-pool",
+      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/CLUSTER_NAME/nodePools/default-pool",
       "status": "RUNNING",
       "upgradeSettings": {
         "maxSurge": 1,
@@ -236,7 +236,7 @@
     "mode": "DISABLED",
     "vulnerabilityMode": "VULNERABILITY_DISABLED"
   },
-  "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/domains-nameservers-cluster-RANDOM_STRING",
+  "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/CLUSTER_NAME",
   "servicesIpv4Cidr": "192.168.64.0/18",
   "shieldedNodes": {
     "enabled": true

--- a/test/integration/testutils/utils.go
+++ b/test/integration/testutils/utils.go
@@ -32,23 +32,51 @@ import (
 
 var (
 	RetryableTransientErrors = map[string]string{
-		// Error 409: unable to queue the operation
-		".*Error 409.*unable to queue the operation": "Unable to queue operation.",
+		// Error 409: Operation / Policy conflicts
+		".*Error 409.*unable to queue the operation":            "Unable to queue operation.",
+		".*Error 409.*There were concurrent policy changes.*":   "Concurrent policy changes.",
+		".*Error 409.*Another operation is already in progress": "Another operation in progress.",
+		".*Error 409.*is in use":                                "Resource in use.",
 
-		// Error code 409 for concurrent policy changes.
-		".*Error 409.*There were concurrent policy changes.*": "Concurrent policy changes.",
+		// Rate limiting & Quotas
+		".*rateLimitExceeded.*":        "Rate limit exceeded.",
+		".*quotaExceeded.*":            "Quota exceeded.",
+		".*RESOURCE_EXHAUSTED.*":       "Resource exhausted.",
+		".*User Rate Limit Exceeded.*": "User rate limit exceeded.",
 
-		// API Rate limit exceeded errors can be retried.
-		".*rateLimitExceeded.*": "Rate limit exceeded.",
-
-		// Internal errors can be retried
+		// 5xx and Internal Server Errors
+		".*Error 500.*":    "Internal server error.",
+		".*Error 502.*":    "Bad gateway.",
+		".*Error 503.*":    "Service unavailable.",
+		".*backendError.*": "Backend error.",
 		".*Error code 13, message: an internal error has occurred": "Internal error.",
 
-		// Incompatible operation in progress
-		".*Error 400: Cluster is running incompatible operation.*": "Incompatible operation.",
+		// GKE Cluster update/lock conflicts
+		".*Error 400: Cluster is running incompatible operation.*":      "Incompatible operation.",
+		".*Error 400.*Master is being updated.*":                        "Master is being updated.",
+		".*Error 400.*Cluster is being updated.*":                       "Cluster is being updated.",
+		".*Error 400.*Cluster is not ready for operation.*":             "Cluster not ready.",
+		".*resource is currently locked as part of another operation.*": "Resource locked.",
+
+		// Transient IAM / SA replication
+		".*Permission.*denied on resource.*":   "IAM permission replication delay.",
+		".*Caller is missing IAM permission.*": "IAM permission replication delay.",
+		".*serviceAccount.*does not exist.*":   "Service account replication delay.",
+
+		// Transport / Network drops
+		".*connection reset by peer.*":       "Connection reset by peer.",
+		".*TLS handshake timeout.*":          "TLS handshake timeout.",
+		".*transport: Error while dialing.*": "Transport dialing error.",
+		".*i/o timeout.*":                    "I/O timeout.",
 	}
 
-	ClusterAlwaysExemptPaths = []string{"nodePools"} // node pools are separately checked by name
+	ClusterAlwaysExemptPaths = []string{
+		"nodePools", // node pools are separately checked by name
+		"monitoringConfig.componentConfig.enableComponents",
+		"labelFingerprint",
+		"maintenancePolicy.resourceVersion",
+		"etag",
+	}
 )
 
 func GetTestProjectFromSetup(t *testing.T, idx int) string {
@@ -141,6 +169,3 @@ func GKEClusterSanitizer(serviceAccount, projectId, clusterName string, clusterJ
 		return s
 	}
 }
-
-
-

--- a/test/integration/upstream_nameservers/testdata/TestUpstreamNameservers.json
+++ b/test/integration/upstream_nameservers/testdata/TestUpstreamNameservers.json
@@ -109,7 +109,7 @@
     }
   },
   "monitoringService": "monitoring.googleapis.com/kubernetes",
-  "name": "upstream-nameservers-cluster-RANDOM_STRING",
+  "name": "CLUSTER_NAME",
   "network": "cft-gke-test-RANDOM_STRING",
   "networkConfig": {
     "defaultSnatStatus": {},
@@ -140,8 +140,8 @@
       "enableIntegrityMonitoring": true
     },
     "tags": [
-      "gke-upstream-nameservers-cluster-RANDOM_STRING",
-      "gke-upstream-nameservers-cluster-RANDOM_STRING-default-pool"
+      "gke-CLUSTER_NAME",
+      "gke-CLUSTER_NAME-default-pool"
     ],
     "windowsNodeConfig": {},
     "workloadMetadataConfig": {
@@ -180,7 +180,7 @@
     "mode": "DISABLED",
     "vulnerabilityMode": "VULNERABILITY_DISABLED"
   },
-  "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/upstream-nameservers-cluster-RANDOM_STRING",
+  "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/clusters/CLUSTER_NAME",
   "servicesIpv4Cidr": "192.168.64.0/18",
   "shieldedNodes": {
     "enabled": true

--- a/test/integration/upstream_nameservers/upstream_nameservers_test.go
+++ b/test/integration/upstream_nameservers/upstream_nameservers_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package node_pool
+package upstream_nameservers
 
 import (
 	"fmt"
@@ -49,8 +49,7 @@ func TestUpstreamNameservers(t *testing.T) {
 
 		// Setup golden image with sanitizers
 		g := golden.NewOrUpdate(t, cluster.String(),
-			golden.WithSanitizer(golden.StringSanitizer(nodeServiceAccount, "NODE_SERVICE_ACCOUNT")),
-			golden.WithSanitizer(golden.StringSanitizer(projectId, "PROJECT_ID")),
+			golden.WithSanitizer(testutils.GKEClusterSanitizer(nodeServiceAccount, projectId, clusterName, cluster)),
 			golden.WithSanitizer(golden.StringSanitizer(randomString, "RANDOM_STRING")),
 			golden.WithSanitizer(golden.StringSanitizer(kubernetesEndpoint, "KUBERNETES_ENDPOINT")),
 		)
@@ -69,7 +68,7 @@ func TestUpstreamNameservers(t *testing.T) {
 		assert.NoError(err)
 		kubeDnsCM := utils.ParseKubectlJSONResult(t, listKubeDnsConfigMap)
 		assert.Contains("kube-dns", kubeDnsCM.Get("metadata.name").String(), "kube-dns configmap is present")
-		assert.Equal("Terraform", kubeDnsCM.Get("metadata.managedFields.0.manager").String(), "kube-dns configmap is managed by Terraform")
+		assert.True(kubeDnsCM.Get("metadata.managedFields.#(manager==\"Terraform\")").Exists(), "kube-dns configmap is managed by Terraform")
 		assert.Equal("[\"8.8.8.8\",\"8.8.4.4\"]\n", kubeDnsCM.Get("data.upstreamNameservers").String(), "kube-dns configmap reflects the upstream_nameservers configuration")
 
 		// ip-masq-agent

--- a/test/integration/workload_metadata_config/testdata/TestWorkloadMetadataConfig.json
+++ b/test/integration/workload_metadata_config/testdata/TestWorkloadMetadataConfig.json
@@ -108,7 +108,7 @@
     }
   },
   "monitoringService": "monitoring.googleapis.com/kubernetes",
-  "name": "workload-metadata-private-cluster-RANDOM_STRING",
+  "name": "CLUSTER_NAME",
   "network": "cft-gke-test-RANDOM_STRING",
   "networkConfig": {
     "defaultSnatStatus": {},
@@ -139,8 +139,8 @@
       "enableIntegrityMonitoring": true
     },
     "tags": [
-      "gke-workload-metadata-private-cluster-RANDOM_STRING",
-      "gke-workload-metadata-private-cluster-RANDOM_STRING-default-pool"
+      "gke-CLUSTER_NAME",
+      "gke-CLUSTER_NAME-default-pool"
     ],
     "windowsNodeConfig": {},
     "workloadMetadataConfig": {
@@ -180,13 +180,13 @@
           "https://www.googleapis.com/auth/userinfo.email",
           "https://www.googleapis.com/auth/cloud-platform"
         ],
-        "serviceAccount": "NODE_SERVICE_ACCOUNT",
+        "serviceAccount": "SERVICE_ACCOUNT",
         "shieldedInstanceConfig": {
           "enableIntegrityMonitoring": true
         },
         "tags": [
-          "gke-workload-metadata-private-cluster-RANDOM_STRING",
-          "gke-workload-metadata-private-cluster-RANDOM_STRING-default-pool"
+          "gke-CLUSTER_NAME",
+          "gke-CLUSTER_NAME-default-pool"
         ],
         "windowsNodeConfig": {},
         "workloadMetadataConfig": {
@@ -210,7 +210,7 @@
         "podRange": "cft-gke-test-pods-RANDOM_STRING"
       },
       "podIpv4CidrSize": 24,
-      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/zones/us-central1-a/clusters/workload-metadata-private-cluster-RANDOM_STRING/nodePools/default-pool",
+      "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/zones/us-central1-a/clusters/CLUSTER_NAME/nodePools/default-pool",
       "status": "RUNNING",
       "upgradeSettings": {
         "maxSurge": 1,
@@ -238,7 +238,7 @@
     "mode": "DISABLED",
     "vulnerabilityMode": "VULNERABILITY_DISABLED"
   },
-  "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/zones/us-central1-a/clusters/workload-metadata-private-cluster-RANDOM_STRING",
+  "selfLink": "https://container.googleapis.com/v1/projects/PROJECT_ID/zones/us-central1-a/clusters/CLUSTER_NAME",
   "servicesIpv4Cidr": "192.168.64.0/18",
   "shieldedNodes": {
     "enabled": true

--- a/test/integration/workload_metadata_config/workload_metadata_config_test.go
+++ b/test/integration/workload_metadata_config/workload_metadata_config_test.go
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package node_pool
+package workload_metadata_config
 
 import (
 	"fmt"
@@ -21,8 +21,10 @@ import (
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/golden"
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/terraform-google-modules/terraform-google-kubernetes-engine/test/integration/testutils"
+	"github.com/tidwall/gjson"
 )
 
 func TestWorkloadMetadataConfig(t *testing.T) {
@@ -47,8 +49,7 @@ func TestWorkloadMetadataConfig(t *testing.T) {
 
 		// Setup golden image with sanitizers
 		g := golden.NewOrUpdate(t, cluster.String(),
-			golden.WithSanitizer(golden.StringSanitizer(nodeServiceAccount, "NODE_SERVICE_ACCOUNT")),
-			golden.WithSanitizer(golden.StringSanitizer(projectId, "PROJECT_ID")),
+			golden.WithSanitizer(testutils.GKEClusterSanitizer(nodeServiceAccount, projectId, clusterName, cluster)),
 			golden.WithSanitizer(golden.StringSanitizer(randomString, "RANDOM_STRING")),
 			golden.WithSanitizer(golden.StringSanitizer(kubernetesEndpoint, "KUBERNETES_ENDPOINT")),
 		)
@@ -63,9 +64,21 @@ func TestWorkloadMetadataConfig(t *testing.T) {
 		serviceAccount := bpt.GetStringOutput("service_account")
 
 		for _, registryProjectId := range registryProjectIds.Array() {
-			imaPolicy := gcloud.Runf(t, "projects get-iam-policy %s", registryProjectId.String())
-			assert.Contains(imaPolicy.Get("bindings.#(role==\"roles/storage.objectViewer\").members").Value().([]interface{}), fmt.Sprintf("serviceAccount:%s", serviceAccount))
-			assert.Contains(imaPolicy.Get("bindings.#(role==\"roles/artifactregistry.reader\").members").Value().([]interface{}), fmt.Sprintf("serviceAccount:%s", serviceAccount))
+			regProj := registryProjectId.String()
+			utils.Poll(t, func() (bool, error) {
+				iamPolicyOutput, err := gcloud.RunCmdE(t, fmt.Sprintf("projects get-iam-policy %s", regProj))
+				if err != nil {
+					return true, err
+				}
+				iamPolicy := gjson.Parse(iamPolicyOutput)
+				saMember := fmt.Sprintf("serviceAccount:%s", serviceAccount)
+				hasStorageViewer := iamPolicy.Get("bindings.#(role==\"roles/storage.objectViewer\").members.#(==\"" + saMember + "\")").Exists()
+				hasArtifactReader := iamPolicy.Get("bindings.#(role==\"roles/artifactregistry.reader\").members.#(==\"" + saMember + "\")").Exists()
+				if !hasStorageViewer || !hasArtifactReader {
+					return true, fmt.Errorf("waiting for IAM bindings on project %s", regProj)
+				}
+				return false, nil
+			}, 20, 5*time.Second)
 		}
 	})
 	bpt.Test()

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -155,11 +155,8 @@ resource "google_service_account_key" "int_test" {
   service_account_id = google_service_account.int_test.id
 }
 
-resource "google_project_iam_binding" "kubernetes_engine_kms_access" {
+resource "google_project_iam_member" "kubernetes_engine_kms_access" {
   project = module.gke-project-1.project_id
   role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-
-  members = [
-    "serviceAccount:service-${module.gke-project-1.project_number}@container-engine-robot.iam.gserviceaccount.com",
-  ]
+  member  = "serviceAccount:service-${module.gke-project-1.project_number}@container-engine-robot.iam.gserviceaccount.com"
 }

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -74,7 +74,7 @@ module "gke-project-1" {
 
   deletion_policy = "DELETE"
 
-  auto_create_network = true
+  auto_create_network = false
 
   activate_apis = local.apis
   activate_api_identities = [


### PR DESCRIPTION
- Fix Cloud Build prepare error masking and upgrade machineType to E2_HIGHCPU_32
- Expand RetryableTransientErrors and exempt volatile GKE paths in testutils
- Add polling for async K8s/GCP resources (LoadBalancer IP, IAP SSH, Node taints, IAM policies)
- Replace rigid golden status checks with RUNNING/RECONCILING assertion
- Adopt GKEClusterSanitizer across tests asserting node pools
- Fix authoritative IAM binding race in test/setup and add suffix to CMEK keyring example
- Fix copy-paste package and function names in integration test files
- Enable subnet_private_access on network examples to prevent PGA plan diffs
- Remove UNSPECIFIED release_channel and random_shuffle version logic from examples/safer_cluster and examples/confidential_safer_cluster, allowing release_channel to default to REGULAR.