### PR TITLE
feat(deps): allow Terraform Google Provider v8 (major)

### DIFF
--- a/autogen/main/versions.tf.tmpl
+++ b/autogen/main/versions.tf.tmpl
@@ -24,33 +24,33 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.39.0, < 8"
+      version = ">= 7.39.0, < 9"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.39.0, < 8"
+      version = ">= 7.39.0, < 9"
     }
 {% elif beta_cluster and autopilot_cluster %}
   required_providers {
     google = {
       source = "hashicorp/google"
-      version = ">= 7.17.0, < 8"
+      version = ">= 7.17.0, < 9"
     }
     google-beta = {
       source = "hashicorp/google-beta"
-      version = ">= 7.17.0, < 8"
+      version = ">= 7.17.0, < 9"
     }
 {% elif autopilot_cluster  %}
   required_providers {
     google = {
       source = "hashicorp/google"
-      version = ">= 7.17.0, < 8"
+      version = ">= 7.17.0, < 9"
     }
 {% else %}
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.39.0, < 8"
+      version = ">= 7.39.0, < 9"
     }
 {% endif %}
     kubernetes = {

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -899,7 +899,7 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.39.0, < 8"
+        version: ">= 7.39.0, < 9"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/auth/metadata.yaml
+++ b/modules/auth/metadata.yaml
@@ -162,4 +162,4 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 4.47.0, != 4.49.0, != 4.50.0, < 8"
+        version: ">= 4.47.0, != 4.49.0, != 4.50.0, < 9"

--- a/modules/auth/versions.tf
+++ b/modules/auth/versions.tf
@@ -21,7 +21,7 @@ terraform {
     google = {
       source = "hashicorp/google"
       # Avoid v4.49 and v4.50 for https://github.com/hashicorp/terraform-provider-google/issues/13507
-      version = ">= 4.47.0, != 4.49.0, != 4.50.0, < 8"
+      version = ">= 4.47.0, != 4.49.0, != 4.50.0, < 9"
     }
   }
 

--- a/modules/beta-autopilot-private-cluster/metadata.yaml
+++ b/modules/beta-autopilot-private-cluster/metadata.yaml
@@ -632,9 +632,9 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.17.0, < 8"
+        version: ">= 7.17.0, < 9"
       - source: hashicorp/google-beta
-        version: ">= 7.17.0, < 8"
+        version: ">= 7.17.0, < 9"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/beta-autopilot-private-cluster/versions.tf
+++ b/modules/beta-autopilot-private-cluster/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.17.0, < 8"
+      version = ">= 7.17.0, < 9"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.17.0, < 8"
+      version = ">= 7.17.0, < 9"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-autopilot-public-cluster/metadata.yaml
+++ b/modules/beta-autopilot-public-cluster/metadata.yaml
@@ -606,9 +606,9 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.17.0, < 8"
+        version: ">= 7.17.0, < 9"
       - source: hashicorp/google-beta
-        version: ">= 7.17.0, < 8"
+        version: ">= 7.17.0, < 9"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/beta-autopilot-public-cluster/versions.tf
+++ b/modules/beta-autopilot-public-cluster/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.17.0, < 8"
+      version = ">= 7.17.0, < 9"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.17.0, < 8"
+      version = ">= 7.17.0, < 9"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-private-cluster-update-variant/metadata.yaml
+++ b/modules/beta-private-cluster-update-variant/metadata.yaml
@@ -927,9 +927,9 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.39.0, < 8"
+        version: ">= 7.39.0, < 9"
       - source: hashicorp/google-beta
-        version: ">= 7.39.0, < 8"
+        version: ">= 7.39.0, < 9"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/beta-private-cluster-update-variant/versions.tf
+++ b/modules/beta-private-cluster-update-variant/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.39.0, < 8"
+      version = ">= 7.39.0, < 9"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.39.0, < 8"
+      version = ">= 7.39.0, < 9"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-private-cluster/metadata.yaml
+++ b/modules/beta-private-cluster/metadata.yaml
@@ -927,9 +927,9 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.39.0, < 8"
+        version: ">= 7.39.0, < 9"
       - source: hashicorp/google-beta
-        version: ">= 7.39.0, < 8"
+        version: ">= 7.39.0, < 9"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/beta-private-cluster/versions.tf
+++ b/modules/beta-private-cluster/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.39.0, < 8"
+      version = ">= 7.39.0, < 9"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.39.0, < 8"
+      version = ">= 7.39.0, < 9"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-public-cluster-update-variant/metadata.yaml
+++ b/modules/beta-public-cluster-update-variant/metadata.yaml
@@ -901,9 +901,9 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.39.0, < 8"
+        version: ">= 7.39.0, < 9"
       - source: hashicorp/google-beta
-        version: ">= 7.39.0, < 8"
+        version: ">= 7.39.0, < 9"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/beta-public-cluster-update-variant/versions.tf
+++ b/modules/beta-public-cluster-update-variant/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.39.0, < 8"
+      version = ">= 7.39.0, < 9"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.39.0, < 8"
+      version = ">= 7.39.0, < 9"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/beta-public-cluster/metadata.yaml
+++ b/modules/beta-public-cluster/metadata.yaml
@@ -901,9 +901,9 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.39.0, < 8"
+        version: ">= 7.39.0, < 9"
       - source: hashicorp/google-beta
-        version: ">= 7.39.0, < 8"
+        version: ">= 7.39.0, < 9"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/beta-public-cluster/versions.tf
+++ b/modules/beta-public-cluster/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.39.0, < 8"
+      version = ">= 7.39.0, < 9"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.39.0, < 8"
+      version = ">= 7.39.0, < 9"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/binary-authorization/metadata.yaml
+++ b/modules/binary-authorization/metadata.yaml
@@ -166,6 +166,6 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: < 8
+        version: < 9
       - source: hashicorp/google-beta
-        version: < 8
+        version: < 9

--- a/modules/binary-authorization/versions.tf
+++ b/modules/binary-authorization/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 8"
+      version = "< 9"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "< 8"
+      version = "< 9"
     }
   }
   provider_meta "google" {

--- a/modules/fleet-membership/metadata.yaml
+++ b/modules/fleet-membership/metadata.yaml
@@ -174,6 +174,6 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 5.6.0, < 8"
+        version: ">= 5.6.0, < 9"
       - source: hashicorp/google-beta
-        version: ">= 5.6.0, < 8"
+        version: ">= 5.6.0, < 9"

--- a/modules/fleet-membership/versions.tf
+++ b/modules/fleet-membership/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.6.0, < 8"
+      version = ">= 5.6.0, < 9"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.6.0, < 8"
+      version = ">= 5.6.0, < 9"
     }
   }
 

--- a/modules/gke-autopilot-cluster/metadata.yaml
+++ b/modules/gke-autopilot-cluster/metadata.yaml
@@ -589,4 +589,4 @@ spec:
       - container.googleapis.com
     providerVersions:
       - source: hashicorp/google-beta
-        version: ">= 6.33.0, < 8"
+        version: ">= 6.33.0, < 9"

--- a/modules/gke-autopilot-cluster/versions.tf
+++ b/modules/gke-autopilot-cluster/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.33.0, < 8"
+      version = ">= 6.33.0, < 9"
     }
   }
   provider_meta "google-beta" {

--- a/modules/gke-node-pool/metadata.yaml
+++ b/modules/gke-node-pool/metadata.yaml
@@ -425,4 +425,4 @@ spec:
       - container.googleapis.com
     providerVersions:
       - source: hashicorp/google-beta
-        version: ">= 6.33.0, < 8"
+        version: ">= 6.33.0, < 9"

--- a/modules/gke-node-pool/versions.tf
+++ b/modules/gke-node-pool/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.33.0, < 8"
+      version = ">= 6.33.0, < 9"
     }
   }
   provider_meta "google-beta" {

--- a/modules/gke-standard-cluster/metadata.yaml
+++ b/modules/gke-standard-cluster/metadata.yaml
@@ -1155,4 +1155,4 @@ spec:
       - container.googleapis.com
     providerVersions:
       - source: hashicorp/google-beta
-        version: ">= 6.33.0, < 8"
+        version: ">= 6.33.0, < 9"

--- a/modules/gke-standard-cluster/versions.tf
+++ b/modules/gke-standard-cluster/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.33.0, < 8"
+      version = ">= 6.33.0, < 9"
     }
   }
   provider_meta "google-beta" {

--- a/modules/hub-legacy/metadata.yaml
+++ b/modules/hub-legacy/metadata.yaml
@@ -195,6 +195,6 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: < 8
+        version: < 9
       - source: hashicorp/google-beta
-        version: < 8
+        version: < 9

--- a/modules/hub-legacy/versions.tf
+++ b/modules/hub-legacy/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 8"
+      version = "< 9"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "< 8"
+      version = "< 9"
     }
   }
   provider_meta "google" {

--- a/modules/private-cluster-update-variant/metadata.yaml
+++ b/modules/private-cluster-update-variant/metadata.yaml
@@ -885,7 +885,7 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.39.0, < 8"
+        version: ">= 7.39.0, < 9"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/private-cluster-update-variant/versions.tf
+++ b/modules/private-cluster-update-variant/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.39.0, < 8"
+      version = ">= 7.39.0, < 9"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/private-cluster/metadata.yaml
+++ b/modules/private-cluster/metadata.yaml
@@ -885,7 +885,7 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 7.39.0, < 8"
+        version: ">= 7.39.0, < 9"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"
       - source: hashicorp/random

--- a/modules/private-cluster/versions.tf
+++ b/modules/private-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.39.0, < 8"
+      version = ">= 7.39.0, < 9"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/modules/workload-identity/metadata.yaml
+++ b/modules/workload-identity/metadata.yaml
@@ -228,6 +228,6 @@ spec:
           - roles/editor
     providerVersions:
       - source: hashicorp/google
-        version: ">= 5.12.0, < 8"
+        version: ">= 5.12.0, < 9"
       - source: hashicorp/kubernetes
         version: ">= 2.10, < 4"

--- a/modules/workload-identity/versions.tf
+++ b/modules/workload-identity/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.12.0, < 8"
+      version = ">= 5.12.0, < 9"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/versions.tf
+++ b/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.39.0, < 8"
+      version = ">= 7.39.0, < 9"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## Summary

- Widen the `google` and `google-beta` upper bound from `< 8` to `< 9` in `autogen/main/versions.tf.tmpl`, every generated and hand-maintained `versions.tf`, and the matching `metadata.yaml` files. Existing lower bounds are unchanged, so this is non-breaking for current users.
- Lets users pick up provider 8.0.0, where `logging_config.enable_components` and `monitoring_config.enable_components` on `google_container_cluster` became a `TypeSet` (GoogleCloudPlatform/magic-modules#18262), fixing the element-ordering permadiff in hashicorp/terraform-provider-google#27247.
- No HCL changes are needed. The modules assign `list(string)` variables to `enable_components`, which Terraform converts to a set on assignment, and nothing in the repo indexes `enable_components` on the resource. The only other `google_container_cluster` change in the v8 upgrade guide is the non-breaking `name_prefix` max-length extension.

Same footprint as the v7 bump in #2425 (35 files).

## Test plan

- [x] `grep -rn "< 8"` across `versions.tf`, `versions.tf.tmpl`, and `metadata.yaml` returns nothing
- [x] `make generate` produces no further changes (template and generated modules agree)
- [x] `terraform init` in `modules/beta-public-cluster` resolves and installs google/google-beta 8.1.0 under the new constraint
- [ ] CI lint (metadata and docs generation check)
- [ ] CI integration tests