### PR TITLE
test: improve CI tolerance for GPU node pool creation in europe-west4

### DIFF
--- a/examples/node_pool/main.tf
+++ b/examples/node_pool/main.tf
@@ -78,8 +78,10 @@ module "gke" {
     {
       name              = "pool-02"
       machine_type      = "g2-standard-4"
-      min_count         = 1
-      max_count         = 2
+      node_locations    = "${var.region}-a,${var.region}-b,${var.region}-c"
+      total_min_count   = 1
+      total_max_count   = 2
+      location_policy   = "ANY"
       local_ssd_count   = 0
       disk_size_gb      = 30
       disk_type         = "pd-standard"

--- a/test/integration/node_pool/testdata/TestNodePool.json
+++ b/test/integration/node_pool/testdata/TestNodePool.json
@@ -407,9 +407,9 @@
     {
       "autoscaling": {
         "enabled": true,
-        "locationPolicy": "BALANCED",
-        "maxNodeCount": 2,
-        "minNodeCount": 1
+        "locationPolicy": "ANY",
+        "totalMaxNodeCount": 2,
+        "totalMinNodeCount": 1
       },
       "config": {
         "accelerators": [
@@ -481,7 +481,9 @@
       },
       "initialNodeCount": 1,
       "locations": [
-        "europe-west4-b"
+        "europe-west4-a",
+        "europe-west4-b",
+        "europe-west4-c"
       ],
       "management": {
         "autoUpgrade": true

--- a/test/integration/testutils/utils.go
+++ b/test/integration/testutils/utils.go
@@ -57,6 +57,8 @@ var (
 		".*Error 400.*Cluster is being updated.*":                       "Cluster is being updated.",
 		".*Error 400.*Cluster is not ready for operation.*":             "Cluster not ready.",
 		".*resource is currently locked as part of another operation.*": "Resource locked.",
+		".*NodePool.*was created in the error state.*":                  "Node pool creation failed in error state.",
+		".*Cluster.*was created in the error state.*":                   "Cluster creation failed in error state.",
 
 		// Transient IAM / SA replication
 		".*Permission.*denied on resource.*":   "IAM permission replication delay.",


### PR DESCRIPTION
Configure pool-02 in examples/node_pool across all europe-west4 zones with location_policy = "ANY" and total min/max node counts, update golden test assertions, and add error state retry patterns to RetryableTransientErrors.