### PR TITLE
feat: add registryPullQPS, registryBurst, eventRecordQPS, eventBurst to node pool kubelet_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,10 @@ The node_pools variable takes the following parameters:
 | initial_node_count | The initial number of nodes for the pool. In regional or multi-zonal clusters, this is the number of nodes per zone. Changing this will force recreation of the resource. Defaults to the value of min_count | " " | Optional |
 | insecure_kubelet_readonly_port_enabled | (boolean) Whether or not to enable the insecure Kubelet readonly port. | null | Optional |
 | single_process_oom_kill | (boolean) On cgroupv2 nodes, defines whether processes in the container are OOM killed individually (true) or as a group (false, the kubelet default). Leave null to keep the kubelet default. | null | Optional |
+| registry_pull_qps | The limit of image registry pulls per second per node. Set to 0 for no limit. Leave null to keep the kubelet default (5 pulls/s). | null | Optional |
+| registry_burst | The maximum burst size for image registry pulls above registry_pull_qps per node. Leave null to keep the kubelet default (10). | null | Optional |
+| event_record_qps | The limit of events created per second per node. Set to 0 for no limit. Leave null to keep the kubelet default (50 events/s). | null | Optional |
+| event_burst | The maximum burst size for events above event_record_qps per node. Leave null to keep the kubelet default (100). | null | Optional |
 | key | The key required for the taint | | Required |
 | logging_variant | The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT. | DEFAULT | Optional |
 | local_ssd_count | The amount of local SSD disks that will be attached to each cluster node and may be used as a `hostpath` volume or a `local` PersistentVolume. | 0 | Optional |

--- a/autogen/main/README.md
+++ b/autogen/main/README.md
@@ -229,6 +229,10 @@ The node_pools variable takes the following parameters:
 | initial_node_count | The initial number of nodes for the pool. In regional or multi-zonal clusters, this is the number of nodes per zone. Changing this will force recreation of the resource. Defaults to the value of min_count | " " | Optional |
 | insecure_kubelet_readonly_port_enabled | (boolean) Whether or not to enable the insecure Kubelet readonly port. | null | Optional |
 | single_process_oom_kill | (boolean) On cgroupv2 nodes, defines whether processes in the container are OOM killed individually (true) or as a group (false, the kubelet default). Leave null to keep the kubelet default. | null | Optional |
+| registry_pull_qps | The limit of image registry pulls per second per node. Set to 0 for no limit. Leave null to keep the kubelet default (5 pulls/s). | null | Optional |
+| registry_burst | The maximum burst size for image registry pulls above registry_pull_qps per node. Leave null to keep the kubelet default (10). | null | Optional |
+| event_record_qps | The limit of events created per second per node. Set to 0 for no limit. Leave null to keep the kubelet default (50 events/s). | null | Optional |
+| event_burst | The maximum burst size for events above event_record_qps per node. Leave null to keep the kubelet default (100). | null | Optional |
 | key | The key required for the taint | | Required |
 | logging_variant | The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT. | DEFAULT | Optional |
 | local_ssd_count | The amount of local SSD disks that will be attached to each cluster node and may be used as a `hostpath` volume or a `local` PersistentVolume. | 0 | Optional |

--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -716,7 +716,7 @@ resource "google_container_cluster" "primary" {
       dynamic "kubelet_config" {
         for_each = length(setintersection(
           keys(local.head_node_pool),
-          ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+          ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
         )) != 0 || var.insecure_kubelet_readonly_port_enabled != null ? [1] : []
 
         content {
@@ -735,6 +735,10 @@ resource "google_container_cluster" "primary" {
           shutdown_grace_period_seconds               = lookup(local.head_node_pool, "shutdown_grace_period_seconds", null)
           shutdown_grace_period_critical_pods_seconds = lookup(local.head_node_pool, "shutdown_grace_period_critical_pods_seconds", null)
           single_process_oom_kill                     = lookup(local.head_node_pool, "single_process_oom_kill", null)
+          registry_pull_qps                           = lookup(local.head_node_pool, "registry_pull_qps", null)
+          registry_burst                              = lookup(local.head_node_pool, "registry_burst", null)
+          event_record_qps                            = lookup(local.head_node_pool, "event_record_qps", null)
+          event_burst                                 = lookup(local.head_node_pool, "event_burst", null)
         }
       }
 
@@ -1331,7 +1335,7 @@ resource "google_container_node_pool" "windows_pools" {
     dynamic "kubelet_config" {
       for_each = length(setintersection(
         keys(each.value),
-        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
       )) != 0 ? [1] : []
 
       content {
@@ -1350,6 +1354,10 @@ resource "google_container_node_pool" "windows_pools" {
         shutdown_grace_period_seconds               = lookup(each.value, "shutdown_grace_period_seconds", null)
         shutdown_grace_period_critical_pods_seconds = lookup(each.value, "shutdown_grace_period_critical_pods_seconds", null)
         single_process_oom_kill                     = lookup(each.value, "single_process_oom_kill", null)
+        registry_pull_qps                           = lookup(each.value, "registry_pull_qps", null)
+        registry_burst                              = lookup(each.value, "registry_burst", null)
+        event_record_qps                            = lookup(each.value, "event_record_qps", null)
+        event_burst                                 = lookup(each.value, "event_burst", null)
       }
     }
 

--- a/cluster.tf
+++ b/cluster.tf
@@ -566,7 +566,7 @@ resource "google_container_cluster" "primary" {
       dynamic "kubelet_config" {
         for_each = length(setintersection(
           keys(local.head_node_pool),
-          ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+          ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
         )) != 0 || var.insecure_kubelet_readonly_port_enabled != null ? [1] : []
 
         content {
@@ -585,6 +585,10 @@ resource "google_container_cluster" "primary" {
           shutdown_grace_period_seconds               = lookup(local.head_node_pool, "shutdown_grace_period_seconds", null)
           shutdown_grace_period_critical_pods_seconds = lookup(local.head_node_pool, "shutdown_grace_period_critical_pods_seconds", null)
           single_process_oom_kill                     = lookup(local.head_node_pool, "single_process_oom_kill", null)
+          registry_pull_qps                           = lookup(local.head_node_pool, "registry_pull_qps", null)
+          registry_burst                              = lookup(local.head_node_pool, "registry_burst", null)
+          event_record_qps                            = lookup(local.head_node_pool, "event_record_qps", null)
+          event_burst                                 = lookup(local.head_node_pool, "event_burst", null)
         }
       }
 
@@ -1013,7 +1017,7 @@ resource "google_container_node_pool" "pools" {
     dynamic "kubelet_config" {
       for_each = length(setintersection(
         keys(each.value),
-        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
       )) != 0 ? [1] : []
 
       content {
@@ -1032,6 +1036,10 @@ resource "google_container_node_pool" "pools" {
         shutdown_grace_period_seconds               = lookup(each.value, "shutdown_grace_period_seconds", null)
         shutdown_grace_period_critical_pods_seconds = lookup(each.value, "shutdown_grace_period_critical_pods_seconds", null)
         single_process_oom_kill                     = lookup(each.value, "single_process_oom_kill", null)
+        registry_pull_qps                           = lookup(each.value, "registry_pull_qps", null)
+        registry_burst                              = lookup(each.value, "registry_burst", null)
+        event_record_qps                            = lookup(each.value, "event_record_qps", null)
+        event_burst                                 = lookup(each.value, "event_burst", null)
       }
     }
 
@@ -1410,7 +1418,7 @@ resource "google_container_node_pool" "windows_pools" {
     dynamic "kubelet_config" {
       for_each = length(setintersection(
         keys(each.value),
-        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
       )) != 0 ? [1] : []
 
       content {
@@ -1429,6 +1437,10 @@ resource "google_container_node_pool" "windows_pools" {
         shutdown_grace_period_seconds               = lookup(each.value, "shutdown_grace_period_seconds", null)
         shutdown_grace_period_critical_pods_seconds = lookup(each.value, "shutdown_grace_period_critical_pods_seconds", null)
         single_process_oom_kill                     = lookup(each.value, "single_process_oom_kill", null)
+        registry_pull_qps                           = lookup(each.value, "registry_pull_qps", null)
+        registry_burst                              = lookup(each.value, "registry_burst", null)
+        event_record_qps                            = lookup(each.value, "event_record_qps", null)
+        event_burst                                 = lookup(each.value, "event_burst", null)
       }
     }
 

--- a/modules/beta-private-cluster-update-variant/README.md
+++ b/modules/beta-private-cluster-update-variant/README.md
@@ -418,6 +418,10 @@ The node_pools variable takes the following parameters:
 | initial_node_count | The initial number of nodes for the pool. In regional or multi-zonal clusters, this is the number of nodes per zone. Changing this will force recreation of the resource. Defaults to the value of min_count | " " | Optional |
 | insecure_kubelet_readonly_port_enabled | (boolean) Whether or not to enable the insecure Kubelet readonly port. | null | Optional |
 | single_process_oom_kill | (boolean) On cgroupv2 nodes, defines whether processes in the container are OOM killed individually (true) or as a group (false, the kubelet default). Leave null to keep the kubelet default. | null | Optional |
+| registry_pull_qps | The limit of image registry pulls per second per node. Set to 0 for no limit. Leave null to keep the kubelet default (5 pulls/s). | null | Optional |
+| registry_burst | The maximum burst size for image registry pulls above registry_pull_qps per node. Leave null to keep the kubelet default (10). | null | Optional |
+| event_record_qps | The limit of events created per second per node. Set to 0 for no limit. Leave null to keep the kubelet default (50 events/s). | null | Optional |
+| event_burst | The maximum burst size for events above event_record_qps per node. Leave null to keep the kubelet default (100). | null | Optional |
 | key | The key required for the taint | | Required |
 | logging_variant | The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT. | DEFAULT | Optional |
 | local_ssd_count | The amount of local SSD disks that will be attached to each cluster node and may be used as a `hostpath` volume or a `local` PersistentVolume. | 0 | Optional |

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -608,7 +608,7 @@ resource "google_container_cluster" "primary" {
       dynamic "kubelet_config" {
         for_each = length(setintersection(
           keys(local.head_node_pool),
-          ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+          ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
         )) != 0 || var.insecure_kubelet_readonly_port_enabled != null ? [1] : []
 
         content {
@@ -627,6 +627,10 @@ resource "google_container_cluster" "primary" {
           shutdown_grace_period_seconds               = lookup(local.head_node_pool, "shutdown_grace_period_seconds", null)
           shutdown_grace_period_critical_pods_seconds = lookup(local.head_node_pool, "shutdown_grace_period_critical_pods_seconds", null)
           single_process_oom_kill                     = lookup(local.head_node_pool, "single_process_oom_kill", null)
+          registry_pull_qps                           = lookup(local.head_node_pool, "registry_pull_qps", null)
+          registry_burst                              = lookup(local.head_node_pool, "registry_burst", null)
+          event_record_qps                            = lookup(local.head_node_pool, "event_record_qps", null)
+          event_burst                                 = lookup(local.head_node_pool, "event_burst", null)
         }
       }
 
@@ -1180,7 +1184,7 @@ resource "google_container_node_pool" "pools" {
     dynamic "kubelet_config" {
       for_each = length(setintersection(
         keys(each.value),
-        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
       )) != 0 ? [1] : []
 
       content {
@@ -1199,6 +1203,10 @@ resource "google_container_node_pool" "pools" {
         shutdown_grace_period_seconds               = lookup(each.value, "shutdown_grace_period_seconds", null)
         shutdown_grace_period_critical_pods_seconds = lookup(each.value, "shutdown_grace_period_critical_pods_seconds", null)
         single_process_oom_kill                     = lookup(each.value, "single_process_oom_kill", null)
+        registry_pull_qps                           = lookup(each.value, "registry_pull_qps", null)
+        registry_burst                              = lookup(each.value, "registry_burst", null)
+        event_record_qps                            = lookup(each.value, "event_record_qps", null)
+        event_burst                                 = lookup(each.value, "event_burst", null)
       }
     }
 
@@ -1591,7 +1599,7 @@ resource "google_container_node_pool" "windows_pools" {
     dynamic "kubelet_config" {
       for_each = length(setintersection(
         keys(each.value),
-        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
       )) != 0 ? [1] : []
 
       content {
@@ -1610,6 +1618,10 @@ resource "google_container_node_pool" "windows_pools" {
         shutdown_grace_period_seconds               = lookup(each.value, "shutdown_grace_period_seconds", null)
         shutdown_grace_period_critical_pods_seconds = lookup(each.value, "shutdown_grace_period_critical_pods_seconds", null)
         single_process_oom_kill                     = lookup(each.value, "single_process_oom_kill", null)
+        registry_pull_qps                           = lookup(each.value, "registry_pull_qps", null)
+        registry_burst                              = lookup(each.value, "registry_burst", null)
+        event_record_qps                            = lookup(each.value, "event_record_qps", null)
+        event_burst                                 = lookup(each.value, "event_burst", null)
       }
     }
 

--- a/modules/beta-private-cluster/README.md
+++ b/modules/beta-private-cluster/README.md
@@ -396,6 +396,10 @@ The node_pools variable takes the following parameters:
 | initial_node_count | The initial number of nodes for the pool. In regional or multi-zonal clusters, this is the number of nodes per zone. Changing this will force recreation of the resource. Defaults to the value of min_count | " " | Optional |
 | insecure_kubelet_readonly_port_enabled | (boolean) Whether or not to enable the insecure Kubelet readonly port. | null | Optional |
 | single_process_oom_kill | (boolean) On cgroupv2 nodes, defines whether processes in the container are OOM killed individually (true) or as a group (false, the kubelet default). Leave null to keep the kubelet default. | null | Optional |
+| registry_pull_qps | The limit of image registry pulls per second per node. Set to 0 for no limit. Leave null to keep the kubelet default (5 pulls/s). | null | Optional |
+| registry_burst | The maximum burst size for image registry pulls above registry_pull_qps per node. Leave null to keep the kubelet default (10). | null | Optional |
+| event_record_qps | The limit of events created per second per node. Set to 0 for no limit. Leave null to keep the kubelet default (50 events/s). | null | Optional |
+| event_burst | The maximum burst size for events above event_record_qps per node. Leave null to keep the kubelet default (100). | null | Optional |
 | key | The key required for the taint | | Required |
 | logging_variant | The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT. | DEFAULT | Optional |
 | local_ssd_count | The amount of local SSD disks that will be attached to each cluster node and may be used as a `hostpath` volume or a `local` PersistentVolume. | 0 | Optional |

--- a/modules/beta-private-cluster/cluster.tf
+++ b/modules/beta-private-cluster/cluster.tf
@@ -608,7 +608,7 @@ resource "google_container_cluster" "primary" {
       dynamic "kubelet_config" {
         for_each = length(setintersection(
           keys(local.head_node_pool),
-          ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+          ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
         )) != 0 || var.insecure_kubelet_readonly_port_enabled != null ? [1] : []
 
         content {
@@ -627,6 +627,10 @@ resource "google_container_cluster" "primary" {
           shutdown_grace_period_seconds               = lookup(local.head_node_pool, "shutdown_grace_period_seconds", null)
           shutdown_grace_period_critical_pods_seconds = lookup(local.head_node_pool, "shutdown_grace_period_critical_pods_seconds", null)
           single_process_oom_kill                     = lookup(local.head_node_pool, "single_process_oom_kill", null)
+          registry_pull_qps                           = lookup(local.head_node_pool, "registry_pull_qps", null)
+          registry_burst                              = lookup(local.head_node_pool, "registry_burst", null)
+          event_record_qps                            = lookup(local.head_node_pool, "event_record_qps", null)
+          event_burst                                 = lookup(local.head_node_pool, "event_burst", null)
         }
       }
 
@@ -1091,7 +1095,7 @@ resource "google_container_node_pool" "pools" {
     dynamic "kubelet_config" {
       for_each = length(setintersection(
         keys(each.value),
-        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
       )) != 0 ? [1] : []
 
       content {
@@ -1110,6 +1114,10 @@ resource "google_container_node_pool" "pools" {
         shutdown_grace_period_seconds               = lookup(each.value, "shutdown_grace_period_seconds", null)
         shutdown_grace_period_critical_pods_seconds = lookup(each.value, "shutdown_grace_period_critical_pods_seconds", null)
         single_process_oom_kill                     = lookup(each.value, "single_process_oom_kill", null)
+        registry_pull_qps                           = lookup(each.value, "registry_pull_qps", null)
+        registry_burst                              = lookup(each.value, "registry_burst", null)
+        event_record_qps                            = lookup(each.value, "event_record_qps", null)
+        event_burst                                 = lookup(each.value, "event_burst", null)
       }
     }
 
@@ -1501,7 +1509,7 @@ resource "google_container_node_pool" "windows_pools" {
     dynamic "kubelet_config" {
       for_each = length(setintersection(
         keys(each.value),
-        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
       )) != 0 ? [1] : []
 
       content {
@@ -1520,6 +1528,10 @@ resource "google_container_node_pool" "windows_pools" {
         shutdown_grace_period_seconds               = lookup(each.value, "shutdown_grace_period_seconds", null)
         shutdown_grace_period_critical_pods_seconds = lookup(each.value, "shutdown_grace_period_critical_pods_seconds", null)
         single_process_oom_kill                     = lookup(each.value, "single_process_oom_kill", null)
+        registry_pull_qps                           = lookup(each.value, "registry_pull_qps", null)
+        registry_burst                              = lookup(each.value, "registry_burst", null)
+        event_record_qps                            = lookup(each.value, "event_record_qps", null)
+        event_burst                                 = lookup(each.value, "event_burst", null)
       }
     }
 

--- a/modules/beta-public-cluster-update-variant/README.md
+++ b/modules/beta-public-cluster-update-variant/README.md
@@ -404,6 +404,10 @@ The node_pools variable takes the following parameters:
 | initial_node_count | The initial number of nodes for the pool. In regional or multi-zonal clusters, this is the number of nodes per zone. Changing this will force recreation of the resource. Defaults to the value of min_count | " " | Optional |
 | insecure_kubelet_readonly_port_enabled | (boolean) Whether or not to enable the insecure Kubelet readonly port. | null | Optional |
 | single_process_oom_kill | (boolean) On cgroupv2 nodes, defines whether processes in the container are OOM killed individually (true) or as a group (false, the kubelet default). Leave null to keep the kubelet default. | null | Optional |
+| registry_pull_qps | The limit of image registry pulls per second per node. Set to 0 for no limit. Leave null to keep the kubelet default (5 pulls/s). | null | Optional |
+| registry_burst | The maximum burst size for image registry pulls above registry_pull_qps per node. Leave null to keep the kubelet default (10). | null | Optional |
+| event_record_qps | The limit of events created per second per node. Set to 0 for no limit. Leave null to keep the kubelet default (50 events/s). | null | Optional |
+| event_burst | The maximum burst size for events above event_record_qps per node. Leave null to keep the kubelet default (100). | null | Optional |
 | key | The key required for the taint | | Required |
 | logging_variant | The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT. | DEFAULT | Optional |
 | local_ssd_count | The amount of local SSD disks that will be attached to each cluster node and may be used as a `hostpath` volume or a `local` PersistentVolume. | 0 | Optional |

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -608,7 +608,7 @@ resource "google_container_cluster" "primary" {
       dynamic "kubelet_config" {
         for_each = length(setintersection(
           keys(local.head_node_pool),
-          ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+          ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
         )) != 0 || var.insecure_kubelet_readonly_port_enabled != null ? [1] : []
 
         content {
@@ -627,6 +627,10 @@ resource "google_container_cluster" "primary" {
           shutdown_grace_period_seconds               = lookup(local.head_node_pool, "shutdown_grace_period_seconds", null)
           shutdown_grace_period_critical_pods_seconds = lookup(local.head_node_pool, "shutdown_grace_period_critical_pods_seconds", null)
           single_process_oom_kill                     = lookup(local.head_node_pool, "single_process_oom_kill", null)
+          registry_pull_qps                           = lookup(local.head_node_pool, "registry_pull_qps", null)
+          registry_burst                              = lookup(local.head_node_pool, "registry_burst", null)
+          event_record_qps                            = lookup(local.head_node_pool, "event_record_qps", null)
+          event_burst                                 = lookup(local.head_node_pool, "event_burst", null)
         }
       }
 
@@ -1158,7 +1162,7 @@ resource "google_container_node_pool" "pools" {
     dynamic "kubelet_config" {
       for_each = length(setintersection(
         keys(each.value),
-        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
       )) != 0 ? [1] : []
 
       content {
@@ -1177,6 +1181,10 @@ resource "google_container_node_pool" "pools" {
         shutdown_grace_period_seconds               = lookup(each.value, "shutdown_grace_period_seconds", null)
         shutdown_grace_period_critical_pods_seconds = lookup(each.value, "shutdown_grace_period_critical_pods_seconds", null)
         single_process_oom_kill                     = lookup(each.value, "single_process_oom_kill", null)
+        registry_pull_qps                           = lookup(each.value, "registry_pull_qps", null)
+        registry_burst                              = lookup(each.value, "registry_burst", null)
+        event_record_qps                            = lookup(each.value, "event_record_qps", null)
+        event_burst                                 = lookup(each.value, "event_burst", null)
       }
     }
 
@@ -1569,7 +1577,7 @@ resource "google_container_node_pool" "windows_pools" {
     dynamic "kubelet_config" {
       for_each = length(setintersection(
         keys(each.value),
-        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
       )) != 0 ? [1] : []
 
       content {
@@ -1588,6 +1596,10 @@ resource "google_container_node_pool" "windows_pools" {
         shutdown_grace_period_seconds               = lookup(each.value, "shutdown_grace_period_seconds", null)
         shutdown_grace_period_critical_pods_seconds = lookup(each.value, "shutdown_grace_period_critical_pods_seconds", null)
         single_process_oom_kill                     = lookup(each.value, "single_process_oom_kill", null)
+        registry_pull_qps                           = lookup(each.value, "registry_pull_qps", null)
+        registry_burst                              = lookup(each.value, "registry_burst", null)
+        event_record_qps                            = lookup(each.value, "event_record_qps", null)
+        event_burst                                 = lookup(each.value, "event_burst", null)
       }
     }
 

--- a/modules/beta-public-cluster/README.md
+++ b/modules/beta-public-cluster/README.md
@@ -382,6 +382,10 @@ The node_pools variable takes the following parameters:
 | initial_node_count | The initial number of nodes for the pool. In regional or multi-zonal clusters, this is the number of nodes per zone. Changing this will force recreation of the resource. Defaults to the value of min_count | " " | Optional |
 | insecure_kubelet_readonly_port_enabled | (boolean) Whether or not to enable the insecure Kubelet readonly port. | null | Optional |
 | single_process_oom_kill | (boolean) On cgroupv2 nodes, defines whether processes in the container are OOM killed individually (true) or as a group (false, the kubelet default). Leave null to keep the kubelet default. | null | Optional |
+| registry_pull_qps | The limit of image registry pulls per second per node. Set to 0 for no limit. Leave null to keep the kubelet default (5 pulls/s). | null | Optional |
+| registry_burst | The maximum burst size for image registry pulls above registry_pull_qps per node. Leave null to keep the kubelet default (10). | null | Optional |
+| event_record_qps | The limit of events created per second per node. Set to 0 for no limit. Leave null to keep the kubelet default (50 events/s). | null | Optional |
+| event_burst | The maximum burst size for events above event_record_qps per node. Leave null to keep the kubelet default (100). | null | Optional |
 | key | The key required for the taint | | Required |
 | logging_variant | The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT. | DEFAULT | Optional |
 | local_ssd_count | The amount of local SSD disks that will be attached to each cluster node and may be used as a `hostpath` volume or a `local` PersistentVolume. | 0 | Optional |

--- a/modules/beta-public-cluster/cluster.tf
+++ b/modules/beta-public-cluster/cluster.tf
@@ -608,7 +608,7 @@ resource "google_container_cluster" "primary" {
       dynamic "kubelet_config" {
         for_each = length(setintersection(
           keys(local.head_node_pool),
-          ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+          ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
         )) != 0 || var.insecure_kubelet_readonly_port_enabled != null ? [1] : []
 
         content {
@@ -627,6 +627,10 @@ resource "google_container_cluster" "primary" {
           shutdown_grace_period_seconds               = lookup(local.head_node_pool, "shutdown_grace_period_seconds", null)
           shutdown_grace_period_critical_pods_seconds = lookup(local.head_node_pool, "shutdown_grace_period_critical_pods_seconds", null)
           single_process_oom_kill                     = lookup(local.head_node_pool, "single_process_oom_kill", null)
+          registry_pull_qps                           = lookup(local.head_node_pool, "registry_pull_qps", null)
+          registry_burst                              = lookup(local.head_node_pool, "registry_burst", null)
+          event_record_qps                            = lookup(local.head_node_pool, "event_record_qps", null)
+          event_burst                                 = lookup(local.head_node_pool, "event_burst", null)
         }
       }
 
@@ -1069,7 +1073,7 @@ resource "google_container_node_pool" "pools" {
     dynamic "kubelet_config" {
       for_each = length(setintersection(
         keys(each.value),
-        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
       )) != 0 ? [1] : []
 
       content {
@@ -1088,6 +1092,10 @@ resource "google_container_node_pool" "pools" {
         shutdown_grace_period_seconds               = lookup(each.value, "shutdown_grace_period_seconds", null)
         shutdown_grace_period_critical_pods_seconds = lookup(each.value, "shutdown_grace_period_critical_pods_seconds", null)
         single_process_oom_kill                     = lookup(each.value, "single_process_oom_kill", null)
+        registry_pull_qps                           = lookup(each.value, "registry_pull_qps", null)
+        registry_burst                              = lookup(each.value, "registry_burst", null)
+        event_record_qps                            = lookup(each.value, "event_record_qps", null)
+        event_burst                                 = lookup(each.value, "event_burst", null)
       }
     }
 
@@ -1479,7 +1487,7 @@ resource "google_container_node_pool" "windows_pools" {
     dynamic "kubelet_config" {
       for_each = length(setintersection(
         keys(each.value),
-        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
       )) != 0 ? [1] : []
 
       content {
@@ -1498,6 +1506,10 @@ resource "google_container_node_pool" "windows_pools" {
         shutdown_grace_period_seconds               = lookup(each.value, "shutdown_grace_period_seconds", null)
         shutdown_grace_period_critical_pods_seconds = lookup(each.value, "shutdown_grace_period_critical_pods_seconds", null)
         single_process_oom_kill                     = lookup(each.value, "single_process_oom_kill", null)
+        registry_pull_qps                           = lookup(each.value, "registry_pull_qps", null)
+        registry_burst                              = lookup(each.value, "registry_burst", null)
+        event_record_qps                            = lookup(each.value, "event_record_qps", null)
+        event_burst                                 = lookup(each.value, "event_burst", null)
       }
     }
 

--- a/modules/private-cluster-update-variant/README.md
+++ b/modules/private-cluster-update-variant/README.md
@@ -404,6 +404,10 @@ The node_pools variable takes the following parameters:
 | initial_node_count | The initial number of nodes for the pool. In regional or multi-zonal clusters, this is the number of nodes per zone. Changing this will force recreation of the resource. Defaults to the value of min_count | " " | Optional |
 | insecure_kubelet_readonly_port_enabled | (boolean) Whether or not to enable the insecure Kubelet readonly port. | null | Optional |
 | single_process_oom_kill | (boolean) On cgroupv2 nodes, defines whether processes in the container are OOM killed individually (true) or as a group (false, the kubelet default). Leave null to keep the kubelet default. | null | Optional |
+| registry_pull_qps | The limit of image registry pulls per second per node. Set to 0 for no limit. Leave null to keep the kubelet default (5 pulls/s). | null | Optional |
+| registry_burst | The maximum burst size for image registry pulls above registry_pull_qps per node. Leave null to keep the kubelet default (10). | null | Optional |
+| event_record_qps | The limit of events created per second per node. Set to 0 for no limit. Leave null to keep the kubelet default (50 events/s). | null | Optional |
+| event_burst | The maximum burst size for events above event_record_qps per node. Leave null to keep the kubelet default (100). | null | Optional |
 | key | The key required for the taint | | Required |
 | logging_variant | The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT. | DEFAULT | Optional |
 | local_ssd_count | The amount of local SSD disks that will be attached to each cluster node and may be used as a `hostpath` volume or a `local` PersistentVolume. | 0 | Optional |

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -566,7 +566,7 @@ resource "google_container_cluster" "primary" {
       dynamic "kubelet_config" {
         for_each = length(setintersection(
           keys(local.head_node_pool),
-          ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+          ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
         )) != 0 || var.insecure_kubelet_readonly_port_enabled != null ? [1] : []
 
         content {
@@ -585,6 +585,10 @@ resource "google_container_cluster" "primary" {
           shutdown_grace_period_seconds               = lookup(local.head_node_pool, "shutdown_grace_period_seconds", null)
           shutdown_grace_period_critical_pods_seconds = lookup(local.head_node_pool, "shutdown_grace_period_critical_pods_seconds", null)
           single_process_oom_kill                     = lookup(local.head_node_pool, "single_process_oom_kill", null)
+          registry_pull_qps                           = lookup(local.head_node_pool, "registry_pull_qps", null)
+          registry_burst                              = lookup(local.head_node_pool, "registry_burst", null)
+          event_record_qps                            = lookup(local.head_node_pool, "event_record_qps", null)
+          event_burst                                 = lookup(local.head_node_pool, "event_burst", null)
         }
       }
 
@@ -1123,7 +1127,7 @@ resource "google_container_node_pool" "pools" {
     dynamic "kubelet_config" {
       for_each = length(setintersection(
         keys(each.value),
-        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
       )) != 0 ? [1] : []
 
       content {
@@ -1142,6 +1146,10 @@ resource "google_container_node_pool" "pools" {
         shutdown_grace_period_seconds               = lookup(each.value, "shutdown_grace_period_seconds", null)
         shutdown_grace_period_critical_pods_seconds = lookup(each.value, "shutdown_grace_period_critical_pods_seconds", null)
         single_process_oom_kill                     = lookup(each.value, "single_process_oom_kill", null)
+        registry_pull_qps                           = lookup(each.value, "registry_pull_qps", null)
+        registry_burst                              = lookup(each.value, "registry_burst", null)
+        event_record_qps                            = lookup(each.value, "event_record_qps", null)
+        event_burst                                 = lookup(each.value, "event_burst", null)
       }
     }
 
@@ -1521,7 +1529,7 @@ resource "google_container_node_pool" "windows_pools" {
     dynamic "kubelet_config" {
       for_each = length(setintersection(
         keys(each.value),
-        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
       )) != 0 ? [1] : []
 
       content {
@@ -1540,6 +1548,10 @@ resource "google_container_node_pool" "windows_pools" {
         shutdown_grace_period_seconds               = lookup(each.value, "shutdown_grace_period_seconds", null)
         shutdown_grace_period_critical_pods_seconds = lookup(each.value, "shutdown_grace_period_critical_pods_seconds", null)
         single_process_oom_kill                     = lookup(each.value, "single_process_oom_kill", null)
+        registry_pull_qps                           = lookup(each.value, "registry_pull_qps", null)
+        registry_burst                              = lookup(each.value, "registry_burst", null)
+        event_record_qps                            = lookup(each.value, "event_record_qps", null)
+        event_burst                                 = lookup(each.value, "event_burst", null)
       }
     }
 

--- a/modules/private-cluster/README.md
+++ b/modules/private-cluster/README.md
@@ -382,6 +382,10 @@ The node_pools variable takes the following parameters:
 | initial_node_count | The initial number of nodes for the pool. In regional or multi-zonal clusters, this is the number of nodes per zone. Changing this will force recreation of the resource. Defaults to the value of min_count | " " | Optional |
 | insecure_kubelet_readonly_port_enabled | (boolean) Whether or not to enable the insecure Kubelet readonly port. | null | Optional |
 | single_process_oom_kill | (boolean) On cgroupv2 nodes, defines whether processes in the container are OOM killed individually (true) or as a group (false, the kubelet default). Leave null to keep the kubelet default. | null | Optional |
+| registry_pull_qps | The limit of image registry pulls per second per node. Set to 0 for no limit. Leave null to keep the kubelet default (5 pulls/s). | null | Optional |
+| registry_burst | The maximum burst size for image registry pulls above registry_pull_qps per node. Leave null to keep the kubelet default (10). | null | Optional |
+| event_record_qps | The limit of events created per second per node. Set to 0 for no limit. Leave null to keep the kubelet default (50 events/s). | null | Optional |
+| event_burst | The maximum burst size for events above event_record_qps per node. Leave null to keep the kubelet default (100). | null | Optional |
 | key | The key required for the taint | | Required |
 | logging_variant | The type of logging agent that is deployed by default for newly created node pools in the cluster. Valid values include DEFAULT and MAX_THROUGHPUT. | DEFAULT | Optional |
 | local_ssd_count | The amount of local SSD disks that will be attached to each cluster node and may be used as a `hostpath` volume or a `local` PersistentVolume. | 0 | Optional |

--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -566,7 +566,7 @@ resource "google_container_cluster" "primary" {
       dynamic "kubelet_config" {
         for_each = length(setintersection(
           keys(local.head_node_pool),
-          ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+          ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
         )) != 0 || var.insecure_kubelet_readonly_port_enabled != null ? [1] : []
 
         content {
@@ -585,6 +585,10 @@ resource "google_container_cluster" "primary" {
           shutdown_grace_period_seconds               = lookup(local.head_node_pool, "shutdown_grace_period_seconds", null)
           shutdown_grace_period_critical_pods_seconds = lookup(local.head_node_pool, "shutdown_grace_period_critical_pods_seconds", null)
           single_process_oom_kill                     = lookup(local.head_node_pool, "single_process_oom_kill", null)
+          registry_pull_qps                           = lookup(local.head_node_pool, "registry_pull_qps", null)
+          registry_burst                              = lookup(local.head_node_pool, "registry_burst", null)
+          event_record_qps                            = lookup(local.head_node_pool, "event_record_qps", null)
+          event_burst                                 = lookup(local.head_node_pool, "event_burst", null)
         }
       }
 
@@ -1035,7 +1039,7 @@ resource "google_container_node_pool" "pools" {
     dynamic "kubelet_config" {
       for_each = length(setintersection(
         keys(each.value),
-        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
       )) != 0 ? [1] : []
 
       content {
@@ -1054,6 +1058,10 @@ resource "google_container_node_pool" "pools" {
         shutdown_grace_period_seconds               = lookup(each.value, "shutdown_grace_period_seconds", null)
         shutdown_grace_period_critical_pods_seconds = lookup(each.value, "shutdown_grace_period_critical_pods_seconds", null)
         single_process_oom_kill                     = lookup(each.value, "single_process_oom_kill", null)
+        registry_pull_qps                           = lookup(each.value, "registry_pull_qps", null)
+        registry_burst                              = lookup(each.value, "registry_burst", null)
+        event_record_qps                            = lookup(each.value, "event_record_qps", null)
+        event_burst                                 = lookup(each.value, "event_burst", null)
       }
     }
 
@@ -1432,7 +1440,7 @@ resource "google_container_node_pool" "windows_pools" {
     dynamic "kubelet_config" {
       for_each = length(setintersection(
         keys(each.value),
-        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill"]
+        ["cpu_manager_policy", "cpu_cfs_quota", "cpu_cfs_quota_period", "insecure_kubelet_readonly_port_enabled", "pod_pids_limit", "container_log_max_size", "container_log_max_files", "image_gc_low_threshold_percent", "image_gc_high_threshold_percent", "image_minimum_gc_age", "image_maximum_gc_age", "allowed_unsafe_sysctls", "shutdown_grace_period_seconds", "shutdown_grace_period_critical_pods_seconds", "single_process_oom_kill", "registry_pull_qps", "registry_burst", "event_record_qps", "event_burst"]
       )) != 0 ? [1] : []
 
       content {
@@ -1451,6 +1459,10 @@ resource "google_container_node_pool" "windows_pools" {
         shutdown_grace_period_seconds               = lookup(each.value, "shutdown_grace_period_seconds", null)
         shutdown_grace_period_critical_pods_seconds = lookup(each.value, "shutdown_grace_period_critical_pods_seconds", null)
         single_process_oom_kill                     = lookup(each.value, "single_process_oom_kill", null)
+        registry_pull_qps                           = lookup(each.value, "registry_pull_qps", null)
+        registry_burst                              = lookup(each.value, "registry_burst", null)
+        event_record_qps                            = lookup(each.value, "event_record_qps", null)
+        event_burst                                 = lookup(each.value, "event_burst", null)
       }
     }
 


### PR DESCRIPTION
## Description

Adds passthrough of four new node-pool keys to `kubelet_config` (all variants — linux and windows pool blocks, plus the head-node-pool block):

| Key | Kubelet flag | Purpose | Kubelet default |
|-----|-------------|---------|-----------------|
| `registry_pull_qps` | `--registry-pull-qps` | Image registry pulls per second per node | 5 (0 = unlimited) |
| `registry_burst` | `--registry-burst` | Burst size above `registry_pull_qps` | 10 |
| `event_record_qps` | `--event-qps` | Events created per second per node | 50 (0 = unlimited) |
| `event_burst` | `--event-burst` | Burst size above `event_record_qps` | 100 |

These fields are supported by the `google` / `google-beta` provider in `kubelet_config` for both `google_container_cluster` (default node pool) and `google_container_node_pool`.

**Real-world motivations:**

- **`registry_pull_qps` / `registry_burst`**: clusters that pull many images in parallel (e.g. large-scale rolling deployments, node scale-out) can hit the kubelet's default 5 QPS pull limit, causing pods to stay `ContainerCreating` while image pulls queue up. Raising or eliminating the limit unblocks those pods.
- **`event_record_qps` / `event_burst`**: busy clusters (many pods per node, frequent scheduling or lifecycle events) can exhaust the default 50 events/s limit, silently dropping Kubernetes events and making incidents harder to debug. Tuning these ensures event delivery at the right fidelity.

## Notes

- All four keys default to `null`, which omits the provider field and preserves the kubelet defaults — **no behavior change for existing users**.
- Changes are generated: `autogen/main/cluster.tf.tmpl` + `autogen/main/README.md` edited, then `make generate` and `make generate_docs`.
- Follows the same pattern as #2631 (`single_process_oom_kill`).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)