### PR TITLE
fix: Preserve pool names when ForceNew inputs are unset

### DIFF
--- a/autogen/main/cluster.tf.tmpl
+++ b/autogen/main/cluster.tf.tmpl
@@ -967,6 +967,7 @@ locals {
     "flex_start",
     "local_ssd_ephemeral_storage_count",
     "ephemeral_storage_local_ssd_data_cache_count",
+    "pod_cidr_overprovision_disabled",
   ]
 }
 
@@ -979,10 +980,10 @@ resource "random_id" "name" {
   byte_length = 2
   prefix      = "${each.key}-"
   keepers = merge(
-    zipmap(
-      local.force_node_pool_recreation_resources,
-      [for keeper in local.force_node_pool_recreation_resources : lookup(each.value, keeper, "")]
-    ),
+    {
+      for keeper in local.force_node_pool_recreation_resources : keeper => lookup(each.value, keeper, "")
+      if contains(keys(each.value), keeper)
+    },
     {
       taints = join(",",
         sort(
@@ -1016,9 +1017,6 @@ resource "random_id" "name" {
           )
         )
       )
-    },
-    {
-      pod_cidr_overprovision_disabled = tostring(lookup(each.value, "pod_cidr_overprovision_disabled", ""))
     }
   )
 }

--- a/modules/beta-private-cluster-update-variant/cluster.tf
+++ b/modules/beta-private-cluster-update-variant/cluster.tf
@@ -841,6 +841,7 @@ locals {
     "flex_start",
     "local_ssd_ephemeral_storage_count",
     "ephemeral_storage_local_ssd_data_cache_count",
+    "pod_cidr_overprovision_disabled",
   ]
 }
 
@@ -853,10 +854,10 @@ resource "random_id" "name" {
   byte_length = 2
   prefix      = "${each.key}-"
   keepers = merge(
-    zipmap(
-      local.force_node_pool_recreation_resources,
-      [for keeper in local.force_node_pool_recreation_resources : lookup(each.value, keeper, "")]
-    ),
+    {
+      for keeper in local.force_node_pool_recreation_resources : keeper => lookup(each.value, keeper, "")
+      if contains(keys(each.value), keeper)
+    },
     {
       taints = join(",",
         sort(
@@ -890,9 +891,6 @@ resource "random_id" "name" {
           )
         )
       )
-    },
-    {
-      pod_cidr_overprovision_disabled = tostring(lookup(each.value, "pod_cidr_overprovision_disabled", ""))
     }
   )
 }

--- a/modules/beta-public-cluster-update-variant/cluster.tf
+++ b/modules/beta-public-cluster-update-variant/cluster.tf
@@ -819,6 +819,7 @@ locals {
     "flex_start",
     "local_ssd_ephemeral_storage_count",
     "ephemeral_storage_local_ssd_data_cache_count",
+    "pod_cidr_overprovision_disabled",
   ]
 }
 
@@ -831,10 +832,10 @@ resource "random_id" "name" {
   byte_length = 2
   prefix      = "${each.key}-"
   keepers = merge(
-    zipmap(
-      local.force_node_pool_recreation_resources,
-      [for keeper in local.force_node_pool_recreation_resources : lookup(each.value, keeper, "")]
-    ),
+    {
+      for keeper in local.force_node_pool_recreation_resources : keeper => lookup(each.value, keeper, "")
+      if contains(keys(each.value), keeper)
+    },
     {
       taints = join(",",
         sort(
@@ -868,9 +869,6 @@ resource "random_id" "name" {
           )
         )
       )
-    },
-    {
-      pod_cidr_overprovision_disabled = tostring(lookup(each.value, "pod_cidr_overprovision_disabled", ""))
     }
   )
 }

--- a/modules/private-cluster-update-variant/cluster.tf
+++ b/modules/private-cluster-update-variant/cluster.tf
@@ -790,6 +790,7 @@ locals {
     "flex_start",
     "local_ssd_ephemeral_storage_count",
     "ephemeral_storage_local_ssd_data_cache_count",
+    "pod_cidr_overprovision_disabled",
   ]
 }
 
@@ -802,10 +803,10 @@ resource "random_id" "name" {
   byte_length = 2
   prefix      = "${each.key}-"
   keepers = merge(
-    zipmap(
-      local.force_node_pool_recreation_resources,
-      [for keeper in local.force_node_pool_recreation_resources : lookup(each.value, keeper, "")]
-    ),
+    {
+      for keeper in local.force_node_pool_recreation_resources : keeper => lookup(each.value, keeper, "")
+      if contains(keys(each.value), keeper)
+    },
     {
       taints = join(",",
         sort(
@@ -839,9 +840,6 @@ resource "random_id" "name" {
           )
         )
       )
-    },
-    {
-      pod_cidr_overprovision_disabled = tostring(lookup(each.value, "pod_cidr_overprovision_disabled", ""))
     }
   )
 }


### PR DESCRIPTION
Build the update-variant `random_id` keeper map from ForceNew node-pool attributes that are explicitly configured.

This prevents an optional ForceNew field introduced in a module release from adding an empty keeper to every existing pool and unnecessarily changing generated node-pool names on upgrade, thereby preventing a complete node pool replacement.

Also add pod_cidr_overprovision_disabled to locals.force_node_pool_recreation_resources to make it consistent with the others and remove its specific line on random_id.

Resolving https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/2646, or rather for the forthcoming additions to the list, because the damage has already been done here.

## Compatibility

There will be a one-time "false" breaking change for existing update-variant pools: their prior state contains empty-string keepers for unset ForceNew inputs, while this version omits them. Upgrading to this change will therefore replace those node pools once even when their effective configuration has not changed.

After that migration, future optional ForceNew attributes can be added without causing replacements for users who do not configure them. The ForceNew attribute list remains authoritative: configuring, changing, or removing any listed attribute still changes the keeper map and creates a replacement pool through the update variant.